### PR TITLE
implement optional pooling

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -76,7 +76,7 @@ type queryKey struct {
 	expCard uint8
 }
 
-func (c *Client) getTypeIDs(q query) (idPair, bool) {
+func (c *baseConn) getTypeIDs(q query) (idPair, bool) {
 	key := queryKey{
 		cmd:     q.cmd,
 		fmt:     q.fmt,
@@ -90,7 +90,7 @@ func (c *Client) getTypeIDs(q query) (idPair, bool) {
 	return idPair{}, false
 }
 
-func (c *Client) putTypeIDs(q query, ids idPair) {
+func (c *baseConn) putTypeIDs(q query, ids idPair) {
 	key := queryKey{
 		cmd:     q.cmd,
 		fmt:     q.fmt,

--- a/conn.go
+++ b/conn.go
@@ -16,28 +16,12 @@
 
 package edgedb
 
-import (
-	"fmt"
-	"log"
+// Conn is a conn created outside of a pool.
+type Conn struct {
+	baseConn
+}
 
-	"github.com/edgedb/edgedb-go/protocol/buff"
-	"github.com/edgedb/edgedb-go/protocol/message"
-)
-
-func (c *baseConn) fallThrough(buf *buff.Buff) error {
-	switch buf.MsgType {
-	case message.ParameterStatus:
-		name := buf.PopString()
-		value := buf.PopString()
-		c.serverSettings[name] = value
-	case message.LogMessage:
-		severity := string([]byte{buf.PopUint8()})
-		code := buf.PopUint32()
-		message := buf.PopString()
-		log.Println("SERVER MESSAGE", severity, code, message)
-	default:
-		return fmt.Errorf("unexpected message type: 0x%x", buf.MsgType)
-	}
-
-	return nil
+// Close closes the connection.
+func (c *Conn) Close() error {
+	return c.baseConn.close()
 }

--- a/connect_test.go
+++ b/connect_test.go
@@ -19,6 +19,7 @@ package edgedb
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,24 +27,27 @@ import (
 
 func TestAuth(t *testing.T) {
 	var host string
-	if server.admin {
+	if opts.admin {
 		host = "localhost"
 	} else {
-		host = server.Host
+		host = opts.Host
 	}
 
 	ctx := context.Background()
-	conn, err := Connect(ctx, Options{
+	conn, err := ConnectOne(ctx, Options{
 		Host:     host,
-		Port:     server.Port,
+		Port:     opts.Port,
 		User:     "user_with_password",
 		Password: "secret",
-		Database: server.Database,
+		Database: opts.Database,
 	})
 	assert.Nil(t, err)
 
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	var result string
 	err = conn.QueryOne(ctx, "SELECT 'It worked!';", &result)
+	cancel()
+
 	require.Nil(t, err)
 	assert.Equal(t, "It worked!", result)
 }

--- a/edgedb.go
+++ b/edgedb.go
@@ -38,7 +38,7 @@ type baseConn struct {
 }
 
 // ConnectOne establishes a connection to an EdgeDB server.
-func ConnectOne(ctx context.Context, opts Options) (*Conn, error) { // nolint
+func ConnectOne(ctx context.Context, opts Options) (*Conn, error) { // nolint:gocritic,lll
 	conn := &baseConn{
 		typeIDCache:   cache.New(1_000),
 		inCodecCache:  cache.New(1_000),
@@ -71,13 +71,7 @@ func connectOne(ctx context.Context, opts *Options, conn *baseConn) error {
 
 // Close the db connection
 func (c *baseConn) close() error {
-	err := c.terminate()
-	if err == nil {
-		return c.conn.Close()
-	}
-
-	c.conn.Close() // nolint:errcheck
-	return err
+	return wrapAll(c.terminate(), c.conn.Close())
 }
 
 // Execute an EdgeQL command (or commands).

--- a/error.go
+++ b/error.go
@@ -18,11 +18,33 @@ package edgedb
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/edgedb/edgedb-go/protocol/buff"
 )
 
+var (
+	// Error is wrapped by all errors returned from the server.
+	Error = errors.New("")
+	// todo error API (hierarchy and wrap all returned errors)
+
+	// ErrorZeroResults is returned when a query has no results.
+	ErrorZeroResults = fmt.Errorf("zero results%w", Error)
+
+	// ErrorPoolClosed is returned by operations on closed pools.
+	ErrorPoolClosed error = fmt.Errorf("pool closed%w", Error)
+
+	// ErrorConnsInUse is returned when all connects are in use.
+	ErrorConnsInUse error = fmt.Errorf("all connections in use%w", Error)
+
+	// ErrorContextExpired is returned when an expired context is used.
+	ErrorContextExpired error = fmt.Errorf("context expired%w", Error)
+
+	// ErrorConfiguration is returned when invalid configuration is received.
+	ErrorConfiguration error = fmt.Errorf("%w", Error)
+)
+
 func decodeError(buf *buff.Buff) error {
 	buf.Discard(5) // skip severity & code
-	return errors.New(buf.PopString())
+	return fmt.Errorf("%v%w", buf.PopString(), Error)
 }

--- a/options.go
+++ b/options.go
@@ -31,6 +31,9 @@ type Options struct {
 	Database string `json:"database"`
 	Password string `json:"password"`
 	admin    bool
+
+	MaxConns int
+	MinConns int
 }
 
 func (o *Options) network() string {

--- a/options_test.go
+++ b/options_test.go
@@ -25,53 +25,53 @@ import (
 )
 
 func TestParseHost(t *testing.T) {
-	opts, err := DSN("edgedb://me@localhost:5656/somedb")
+	o, err := DSN("edgedb://me@localhost:5656/somedb")
 	require.Nil(t, err)
-	assert.Equal(t, "localhost", opts.Host)
+	assert.Equal(t, "localhost", o.Host)
 }
 
 func TestParsePort(t *testing.T) {
-	opts, err := DSN("edgedb://me@localhost:5656/somedb")
+	o, err := DSN("edgedb://me@localhost:5656/somedb")
 	require.Nil(t, err)
-	assert.Equal(t, 5656, opts.Port)
+	assert.Equal(t, 5656, o.Port)
 }
 
 func TestParseUser(t *testing.T) {
-	opts, err := DSN("edgedb://me@localhost:5656/somedb")
+	o, err := DSN("edgedb://me@localhost:5656/somedb")
 	require.Nil(t, err)
-	assert.Equal(t, "me", opts.User)
+	assert.Equal(t, "me", o.User)
 }
 
 func TestParseDatabase(t *testing.T) {
-	opts, err := DSN("edgedb://me@localhost:5656/somedb")
+	o, err := DSN("edgedb://me@localhost:5656/somedb")
 	require.Nil(t, err)
-	assert.Equal(t, "somedb", opts.Database)
+	assert.Equal(t, "somedb", o.Database)
 }
 
 func TestParsePassword(t *testing.T) {
-	opts, err := DSN("edgedb://me:secret@localhost:5656/somedb")
+	o, err := DSN("edgedb://me:secret@localhost:5656/somedb")
 	require.Nil(t, err)
-	assert.Equal(t, "secret", opts.Password)
+	assert.Equal(t, "secret", o.Password)
 }
 
 func TestMissingPort(t *testing.T) {
-	opts, err := DSN("edgedb://me@localhost/somedb")
+	o, err := DSN("edgedb://me@localhost/somedb")
 	require.Nil(t, err)
-	assert.Equal(t, 5656, opts.Port)
+	assert.Equal(t, 5656, o.Port)
 }
 
 func TestDialHost(t *testing.T) {
-	opts := Options{Host: "some.com", Port: 1234}
-	assert.Equal(t, "some.com:1234", opts.address())
+	o := Options{Host: "some.com", Port: 1234}
+	assert.Equal(t, "some.com:1234", o.address())
 
-	opts = Options{Port: 1234}
-	assert.Equal(t, "localhost:1234", opts.address())
+	o = Options{Port: 1234}
+	assert.Equal(t, "localhost:1234", o.address())
 
-	opts = Options{Host: "some.com"}
-	assert.Equal(t, "some.com:5656", opts.address())
+	o = Options{Host: "some.com"}
+	assert.Equal(t, "some.com:5656", o.address())
 
-	opts = Options{}
-	assert.Equal(t, "localhost:5656", opts.address())
+	o = Options{}
+	assert.Equal(t, "localhost:5656", o.address())
 }
 
 func TestWrongScheme(t *testing.T) {

--- a/pool.go
+++ b/pool.go
@@ -44,7 +44,6 @@ type Pool struct {
 
 // Connect a pool of connections to a server.
 func Connect(ctx context.Context, opts Options) (*Pool, error) { // nolint:gocritic,lll
-	// todo should 0 be a valid value for MinConns?
 	if opts.MinConns < 1 {
 		return nil, fmt.Errorf(
 			"MinConns may not be less than 1, got: %v%w",

--- a/pool.go
+++ b/pool.go
@@ -1,0 +1,349 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedb
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/edgedb/edgedb-go/cache"
+)
+
+// Pool is a pool of connections.
+type Pool struct {
+	// mu locks the closeSignal channel in calls to Pool.Close()
+	mu sync.Mutex
+
+	// pool.Close() sends on this channel to signal closing the pool
+	closeSignal chan chan struct{}
+
+	// A buffered channel of connections ready for use.
+	freeConns chan *baseConn
+
+	// A buffered channel of structs representing unconnected capacity.
+	potentialConns chan struct{}
+
+	// Connections that did not produce a connection error
+	// are sent back to the pool on releasedConns.
+	releasedConns chan *baseConn
+
+	opts          *Options
+	typeIDCache   *cache.Cache
+	inCodecCache  *cache.Cache
+	outCodecCache *cache.Cache
+}
+
+// Connect a pool of connections to a server.
+func Connect(ctx context.Context, opts Options) (*Pool, error) { // nolint
+	// todo should 0 be a valid value for MinConns?
+	if opts.MinConns < 1 {
+		return nil, fmt.Errorf(
+			"MinConns may not be less than 1, got: %v%w",
+			opts.MinConns,
+			ErrorConfiguration,
+		)
+	}
+
+	if opts.MaxConns < opts.MinConns {
+		return nil, fmt.Errorf(
+			"MaxConns may not be less than MinConns%w",
+			ErrorConfiguration,
+		)
+	}
+
+	pool := &Pool{
+		opts: &opts,
+
+		closeSignal:    make(chan chan struct{}, 1),
+		freeConns:      make(chan *baseConn, opts.MinConns),
+		potentialConns: make(chan struct{}, opts.MaxConns),
+		releasedConns:  make(chan *baseConn, opts.MaxConns),
+
+		typeIDCache:   cache.New(1_000),
+		inCodecCache:  cache.New(1_000),
+		outCodecCache: cache.New(1_000),
+	}
+
+	for i := 0; i < opts.MaxConns-opts.MinConns; i++ {
+		pool.potentialConns <- struct{}{}
+	}
+
+	errCh := make(chan error, opts.MinConns)
+
+	for i := 0; i < opts.MinConns; i++ {
+		go func() {
+			conn, e := pool.newConn(ctx)
+			pool.releasedConns <- conn
+			errCh <- e
+		}()
+	}
+
+	var err error
+	for i := 0; i < opts.MinConns; i++ {
+		e := <-errCh
+		if e != nil {
+			err = e
+		}
+	}
+
+	if err != nil {
+		pool.closeSignal <- make(chan struct{}, 1)
+		pool.daemon()
+		return nil, err
+	}
+
+	go pool.daemon()
+	return pool, nil
+}
+
+func (p *Pool) daemon() {
+	closeIn := p.closeSignal
+	connCount := p.opts.MaxConns
+	var closeOut chan struct{}
+
+	for {
+		select {
+		case closeOut = <-closeIn:
+			close(p.freeConns)
+			close(p.potentialConns)
+
+			for range p.potentialConns {
+				connCount--
+			}
+
+			for conn := range p.freeConns {
+				go conn.close() // nolint:errcheck
+				connCount--
+			}
+
+			goto shutdown
+		case conn := <-p.releasedConns:
+			if conn == nil {
+				p.potentialConns <- struct{}{}
+				break
+			}
+
+			select {
+			case p.freeConns <- conn:
+			default:
+				// we have MinConns idle so no need to keep this connection.
+				go conn.close() // nolint:errcheck
+				p.potentialConns <- struct{}{}
+			}
+		}
+	}
+
+shutdown:
+	for connCount > 0 {
+		conn := <-p.releasedConns
+		if conn != nil {
+			go conn.close() // nolint:errcheck
+		}
+		connCount--
+	}
+
+	closeOut <- struct{}{}
+}
+
+func (p *Pool) newConn(ctx context.Context) (*baseConn, error) {
+	conn := &baseConn{
+		typeIDCache:   p.typeIDCache,
+		inCodecCache:  p.inCodecCache,
+		outCodecCache: p.outCodecCache,
+	}
+
+	if err := connectOne(ctx, p.opts, conn); err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+func (p *Pool) acquire(ctx context.Context) (*baseConn, error) {
+	// force do nothing if context is expired
+	select {
+	case <-ctx.Done():
+		return nil, ErrorContextExpired
+	default:
+	}
+
+	// force using an existing connection over connecting a new socket.
+	select {
+	case conn, ok := <-p.freeConns:
+		if !ok {
+			return nil, ErrorPoolClosed
+		}
+		return conn, nil
+	default:
+	}
+
+	select {
+	case conn, ok := <-p.freeConns:
+		if !ok {
+			return nil, ErrorPoolClosed
+		}
+		return conn, nil
+	case _, ok := <-p.potentialConns:
+		if !ok {
+			return nil, ErrorPoolClosed
+		}
+
+		conn, err := p.newConn(ctx)
+		if err != nil {
+			p.releasedConns <- nil
+			return nil, err
+		}
+		return conn, nil
+	case <-ctx.Done():
+		return nil, ErrorContextExpired
+	}
+}
+
+// Acquire gets a connection out of the pool
+// blocking until a connection is available.
+// Acquired connections must be released to the pool when no longer needed.
+func (p *Pool) Acquire(ctx context.Context) (*PoolConn, error) {
+	conn, err := p.acquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PoolConn{pool: p, baseConn: conn}, nil
+}
+
+func (p *Pool) release(conn *baseConn, err error) {
+	if err == nil {
+		p.releasedConns <- conn
+		return
+	}
+
+	e, ok := err.(*net.OpError)
+	if ok && e.Temporary() {
+		p.releasedConns <- conn
+		return
+	}
+
+	go conn.close() // nolint:errcheck
+	p.releasedConns <- nil
+}
+
+// Close closes all connections in the pool.
+// Calling close blocks until all acquired connections have been released.
+// Returns an error if called more than once.
+func (p *Pool) Close() error {
+	p.mu.Lock()
+
+	if p.closeSignal == nil {
+		p.mu.Unlock()
+		return ErrorPoolClosed
+	}
+
+	ch := make(chan struct{})
+
+	p.closeSignal <- ch
+	<-ch
+	p.closeSignal = nil
+	p.mu.Unlock()
+	return nil
+}
+
+// Execute an EdgeQL command (or commands).
+func (p *Pool) Execute(ctx context.Context, cmd string) (err error) {
+	conn, err := p.acquire(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = conn.Execute(ctx, cmd)
+	p.release(conn, err)
+	return err
+}
+
+// Query runs a query and returns the results.
+func (p *Pool) Query(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
+	conn, err := p.acquire(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = conn.Query(ctx, cmd, out, args...)
+	p.release(conn, err)
+	return err
+}
+
+// QueryOne runs a singleton-returning query and returns its element.
+// If the query executes successfully but doesn't return a result
+// ErrorZeroResults is returned.
+func (p *Pool) QueryOne(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
+	conn, err := p.acquire(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = conn.QueryOne(ctx, cmd, out, args...)
+	p.release(conn, err)
+	return err
+}
+
+// QueryJSON runs a query and return the results as JSON.
+func (p *Pool) QueryJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
+	conn, err := p.acquire(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = conn.QueryJSON(ctx, cmd, out, args...)
+	p.release(conn, err)
+	return err
+}
+
+// QueryOneJSON runs a singleton-returning query
+// and return its element in JSON.
+// If the query executes successfully but doesn't return a result
+// []byte{}, ErrorZeroResults is returned.
+func (p *Pool) QueryOneJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
+	conn, err := p.acquire(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = conn.QueryOneJSON(ctx, cmd, out, args...)
+	p.release(conn, err)
+	return err
+}

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,0 +1,175 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedb
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectPool(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	o := opts
+	o.MinConns = 1
+	o.MaxConns = 2
+	pool, err := Connect(ctx, o)
+	require.Nil(t, err)
+
+	var result string
+	err = pool.QueryOne(ctx, "SELECT 'hello';", &result)
+	assert.Nil(t, err)
+	assert.Equal(t, "hello", result)
+
+	err = pool.Close()
+	assert.Nil(t, err)
+}
+
+func TestClosePoolConcurently(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	o := opts
+	o.MinConns = 1
+	o.MaxConns = 2
+	pool, err := Connect(ctx, o)
+	require.Nil(t, err)
+
+	errs := make(chan error)
+	go func() { errs <- pool.Close() }()
+	go func() { errs <- pool.Close() }()
+
+	assert.Nil(t, <-errs)
+	assert.Equal(t, ErrorPoolClosed, <-errs)
+}
+
+func TestConnectPoolMinConnGteZero(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	o := Options{MinConns: 0, MaxConns: 10}
+	_, err := Connect(ctx, o)
+	assert.EqualError(t, err, "MinConns may not be less than 1, got: 0")
+	assert.True(t, errors.Is(err, ErrorConfiguration))
+}
+
+func TestConnectPoolMinConnLteMaxConn(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	o := Options{MinConns: 5, MaxConns: 1}
+	_, err := Connect(ctx, o)
+	assert.EqualError(t, err, "MaxConns may not be less than MinConns")
+	assert.True(t, errors.Is(err, ErrorConfiguration))
+}
+
+func TestAcquireFromClosedPool(t *testing.T) {
+	pool := &Pool{
+		freeConns:      make(chan *baseConn),
+		potentialConns: make(chan struct{}),
+	}
+	close(pool.freeConns)
+
+	conn, err := pool.Acquire(context.TODO())
+	assert.Equal(t, err, ErrorPoolClosed)
+	assert.Nil(t, conn)
+
+	pool = &Pool{
+		freeConns:      make(chan *baseConn),
+		potentialConns: make(chan struct{}),
+	}
+	close(pool.potentialConns)
+
+	conn, err = pool.Acquire(context.TODO())
+	assert.Equal(t, err, ErrorPoolClosed)
+	assert.Nil(t, conn)
+}
+
+func TestAcquireFreeConn(t *testing.T) {
+	conn := &baseConn{}
+	pool := &Pool{freeConns: make(chan *baseConn, 1)}
+	pool.freeConns <- conn
+
+	result, err := pool.Acquire(context.TODO())
+	assert.Nil(t, err)
+	assert.Equal(t, conn, result.baseConn)
+}
+
+func TestAcquirePotentialConn(t *testing.T) {
+	pool := &Pool{
+		potentialConns: make(chan struct{}, 1),
+		releasedConns:  make(chan *baseConn, 1),
+		opts:           &opts,
+	}
+	pool.potentialConns <- struct{}{}
+
+	deadline := time.Now().Add(10 * time.Millisecond)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	conn, err := pool.Acquire(ctx)
+	assert.True(t, errors.Is(err, os.ErrDeadlineExceeded))
+	assert.Nil(t, conn)
+	cancel()
+}
+
+func TestAcquireExpiredContext(t *testing.T) {
+	pool := &Pool{
+		freeConns:      make(chan *baseConn, 1),
+		potentialConns: make(chan struct{}, 1),
+	}
+	pool.freeConns <- &baseConn{}
+	pool.potentialConns <- struct{}{}
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now())
+	cancel()
+
+	conn, err := pool.Acquire(ctx)
+	assert.Equal(t, err, ErrorContextExpired)
+	assert.Nil(t, conn)
+}
+
+func TestAcquireThenContextExpires(t *testing.T) {
+	pool := &Pool{}
+
+	deadline := time.Now().Add(10 * time.Millisecond)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	conn, err := pool.Acquire(ctx)
+	assert.Equal(t, err, ErrorContextExpired)
+	assert.Nil(t, conn)
+	cancel()
+}
+
+func TestClosePool(t *testing.T) {
+	pool := &Pool{
+		freeConns:      make(chan *baseConn),
+		potentialConns: make(chan struct{}),
+		closeSignal:    make(chan chan struct{}, 1),
+		opts:           &Options{MaxConns: 0, MinConns: 0},
+	}
+	go pool.daemon()
+	err := pool.Close()
+	assert.Nil(t, err)
+
+	err = pool.Close()
+	assert.Equal(t, err, ErrorPoolClosed)
+}

--- a/poolconn.go
+++ b/poolconn.go
@@ -1,0 +1,109 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedb
+
+import (
+	"context"
+	"net"
+)
+
+// PoolConn is a pooled connection.
+type PoolConn struct {
+	pool *Pool
+	err  error
+	*baseConn
+}
+
+// Release the connection back to its pool. Panics if called more than once.
+// PoolConn is not useable after Release has been called.
+func (c *PoolConn) Release() {
+	if c.pool == nil {
+		panic("connection was already released")
+	}
+
+	c.pool.release(c.baseConn, c.err)
+	c.pool = nil
+	c.baseConn = nil
+	c.err = nil
+}
+
+func (c *PoolConn) checkErr(err error) {
+	e, ok := err.(*net.OpError)
+	if ok && !e.Temporary() {
+		c.err = e
+	}
+}
+
+// Execute an EdgeQL command (or commands).
+func (c *PoolConn) Execute(ctx context.Context, cmd string) error {
+	err := c.baseConn.Execute(ctx, cmd)
+	c.checkErr(err)
+	return err
+}
+
+// Query runs a query and returns the results.
+func (c *PoolConn) Query(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
+	err := c.baseConn.Query(ctx, cmd, out, args)
+	c.checkErr(err)
+	return err
+}
+
+// QueryOne runs a singleton-returning query and returns its element.
+// If the query executes successfully but doesn't return a result
+// ErrorZeroResults is returned.
+func (c *PoolConn) QueryOne(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
+	err := c.baseConn.QueryOne(ctx, cmd, out, args)
+	c.checkErr(err)
+	return err
+}
+
+// QueryJSON runs a query and return the results as JSON.
+func (c *PoolConn) QueryJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
+	err := c.baseConn.QueryJSON(ctx, cmd, out, args)
+	c.checkErr(err)
+	return err
+}
+
+// QueryOneJSON runs a singleton-returning query
+// and return its element in JSON.
+// If the query executes successfully but doesn't return a result
+// []byte{}, ErrorZeroResults is returned.
+func (c *PoolConn) QueryOneJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
+	err := c.baseConn.QueryOneJSON(ctx, cmd, out, args)
+	c.checkErr(err)
+	return err
+}

--- a/poolconn.go
+++ b/poolconn.go
@@ -30,15 +30,17 @@ type PoolConn struct {
 
 // Release the connection back to its pool. Panics if called more than once.
 // PoolConn is not useable after Release has been called.
-func (c *PoolConn) Release() {
+func (c *PoolConn) Release() error {
 	if c.pool == nil {
-		panic("connection was already released")
+		return ErrReleasedTwice
 	}
 
-	c.pool.release(c.baseConn, c.err)
+	err := c.pool.release(c.baseConn, c.err)
 	c.pool = nil
 	c.baseConn = nil
 	c.err = nil
+
+	return err
 }
 
 func (c *PoolConn) checkErr(err error) {

--- a/query_test.go
+++ b/query_test.go
@@ -30,7 +30,7 @@ import (
 func TestNamedQueryArguments(t *testing.T) {
 	ctx := context.Background()
 	var result [][]int64
-	err := client.Query(
+	err := conn.Query(
 		ctx,
 		"SELECT [<int64>$first, <int64>$second]",
 		&result,
@@ -47,7 +47,7 @@ func TestNamedQueryArguments(t *testing.T) {
 func TestNumberedQueryArguments(t *testing.T) {
 	ctx := context.Background()
 	result := [][]int64{}
-	err := client.Query(
+	err := conn.Query(
 		ctx,
 		"SELECT [<int64>$0, <int64>$1]",
 		&result,
@@ -62,7 +62,7 @@ func TestNumberedQueryArguments(t *testing.T) {
 func TestQueryJSON(t *testing.T) {
 	ctx := context.Background()
 	var result []byte
-	err := client.QueryJSON(
+	err := conn.QueryJSON(
 		ctx,
 		"SELECT {(a := 0, b := <int64>$0), (a := 42, b := <int64>$1)}",
 		&result,
@@ -85,7 +85,7 @@ func TestQueryJSON(t *testing.T) {
 func TestQueryOneJSON(t *testing.T) {
 	ctx := context.Background()
 	var result []byte
-	err := client.QueryOneJSON(
+	err := conn.QueryOneJSON(
 		ctx,
 		"SELECT (a := 0, b := <int64>$0)",
 		&result,
@@ -103,7 +103,7 @@ func TestQueryOneJSON(t *testing.T) {
 func TestQueryOneJSONZeroResults(t *testing.T) {
 	ctx := context.Background()
 	var result []byte
-	err := client.QueryOneJSON(ctx, "SELECT <int64>{}", &result)
+	err := conn.QueryOneJSON(ctx, "SELECT <int64>{}", &result)
 
 	require.Equal(t, err, ErrorZeroResults)
 	assert.Equal(t, []byte(nil), result)
@@ -112,7 +112,7 @@ func TestQueryOneJSONZeroResults(t *testing.T) {
 func TestQueryOne(t *testing.T) {
 	ctx := context.Background()
 	var result int64
-	err := client.QueryOne(ctx, "SELECT 42", &result)
+	err := conn.QueryOne(ctx, "SELECT 42", &result)
 
 	assert.Nil(t, err)
 	assert.Equal(t, int64(42), result)
@@ -121,21 +121,21 @@ func TestQueryOne(t *testing.T) {
 func TestQueryOneZeroResults(t *testing.T) {
 	ctx := context.Background()
 	var result int64
-	err := client.QueryOne(ctx, "SELECT <int64>{}", &result)
+	err := conn.QueryOne(ctx, "SELECT <int64>{}", &result)
 
 	assert.Equal(t, ErrorZeroResults, err)
 }
 
 func TestError(t *testing.T) {
 	ctx := context.Background()
-	err := client.Execute(ctx, "malformed query;")
-	expected := errors.New("Unexpected 'malformed'")
-	assert.Equal(t, expected, err)
+	err := conn.Execute(ctx, "malformed query;")
+	assert.EqualError(t, err, "Unexpected 'malformed'")
+	assert.True(t, errors.Is(err, Error))
 }
 
 func TestQueryTimesOut(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now())
-	err := client.Execute(ctx, "SELECT 1;")
+	err := conn.Execute(ctx, "SELECT 1;")
 
 	assert.True(t, errors.Is(err, os.ErrDeadlineExceeded))
 	cancel()

--- a/script_flow.go
+++ b/script_flow.go
@@ -24,7 +24,7 @@ import (
 	"github.com/edgedb/edgedb-go/protocol/message"
 )
 
-func (c *Client) scriptFlow(
+func (c *baseConn) scriptFlow(
 	ctx context.Context,
 	conn net.Conn,
 	query string,
@@ -35,7 +35,7 @@ func (c *Client) scriptFlow(
 	buf.PushString(query)
 	buf.EndMessage()
 
-	err := writeAndRead(ctx, conn, buf.Unwrap())
+	err := c.writeAndRead(ctx, buf.Unwrap())
 	if err != nil {
 		return err
 	}

--- a/tutorial_test.go
+++ b/tutorial_test.go
@@ -43,21 +43,22 @@ type Movie struct {
 }
 
 func TestTutorial(t *testing.T) {
-	ctx := context.Background()
-	rand.Seed(time.Now().UnixNano())
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
 	dbName := fmt.Sprintf("test%v", rand.Intn(10_000))
-	err := client.Execute(ctx, "CREATE DATABASE "+dbName)
+	err := conn.Execute(ctx, "CREATE DATABASE "+dbName)
 	require.Nil(t, err)
 
-	edb, err := Connect(
+	edb, err := ConnectOne(
 		ctx,
 		Options{
-			Host:     server.Host,
-			Port:     server.Port,
-			User:     server.User,
-			Password: server.Password,
+			Host:     opts.Host,
+			Port:     opts.Port,
+			User:     opts.User,
+			Password: opts.Password,
 			Database: dbName,
-			admin:    server.admin,
+			admin:    opts.admin,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
This change adds:
- the ability to connect either a single connection or a pool
- the ability to acquire connections from a pool
- termination of all connections when a pool is closed
- configurable max and min connection counts

fixes https://github.com/edgedb/edgedb-go/issues/19

## After
![image](https://user-images.githubusercontent.com/8278635/100155449-88b36e80-2e64-11eb-9614-1666d5402e77.png)


## Before
![image](https://user-images.githubusercontent.com/8278635/100155480-9668f400-2e64-11eb-9136-323a26969084.png)
