### PR TITLE
add coherent error api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,8 @@ bench:
 
 format:
 	gofmt -s -w .
+
+errors:
+	edb gen-errors-json --client | \
+		go run internal/cmd/generr/main.go -file=codes > \
+		generatederrors.go

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ format:
 	gofmt -s -w .
 
 errors:
+	type edb || (\
+		echo "the edb command must be in your path " \
+		echo "see https://www.edgedb.com/docs/internals/dev/#building-locally" && \
+		exit 1 \
+		)
 	edb gen-errors-json --client | \
 		go run internal/cmd/generr/main.go -file=codes > \
 		generatederrors.go

--- a/connect.go
+++ b/connect.go
@@ -43,7 +43,7 @@ func (c *baseConn) connect(r *buff.Reader, cfg *connConfig) error {
 	c.writer.EndMessage()
 
 	if err := c.writer.Send(c.conn); err != nil {
-		return wrapError(err)
+		return wrapErrorWithType(clientConnectionErrorCode, err)
 	}
 
 	var (
@@ -106,7 +106,7 @@ func (c *baseConn) connect(r *buff.Reader, cfg *connConfig) error {
 	}
 
 	if r.Err != nil {
-		return wrapError(r.Err)
+		return wrapErrorWithType(clientConnectionErrorCode, r.Err)
 	}
 
 	return err
@@ -130,7 +130,7 @@ func (c *baseConn) authenticate(r *buff.Reader, cfg *connConfig) error {
 	c.writer.EndMessage()
 
 	if e := c.writer.Send(c.conn); e != nil {
-		return wrapError(e)
+		return wrapErrorWithType(clientConnectionErrorCode, e)
 	}
 
 	done := buff.NewSignal()
@@ -166,7 +166,7 @@ func (c *baseConn) authenticate(r *buff.Reader, cfg *connConfig) error {
 	}
 
 	if r.Err != nil {
-		return wrapError(r.Err)
+		return wrapErrorWithType(clientConnectionErrorCode, r.Err)
 	}
 
 	if err != nil {
@@ -178,7 +178,7 @@ func (c *baseConn) authenticate(r *buff.Reader, cfg *connConfig) error {
 	c.writer.EndMessage()
 
 	if e := c.writer.Send(c.conn); e != nil {
-		return wrapError(e)
+		return wrapErrorWithType(clientConnectionErrorCode, e)
 	}
 
 	done = buff.NewSignal()
@@ -221,7 +221,7 @@ func (c *baseConn) authenticate(r *buff.Reader, cfg *connConfig) error {
 	}
 
 	if r.Err != nil {
-		return wrapError(r.Err)
+		return wrapErrorWithType(clientConnectionErrorCode, r.Err)
 	}
 
 	return err
@@ -232,7 +232,7 @@ func (c *baseConn) terminate() error {
 	c.writer.EndMessage()
 
 	if e := c.writer.Send(c.conn); e != nil {
-		return wrapError(e)
+		return wrapErrorWithType(clientConnectionErrorCode, e)
 	}
 
 	return nil

--- a/connutils.go
+++ b/connutils.go
@@ -48,10 +48,10 @@ func validatePortSpec(hosts []string, ports []int) ([]int, error) {
 	var result []int
 	if len(ports) > 1 {
 		if len(ports) != len(hosts) {
-			return nil, fmt.Errorf(
-				"could not match %v port numbers to %v hosts%w",
-				len(ports), len(hosts), ErrInterfaceViolation,
-			)
+			return nil, newErrorFromCode(configurationErrorCode, fmt.Sprintf(
+				"could not match %v port numbers to %v hosts",
+				len(ports), len(hosts),
+			))
 		}
 
 		result = ports
@@ -71,10 +71,10 @@ func parsePortSpec(spec string) ([]int, error) {
 	for _, p := range strings.Split(spec, ",") {
 		port, err := strconv.Atoi(p)
 		if err != nil {
-			return nil, fmt.Errorf(
-				"invalid port %q found in %q: %v%w",
-				p, spec, err, ErrBadConfig,
-			)
+			return nil, newErrorFromCode(configurationErrorCode, fmt.Sprintf(
+				"invalid port %q found in %q: %v",
+				p, spec, err,
+			))
 		}
 
 		ports = append(ports, port)
@@ -122,10 +122,12 @@ func parseHostList(hostList string, ports []int) ([]string, []int, error) {
 			if hostSpecPort != "" {
 				port, err := strconv.Atoi(hostSpecPort)
 				if err != nil {
-					return nil, nil, fmt.Errorf(
-						"invalid port %q found in %q: %v%w",
-						hostSpecPort, hostSpec, err, ErrBadConfig,
+					msg := fmt.Sprintf(
+						"invalid port %q found in %q: %v",
+						hostSpecPort, hostSpec, err,
 					)
+					err = newErrorFromCode(configurationErrorCode, msg)
+					return nil, nil, err
 				}
 				hostListPorts = append(hostListPorts, port)
 			} else {
@@ -180,14 +182,14 @@ func parseConnectDSNAndArgs(
 	if dsn != "" && strings.HasPrefix(dsn, "edgedb://") {
 		parsed, err := url.Parse(dsn)
 		if err != nil {
-			return nil, fmt.Errorf(
-				"could not parse %q: %v%w", dsn, err, ErrBadConfig)
+			return nil, newErrorFromCode(configurationErrorCode, fmt.Sprintf(
+				"could not parse %q: %v", dsn, err))
 		}
 
 		if parsed.Scheme != "edgedb" {
-			return nil, fmt.Errorf(
-				`invalid DSN: scheme is expected to be "edgedb", got %q%w`,
-				dsn, ErrBadConfig)
+			return nil, newErrorFromCode(configurationErrorCode, fmt.Sprintf(
+				`invalid DSN: scheme is expected to be "edgedb", got %q`, dsn,
+			))
 		}
 
 		if len(hosts) == 0 && parsed.Host != "" {
@@ -212,8 +214,8 @@ func parseConnectDSNAndArgs(
 		if parsed.RawQuery != "" {
 			q, err := url.ParseQuery(parsed.RawQuery)
 			if err != nil {
-				return nil, fmt.Errorf(
-					"invalid DSN %q: %v%w", dsn, err, ErrBadConfig)
+				msg := fmt.Sprintf("invalid DSN %q: %v", dsn, err)
+				return nil, newErrorFromCode(configurationErrorCode, msg)
 			}
 
 			query := make(map[string]string, len(q))
@@ -258,26 +260,25 @@ func parseConnectDSNAndArgs(
 	} else if dsn != "" {
 		isIdentifier := regexp.MustCompile(`^[A-Za-z_][A-Za-z_0-9]*$`)
 		if !isIdentifier.Match([]byte(dsn)) {
-			return nil, fmt.Errorf(
-				"dsn %q is neither a edgedb:// URI nor valid instance name%w",
-				dsn, ErrBadConfig,
-			)
+			return nil, newErrorFromCode(configurationErrorCode, fmt.Sprintf(
+				"dsn %q is neither a edgedb:// URI nor valid instance name",
+				dsn,
+			))
 		}
 
 		usingCredentials = true
 
 		u, err := usr.Current()
 		if err != nil {
-			return nil, err
+			return nil, newError(err.Error())
 		}
 
 		file := path.Join(u.HomeDir, ".edgedb", "credentials", dsn+".json")
 		creds, err := readCredentials(file)
 		if err != nil {
-			return nil, fmt.Errorf(
-				"cannot read credentials of instance %q: %v%w",
-				dsn, err, ErrClientFault,
-			)
+			return nil, newErrorFromCode(configurationErrorCode, fmt.Sprintf(
+				"cannot read credentials of instance %q: %v", dsn, err,
+			))
 		}
 
 		if len(ports) == 0 {
@@ -372,9 +373,8 @@ func parseConnectDSNAndArgs(
 	}
 
 	if len(addrs) == 0 {
-		return nil, fmt.Errorf(
-			"could not determine the database address to connect to%w",
-			ErrBadConfig, // TODO evaluate error type
+		return nil, newErrorFromCode(configurationErrorCode,
+			"could not determine the database address to connect to",
 		)
 	}
 

--- a/connutils.go
+++ b/connutils.go
@@ -270,7 +270,7 @@ func parseConnectDSNAndArgs(
 
 		u, err := usr.Current()
 		if err != nil {
-			return nil, newError(err.Error())
+			return nil, newErrorFromCode(configurationErrorCode, err.Error())
 		}
 
 		file := path.Join(u.HomeDir, ".edgedb", "credentials", dsn+".json")

--- a/connutils_test.go
+++ b/connutils_test.go
@@ -358,8 +358,8 @@ func TestConUtils(t *testing.T) {
 			name: "DSN requires edgedb scheme",
 			dsn:  "pq:///dbname?host=/unix_sock/test&user=spam",
 			expected: Result{
-				err: ErrBadConfig,
-				errMessage: "dsn " +
+				err: ConfigurationError{},
+				errMessage: "edgedb: dsn " +
 					`"pq:///dbname?host=/unix_sock/test&user=spam" ` +
 					"is neither a edgedb:// URI nor valid instance name",
 			},
@@ -371,8 +371,8 @@ func TestConUtils(t *testing.T) {
 				Ports: []int{111, 222},
 			},
 			expected: Result{
-				err:        ErrInterfaceViolation,
-				errMessage: "could not match 2 port numbers to 3 hosts",
+				err:        InterfaceError{},
+				errMessage: "edgedb: could not match 2 port numbers to 3 hosts", // nolint:lll
 			},
 		},
 		{
@@ -400,7 +400,7 @@ func TestConUtils(t *testing.T) {
 
 			if c.expected.err != nil {
 				require.EqualError(t, err, c.expected.errMessage)
-				require.True(t, errors.Is(err, c.expected.err))
+				require.True(t, errors.As(err, &c.expected.err))
 				assert.Nil(t, config)
 			} else {
 				require.Nil(t, err, "encountered err")

--- a/connutils_test.go
+++ b/connutils_test.go
@@ -358,8 +358,8 @@ func TestConUtils(t *testing.T) {
 			name: "DSN requires edgedb scheme",
 			dsn:  "pq:///dbname?host=/unix_sock/test&user=spam",
 			expected: Result{
-				err: ConfigurationError{},
-				errMessage: "edgedb: dsn " +
+				err: &configurationError{},
+				errMessage: "edgedb.ConfigurationError: dsn " +
 					`"pq:///dbname?host=/unix_sock/test&user=spam" ` +
 					"is neither a edgedb:// URI nor valid instance name",
 			},
@@ -371,8 +371,8 @@ func TestConUtils(t *testing.T) {
 				Ports: []int{111, 222},
 			},
 			expected: Result{
-				err:        InterfaceError{},
-				errMessage: "edgedb: could not match 2 port numbers to 3 hosts", // nolint:lll
+				err:        &configurationError{},
+				errMessage: "edgedb.ConfigurationError: could not match 2 port numbers to 3 hosts", // nolint:lll
 			},
 		},
 		{

--- a/credentials.go
+++ b/credentials.go
@@ -57,7 +57,7 @@ func readCredentials(path string) (*credentials, error) {
 
 Failed:
 	msg := fmt.Sprintf("cannot read credentials at %q: %v", path, err)
-	return nil, newErrorFromCode(configurationErrorCode, msg)
+	return nil, &configurationError{msg: msg}
 }
 
 func validateCredentials(data map[string]interface{}) (*credentials, error) {

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -17,7 +17,6 @@
 package edgedb
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,7 +40,6 @@ func TestCredentialsRead(t *testing.T) {
 func TestCredentialsEmpty(t *testing.T) {
 	creds, err := validateCredentials(map[string]interface{}{})
 	assert.EqualError(t, err, "`user` key is required")
-	assert.True(t, errors.Is(err, ErrBadConfig))
 	assert.Nil(t, creds)
 }
 
@@ -51,7 +49,6 @@ func TestCredentialsPort(t *testing.T) {
 		"port": "1234",
 	})
 	assert.EqualError(t, err, "invalid `port` value")
-	assert.True(t, errors.Is(err, ErrBadConfig))
 	assert.Nil(t, creds)
 
 	creds, err = validateCredentials(map[string]interface{}{
@@ -59,7 +56,6 @@ func TestCredentialsPort(t *testing.T) {
 		"port": 0,
 	})
 	assert.EqualError(t, err, "invalid `port` value")
-	assert.True(t, errors.Is(err, ErrBadConfig))
 	assert.Nil(t, creds)
 
 	creds, err = validateCredentials(map[string]interface{}{
@@ -67,7 +63,6 @@ func TestCredentialsPort(t *testing.T) {
 		"port": -1,
 	})
 	assert.EqualError(t, err, "invalid `port` value")
-	assert.True(t, errors.Is(err, ErrBadConfig))
 	assert.Nil(t, creds)
 
 	creds, err = validateCredentials(map[string]interface{}{
@@ -75,6 +70,5 @@ func TestCredentialsPort(t *testing.T) {
 		"port": 65536,
 	})
 	assert.EqualError(t, err, "invalid `port` value")
-	assert.True(t, errors.Is(err, ErrBadConfig))
 	assert.Nil(t, creds)
 }

--- a/edgedb.go
+++ b/edgedb.go
@@ -18,6 +18,7 @@ package edgedb
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
@@ -146,8 +147,7 @@ func (c *baseConn) acquireReader(ctx context.Context) (*buff.Reader, error) {
 
 		return r, nil
 	case <-ctx.Done():
-		err := ctx.Err()
-		return nil, &baseError{msg: "edgedb: " + err.Error(), err: err}
+		return nil, fmt.Errorf("edgedb: %w", ctx.Err())
 	}
 }
 

--- a/edgedb.go
+++ b/edgedb.go
@@ -18,6 +18,7 @@ package edgedb
 
 import (
 	"context"
+	"fmt"
 	"net"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
@@ -140,7 +141,7 @@ func (c *baseConn) acquireReader(ctx context.Context) (*buff.Reader, error) {
 
 		return r, nil
 	case <-ctx.Done():
-		return nil, ErrContextExpired
+		return nil, fmt.Errorf("edgedb: %w", ctx.Err())
 	}
 }
 
@@ -217,7 +218,7 @@ func (c *baseConn) QueryOne(
 ) (err error) {
 	val, err := marshal.ValueOf(out)
 	if err != nil {
-		return newError(err.Error())
+		return newErrorFromCode(invalidArgumentErrorCode, err.Error())
 	}
 
 	q := query{
@@ -248,7 +249,7 @@ func (c *baseConn) Query(
 ) error {
 	val, err := marshal.ValueOfSlice(out)
 	if err != nil {
-		return newError(err.Error())
+		return newErrorFromCode(invalidArgumentErrorCode, err.Error())
 	}
 
 	q := query{
@@ -279,7 +280,7 @@ func (c *baseConn) QueryJSON(
 ) error {
 	val, err := marshal.ValueOf(out)
 	if err != nil {
-		return newError(err.Error())
+		return newErrorFromCode(invalidArgumentErrorCode, err.Error())
 	}
 
 	q := query{
@@ -313,7 +314,7 @@ func (c *baseConn) QueryOneJSON(
 ) error {
 	val, err := marshal.ValueOf(out)
 	if err != nil {
-		return newError(err.Error())
+		return newErrorFromCode(invalidArgumentErrorCode, err.Error())
 	}
 
 	q := query{

--- a/edgedb.go
+++ b/edgedb.go
@@ -18,7 +18,6 @@ package edgedb
 
 import (
 	"context"
-	"fmt"
 	"net"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
@@ -143,7 +142,8 @@ func (c *baseConn) acquireReader(ctx context.Context) (*buff.Reader, error) {
 
 		return r, nil
 	case <-ctx.Done():
-		return nil, fmt.Errorf("edgedb: %w", ctx.Err())
+		err := ctx.Err()
+		return nil, &baseError{msg: "edgedb: " + err.Error(), err: err}
 	}
 }
 

--- a/edgedb.go
+++ b/edgedb.go
@@ -86,7 +86,7 @@ func connectOne(ctx context.Context, cfg *connConfig, conn *baseConn) error {
 	for _, addr := range cfg.addrs { // nolint:gocritic
 		conn.conn, err = d.DialContext(ctx, addr.network, addr.address)
 		if err != nil {
-			err = wrapErrorFromCode(clientConnectionErrorCode, err)
+			err = wrapErrorWithType(clientConnectionErrorCode, err)
 			continue
 		}
 
@@ -129,7 +129,7 @@ func connectOne(ctx context.Context, cfg *connConfig, conn *baseConn) error {
 func (c *baseConn) setDeadline(ctx context.Context) error {
 	deadline, _ := ctx.Deadline()
 	err := c.conn.SetDeadline(deadline)
-	return wrapErrorFromCode(clientConnectionErrorCode, err)
+	return wrapErrorWithType(clientConnectionErrorCode, err)
 }
 
 func (c *baseConn) acquireReader(ctx context.Context) (*buff.Reader, error) {
@@ -138,7 +138,7 @@ func (c *baseConn) acquireReader(ctx context.Context) (*buff.Reader, error) {
 	select {
 	case r := <-c.readerChan:
 		if r.Err != nil {
-			return nil, wrapErrorFromCode(clientConnectionErrorCode, r.Err)
+			return nil, wrapErrorWithType(clientConnectionErrorCode, r.Err)
 		}
 
 		return r, nil
@@ -189,7 +189,7 @@ func (c *baseConn) close() error {
 
 	err = c.conn.Close()
 	if err != nil {
-		return wrapErrorFromCode(clientConnectionErrorCode, err)
+		return wrapErrorWithType(clientConnectionErrorCode, err)
 	}
 
 	return nil

--- a/error.go
+++ b/error.go
@@ -27,26 +27,7 @@ var errZeroResults error = &noDataError{msg: "zero results"}
 // Error is wrapped by all errors.
 type Error interface {
 	Error() string
-	isError()
-}
-
-type baseError struct {
-	msg string
-	err error
-}
-
-func (e *baseError) isError() {}
-
-func (e *baseError) Error() string {
-	if e.err != nil {
-		return e.err.Error()
-	}
-
-	return e.msg
-}
-
-func (e *baseError) Unwrap() error {
-	return e.err
+	isEdgeDBError()
 }
 
 func firstError(a, b error) error {

--- a/error.go
+++ b/error.go
@@ -49,14 +49,12 @@ func (e *baseError) Unwrap() error {
 	return e.err
 }
 
-func firstError(errs ...error) error {
-	for _, err := range errs {
-		if err != nil {
-			return err
-		}
+func firstError(a, b error) error {
+	if a != nil {
+		return a
 	}
 
-	return nil
+	return b
 }
 
 func decodeError(r *buff.Reader) error {

--- a/error.go
+++ b/error.go
@@ -23,14 +23,8 @@ import (
 )
 
 var (
-	// ErrReleasedTwice is returned if a PoolConn is released more than once.
-	ErrReleasedTwice = newError("connection released more than once")
-
 	// ErrZeroResults is returned when a query has no results.
 	ErrZeroResults = newError("zero results")
-
-	// ErrPoolClosed is returned by operations on closed pools.
-	ErrPoolClosed = newError("pool closed")
 )
 
 func wrapError(err error) error {

--- a/error.go
+++ b/error.go
@@ -31,9 +31,6 @@ var (
 
 	// ErrPoolClosed is returned by operations on closed pools.
 	ErrPoolClosed = newError("pool closed")
-
-	// ErrContextExpired is returned when an expired context is used.
-	ErrContextExpired = newError("context expired")
 )
 
 func wrapError(err error) error {

--- a/error.go
+++ b/error.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// ErrZeroResults is returned when a query has no results.
-	ErrZeroResults = newError("zero results")
+	ErrZeroResults error = &Error{&baseError{msg: "edgedb: zero results"}}
 )
 
 func wrapError(err error) error {
@@ -35,18 +35,10 @@ func wrapError(err error) error {
 	return &Error{&baseError{msg: "edgedb: " + err.Error(), err: err}}
 }
 
-func newError(msg string) error {
-	if msg == "" {
-		panic("no error message specified")
-	}
-
-	return &Error{&baseError{msg: "edgedb: " + msg}}
-}
-
 // newErrorFromCode returns a new edgedb error.
 func newErrorFromCode(code uint32, msg string) error {
 	err := &Error{&baseError{msg: msg}}
-	return wrapErrorFromCode(code, err)
+	return wrapErrorWithType(code, err)
 }
 
 func firstError(errs ...error) error {

--- a/error.go
+++ b/error.go
@@ -49,6 +49,12 @@ func newError(msg string) error {
 	return &Error{&baseError{msg: "edgedb: " + msg}}
 }
 
+// newErrorFromCode returns a new edgedb error.
+func newErrorFromCode(code uint32, msg string) error {
+	err := &Error{&baseError{msg: msg}}
+	return wrapErrorFromCode(code, err)
+}
+
 func firstError(errs ...error) error {
 	for _, err := range errs {
 		if err != nil {

--- a/error.go
+++ b/error.go
@@ -22,10 +22,7 @@ import (
 	"github.com/edgedb/edgedb-go/internal/buff"
 )
 
-var (
-	// ErrZeroResults is returned when a query has no results.
-	ErrZeroResults error = &noDataError{msg: "zero results"}
-)
+var errZeroResults error = &noDataError{msg: "zero results"}
 
 // Error is wrapped by all errors.
 type Error interface {

--- a/error_test.go
+++ b/error_test.go
@@ -78,13 +78,12 @@ func TestWrapAllAs(t *testing.T) {
 }
 
 func TestWrapAllIs(t *testing.T) {
-	err := wrapAll(ErrReleasedTwice, ErrPoolClosed)
+	errA := errors.New("error A")
+	errB := errors.New("error B")
+	err := wrapAll(errA, errB)
+
 	require.NotNil(t, err)
-
-	msg := "edgedb: connection released more than once; " +
-		"edgedb: pool closed"
-	assert.Equal(t, msg, err.Error())
-
-	assert.True(t, errors.Is(err, ErrReleasedTwice))
-	assert.True(t, errors.Is(err, ErrPoolClosed))
+	assert.Equal(t, "error A; error B", err.Error())
+	assert.True(t, errors.Is(err, errA))
+	assert.True(t, errors.Is(err, errB))
 }

--- a/error_test.go
+++ b/error_test.go
@@ -32,23 +32,23 @@ func TestNewErrorFromCodeAs(t *testing.T) {
 	msg = "edgedb.DuplicateCastDefinitionError: " + msg
 
 	var cast DuplicateCastDefinitionError
-	assert.True(t, errors.As(err, &cast))
+	require.True(t, errors.As(err, &cast))
 	assert.Equal(t, msg, cast.Error())
 
 	var def DuplicateDefinitionError
-	assert.True(t, errors.As(err, &def))
+	require.True(t, errors.As(err, &def))
 	assert.Equal(t, msg, def.Error())
 
 	var schem SchemaDefinitionError
-	assert.True(t, errors.As(err, &schem))
+	require.True(t, errors.As(err, &schem))
 	assert.Equal(t, msg, schem.Error())
 
 	var query QueryError
-	assert.True(t, errors.As(err, &query))
+	require.True(t, errors.As(err, &query))
 	assert.Equal(t, msg, query.Error())
 
 	var base Error
-	assert.True(t, errors.As(err, &base))
+	require.True(t, errors.As(err, &base))
 	assert.Equal(t, msg, query.Error())
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -26,55 +26,60 @@ import (
 
 func TestNewErrorFromCodeAs(t *testing.T) {
 	msg := "example error message"
-	err := newErrorFromCode(duplicateCastDefinitionErrorCode, msg)
+	err := &duplicateCastDefinitionError{msg: msg}
 	require.NotNil(t, err)
 
-	msg = "edgedb: " + msg
+	msg = "edgedb.DuplicateCastDefinitionError: " + msg
 
-	var cast *DuplicateCastDefinitionError
+	var cast DuplicateCastDefinitionError
 	assert.True(t, errors.As(err, &cast))
 	assert.Equal(t, msg, cast.Error())
 
-	var def *DuplicateDefinitionError
+	var def DuplicateDefinitionError
 	assert.True(t, errors.As(err, &def))
 	assert.Equal(t, msg, def.Error())
 
-	var schem *SchemaDefinitionError
+	var schem SchemaDefinitionError
 	assert.True(t, errors.As(err, &schem))
 	assert.Equal(t, msg, schem.Error())
 
-	var query *QueryError
+	var query QueryError
 	assert.True(t, errors.As(err, &query))
 	assert.Equal(t, msg, query.Error())
 
-	var base *Error
+	var base Error
 	assert.True(t, errors.As(err, &base))
 	assert.Equal(t, msg, query.Error())
 }
 
 func TestWrapAllAs(t *testing.T) {
-	err1 := newErrorFromCode(binaryProtocolErrorCode, "bad bits!")
-	err2 := newErrorFromCode(invalidValueErrorCode, "guess again...")
+	err1 := &binaryProtocolError{msg: "bad bits!"}
+	err2 := &invalidValueError{msg: "guess again..."}
 	err := wrapAll(err1, err2)
 
 	require.NotNil(t, err)
-	assert.Equal(t, "edgedb: bad bits!; edgedb: guess again...", err.Error())
+	assert.Equal(
+		t,
+		"edgedb.BinaryProtocolError: bad bits!; "+
+			"edgedb.InvalidValueError: guess again...",
+		err.Error(),
+	)
 
-	var bin *BinaryProtocolError
+	var bin BinaryProtocolError
 	require.True(t, errors.As(err, &bin), "errors.As failed")
-	assert.Equal(t, "edgedb: bad bits!", bin.Error())
+	assert.Equal(t, "edgedb.BinaryProtocolError: bad bits!", bin.Error())
 
-	var proto *ProtocolError
+	var proto ProtocolError
 	require.True(t, errors.As(err, &proto))
-	assert.Equal(t, "edgedb: bad bits!", proto.Error())
+	assert.Equal(t, "edgedb.BinaryProtocolError: bad bits!", proto.Error())
 
-	var val *InvalidValueError
+	var val InvalidValueError
 	require.True(t, errors.As(err, &val))
-	assert.Equal(t, "edgedb: guess again...", val.Error())
+	assert.Equal(t, "edgedb.InvalidValueError: guess again...", val.Error())
 
-	var exe *ExecutionError
+	var exe ExecutionError
 	require.True(t, errors.As(err, &exe))
-	assert.Equal(t, "edgedb: guess again...", exe.Error())
+	assert.Equal(t, "edgedb.InvalidValueError: guess again...", exe.Error())
 }
 
 func TestWrapAllIs(t *testing.T) {

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,90 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedb
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewErrorFromCodeAs(t *testing.T) {
+	msg := "example error message"
+	err := newErrorFromCode(duplicateCastDefinitionErrorCode, msg)
+	require.NotNil(t, err)
+
+	msg = "edgedb: " + msg
+
+	var cast *DuplicateCastDefinitionError
+	assert.True(t, errors.As(err, &cast))
+	assert.Equal(t, msg, cast.Error())
+
+	var def *DuplicateDefinitionError
+	assert.True(t, errors.As(err, &def))
+	assert.Equal(t, msg, def.Error())
+
+	var schem *SchemaDefinitionError
+	assert.True(t, errors.As(err, &schem))
+	assert.Equal(t, msg, schem.Error())
+
+	var query *QueryError
+	assert.True(t, errors.As(err, &query))
+	assert.Equal(t, msg, query.Error())
+
+	var base *Error
+	assert.True(t, errors.As(err, &base))
+	assert.Equal(t, msg, query.Error())
+}
+
+func TestWrapAllAs(t *testing.T) {
+	err1 := newErrorFromCode(binaryProtocolErrorCode, "bad bits!")
+	err2 := newErrorFromCode(invalidValueErrorCode, "guess again...")
+	err := wrapAll(err1, err2)
+
+	require.NotNil(t, err)
+	assert.Equal(t, "edgedb: bad bits!; edgedb: guess again...", err.Error())
+
+	var bin *BinaryProtocolError
+	require.True(t, errors.As(err, &bin), "errors.As failed")
+	assert.Equal(t, "edgedb: bad bits!", bin.Error())
+
+	var proto *ProtocolError
+	require.True(t, errors.As(err, &proto))
+	assert.Equal(t, "edgedb: bad bits!", proto.Error())
+
+	var val *InvalidValueError
+	require.True(t, errors.As(err, &val))
+	assert.Equal(t, "edgedb: guess again...", val.Error())
+
+	var exe *ExecutionError
+	require.True(t, errors.As(err, &exe))
+	assert.Equal(t, "edgedb: guess again...", exe.Error())
+}
+
+func TestWrapAllIs(t *testing.T) {
+	err := wrapAll(ErrReleasedTwice, ErrPoolClosed)
+	require.NotNil(t, err)
+
+	msg := "edgedb: connection released more than once; " +
+		"edgedb: pool closed"
+	assert.Equal(t, msg, err.Error())
+
+	assert.True(t, errors.Is(err, ErrReleasedTwice))
+	assert.True(t, errors.Is(err, ErrPoolClosed))
+}

--- a/fallthrough.go
+++ b/fallthrough.go
@@ -45,7 +45,7 @@ func (c *baseConn) fallThrough(r *buff.Reader) error {
 		log.Println("SERVER MESSAGE", severity, code, message)
 	default:
 		msg := fmt.Sprintf("unexpected message type: 0x%x", r.MsgType)
-		return newErrorFromCode(unexpectedMessageErrorCode, msg)
+		return &unexpectedMessageError{msg: msg}
 	}
 
 	return nil

--- a/fallthrough.go
+++ b/fallthrough.go
@@ -45,7 +45,7 @@ func (c *baseConn) fallThrough(r *buff.Reader) error {
 		log.Println("SERVER MESSAGE", severity, code, message)
 	default:
 		msg := fmt.Sprintf("unexpected message type: 0x%x", r.MsgType)
-		return newError(msg)
+		return newErrorFromCode(unexpectedMessageErrorCode, msg)
 	}
 
 	return nil

--- a/fallthrough.go
+++ b/fallthrough.go
@@ -44,7 +44,8 @@ func (c *baseConn) fallThrough(r *buff.Reader) error {
 		r.Discard(2) // number of headers, assume 0
 		log.Println("SERVER MESSAGE", severity, code, message)
 	default:
-		return fmt.Errorf("unexpected message type: 0x%x", r.MsgType)
+		msg := fmt.Sprintf("unexpected message type: 0x%x", r.MsgType)
+		return newError(msg)
 	}
 
 	return nil

--- a/generatederrors.go
+++ b/generatederrors.go
@@ -95,8 +95,8 @@ const (
 	noDataErrorCode uint32 = 0xff_03_00_00
 )
 
-// wrapErrorFromCode wraps an error in an edgedb error type.
-func wrapErrorFromCode(code uint32, err error) error {
+// wrapErrorWithType wraps an error in an edgedb error type.
+func wrapErrorWithType(code uint32, err error) error {
 	if err == nil {
 		return nil
 	}
@@ -109,206 +109,206 @@ func wrapErrorFromCode(code uint32, err error) error {
 	case protocolErrorCode:
 		return &ProtocolError{&baseError{err: wrapError(err)}}
 	case binaryProtocolErrorCode:
-		next := wrapErrorFromCode(protocolErrorCode, err)
+		next := wrapErrorWithType(protocolErrorCode, err)
 		return &BinaryProtocolError{&baseError{err: next}}
 	case unsupportedProtocolVersionErrorCode:
-		next := wrapErrorFromCode(binaryProtocolErrorCode, err)
+		next := wrapErrorWithType(binaryProtocolErrorCode, err)
 		return &UnsupportedProtocolVersionError{&baseError{err: next}}
 	case typeSpecNotFoundErrorCode:
-		next := wrapErrorFromCode(binaryProtocolErrorCode, err)
+		next := wrapErrorWithType(binaryProtocolErrorCode, err)
 		return &TypeSpecNotFoundError{&baseError{err: next}}
 	case unexpectedMessageErrorCode:
-		next := wrapErrorFromCode(binaryProtocolErrorCode, err)
+		next := wrapErrorWithType(binaryProtocolErrorCode, err)
 		return &UnexpectedMessageError{&baseError{err: next}}
 	case inputDataErrorCode:
-		next := wrapErrorFromCode(protocolErrorCode, err)
+		next := wrapErrorWithType(protocolErrorCode, err)
 		return &InputDataError{&baseError{err: next}}
 	case resultCardinalityMismatchErrorCode:
-		next := wrapErrorFromCode(protocolErrorCode, err)
+		next := wrapErrorWithType(protocolErrorCode, err)
 		return &ResultCardinalityMismatchError{&baseError{err: next}}
 	case queryErrorCode:
 		return &QueryError{&baseError{err: wrapError(err)}}
 	case invalidSyntaxErrorCode:
-		next := wrapErrorFromCode(queryErrorCode, err)
+		next := wrapErrorWithType(queryErrorCode, err)
 		return &InvalidSyntaxError{&baseError{err: next}}
 	case edgeQLSyntaxErrorCode:
-		next := wrapErrorFromCode(invalidSyntaxErrorCode, err)
+		next := wrapErrorWithType(invalidSyntaxErrorCode, err)
 		return &EdgeQLSyntaxError{&baseError{err: next}}
 	case schemaSyntaxErrorCode:
-		next := wrapErrorFromCode(invalidSyntaxErrorCode, err)
+		next := wrapErrorWithType(invalidSyntaxErrorCode, err)
 		return &SchemaSyntaxError{&baseError{err: next}}
 	case graphQLSyntaxErrorCode:
-		next := wrapErrorFromCode(invalidSyntaxErrorCode, err)
+		next := wrapErrorWithType(invalidSyntaxErrorCode, err)
 		return &GraphQLSyntaxError{&baseError{err: next}}
 	case invalidTypeErrorCode:
-		next := wrapErrorFromCode(queryErrorCode, err)
+		next := wrapErrorWithType(queryErrorCode, err)
 		return &InvalidTypeError{&baseError{err: next}}
 	case invalidTargetErrorCode:
-		next := wrapErrorFromCode(invalidTypeErrorCode, err)
+		next := wrapErrorWithType(invalidTypeErrorCode, err)
 		return &InvalidTargetError{&baseError{err: next}}
 	case invalidLinkTargetErrorCode:
-		next := wrapErrorFromCode(invalidTargetErrorCode, err)
+		next := wrapErrorWithType(invalidTargetErrorCode, err)
 		return &InvalidLinkTargetError{&baseError{err: next}}
 	case invalidPropertyTargetErrorCode:
-		next := wrapErrorFromCode(invalidTargetErrorCode, err)
+		next := wrapErrorWithType(invalidTargetErrorCode, err)
 		return &InvalidPropertyTargetError{&baseError{err: next}}
 	case invalidReferenceErrorCode:
-		next := wrapErrorFromCode(queryErrorCode, err)
+		next := wrapErrorWithType(queryErrorCode, err)
 		return &InvalidReferenceError{&baseError{err: next}}
 	case unknownModuleErrorCode:
-		next := wrapErrorFromCode(invalidReferenceErrorCode, err)
+		next := wrapErrorWithType(invalidReferenceErrorCode, err)
 		return &UnknownModuleError{&baseError{err: next}}
 	case unknownLinkErrorCode:
-		next := wrapErrorFromCode(invalidReferenceErrorCode, err)
+		next := wrapErrorWithType(invalidReferenceErrorCode, err)
 		return &UnknownLinkError{&baseError{err: next}}
 	case unknownPropertyErrorCode:
-		next := wrapErrorFromCode(invalidReferenceErrorCode, err)
+		next := wrapErrorWithType(invalidReferenceErrorCode, err)
 		return &UnknownPropertyError{&baseError{err: next}}
 	case unknownUserErrorCode:
-		next := wrapErrorFromCode(invalidReferenceErrorCode, err)
+		next := wrapErrorWithType(invalidReferenceErrorCode, err)
 		return &UnknownUserError{&baseError{err: next}}
 	case unknownDatabaseErrorCode:
-		next := wrapErrorFromCode(invalidReferenceErrorCode, err)
+		next := wrapErrorWithType(invalidReferenceErrorCode, err)
 		return &UnknownDatabaseError{&baseError{err: next}}
 	case unknownParameterErrorCode:
-		next := wrapErrorFromCode(invalidReferenceErrorCode, err)
+		next := wrapErrorWithType(invalidReferenceErrorCode, err)
 		return &UnknownParameterError{&baseError{err: next}}
 	case schemaErrorCode:
-		next := wrapErrorFromCode(queryErrorCode, err)
+		next := wrapErrorWithType(queryErrorCode, err)
 		return &SchemaError{&baseError{err: next}}
 	case schemaDefinitionErrorCode:
-		next := wrapErrorFromCode(queryErrorCode, err)
+		next := wrapErrorWithType(queryErrorCode, err)
 		return &SchemaDefinitionError{&baseError{err: next}}
 	case invalidDefinitionErrorCode:
-		next := wrapErrorFromCode(schemaDefinitionErrorCode, err)
+		next := wrapErrorWithType(schemaDefinitionErrorCode, err)
 		return &InvalidDefinitionError{&baseError{err: next}}
 	case invalidModuleDefinitionErrorCode:
-		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
 		return &InvalidModuleDefinitionError{&baseError{err: next}}
 	case invalidLinkDefinitionErrorCode:
-		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
 		return &InvalidLinkDefinitionError{&baseError{err: next}}
 	case invalidPropertyDefinitionErrorCode:
-		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
 		return &InvalidPropertyDefinitionError{&baseError{err: next}}
 	case invalidUserDefinitionErrorCode:
-		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
 		return &InvalidUserDefinitionError{&baseError{err: next}}
 	case invalidDatabaseDefinitionErrorCode:
-		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
 		return &InvalidDatabaseDefinitionError{&baseError{err: next}}
 	case invalidOperatorDefinitionErrorCode:
-		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
 		return &InvalidOperatorDefinitionError{&baseError{err: next}}
 	case invalidAliasDefinitionErrorCode:
-		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
 		return &InvalidAliasDefinitionError{&baseError{err: next}}
 	case invalidFunctionDefinitionErrorCode:
-		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
 		return &InvalidFunctionDefinitionError{&baseError{err: next}}
 	case invalidConstraintDefinitionErrorCode:
-		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
 		return &InvalidConstraintDefinitionError{&baseError{err: next}}
 	case invalidCastDefinitionErrorCode:
-		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
 		return &InvalidCastDefinitionError{&baseError{err: next}}
 	case duplicateDefinitionErrorCode:
-		next := wrapErrorFromCode(schemaDefinitionErrorCode, err)
+		next := wrapErrorWithType(schemaDefinitionErrorCode, err)
 		return &DuplicateDefinitionError{&baseError{err: next}}
 	case duplicateModuleDefinitionErrorCode:
-		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
 		return &DuplicateModuleDefinitionError{&baseError{err: next}}
 	case duplicateLinkDefinitionErrorCode:
-		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
 		return &DuplicateLinkDefinitionError{&baseError{err: next}}
 	case duplicatePropertyDefinitionErrorCode:
-		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
 		return &DuplicatePropertyDefinitionError{&baseError{err: next}}
 	case duplicateUserDefinitionErrorCode:
-		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
 		return &DuplicateUserDefinitionError{&baseError{err: next}}
 	case duplicateDatabaseDefinitionErrorCode:
-		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
 		return &DuplicateDatabaseDefinitionError{&baseError{err: next}}
 	case duplicateOperatorDefinitionErrorCode:
-		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
 		return &DuplicateOperatorDefinitionError{&baseError{err: next}}
 	case duplicateViewDefinitionErrorCode:
-		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
 		return &DuplicateViewDefinitionError{&baseError{err: next}}
 	case duplicateFunctionDefinitionErrorCode:
-		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
 		return &DuplicateFunctionDefinitionError{&baseError{err: next}}
 	case duplicateConstraintDefinitionErrorCode:
-		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
 		return &DuplicateConstraintDefinitionError{&baseError{err: next}}
 	case duplicateCastDefinitionErrorCode:
-		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
 		return &DuplicateCastDefinitionError{&baseError{err: next}}
 	case queryTimeoutErrorCode:
-		next := wrapErrorFromCode(queryErrorCode, err)
+		next := wrapErrorWithType(queryErrorCode, err)
 		return &QueryTimeoutError{&baseError{err: next}}
 	case executionErrorCode:
 		return &ExecutionError{&baseError{err: wrapError(err)}}
 	case invalidValueErrorCode:
-		next := wrapErrorFromCode(executionErrorCode, err)
+		next := wrapErrorWithType(executionErrorCode, err)
 		return &InvalidValueError{&baseError{err: next}}
 	case divisionByZeroErrorCode:
-		next := wrapErrorFromCode(invalidValueErrorCode, err)
+		next := wrapErrorWithType(invalidValueErrorCode, err)
 		return &DivisionByZeroError{&baseError{err: next}}
 	case numericOutOfRangeErrorCode:
-		next := wrapErrorFromCode(invalidValueErrorCode, err)
+		next := wrapErrorWithType(invalidValueErrorCode, err)
 		return &NumericOutOfRangeError{&baseError{err: next}}
 	case integrityErrorCode:
-		next := wrapErrorFromCode(executionErrorCode, err)
+		next := wrapErrorWithType(executionErrorCode, err)
 		return &IntegrityError{&baseError{err: next}}
 	case constraintViolationErrorCode:
-		next := wrapErrorFromCode(integrityErrorCode, err)
+		next := wrapErrorWithType(integrityErrorCode, err)
 		return &ConstraintViolationError{&baseError{err: next}}
 	case cardinalityViolationErrorCode:
-		next := wrapErrorFromCode(integrityErrorCode, err)
+		next := wrapErrorWithType(integrityErrorCode, err)
 		return &CardinalityViolationError{&baseError{err: next}}
 	case missingRequiredErrorCode:
-		next := wrapErrorFromCode(integrityErrorCode, err)
+		next := wrapErrorWithType(integrityErrorCode, err)
 		return &MissingRequiredError{&baseError{err: next}}
 	case transactionErrorCode:
-		next := wrapErrorFromCode(executionErrorCode, err)
+		next := wrapErrorWithType(executionErrorCode, err)
 		return &TransactionError{&baseError{err: next}}
 	case transactionSerializationErrorCode:
-		next := wrapErrorFromCode(transactionErrorCode, err)
+		next := wrapErrorWithType(transactionErrorCode, err)
 		return &TransactionSerializationError{&baseError{err: next}}
 	case transactionDeadlockErrorCode:
-		next := wrapErrorFromCode(transactionErrorCode, err)
+		next := wrapErrorWithType(transactionErrorCode, err)
 		return &TransactionDeadlockError{&baseError{err: next}}
 	case configurationErrorCode:
 		return &ConfigurationError{&baseError{err: wrapError(err)}}
 	case accessErrorCode:
 		return &AccessError{&baseError{err: wrapError(err)}}
 	case authenticationErrorCode:
-		next := wrapErrorFromCode(accessErrorCode, err)
+		next := wrapErrorWithType(accessErrorCode, err)
 		return &AuthenticationError{&baseError{err: next}}
 	case clientErrorCode:
 		return &ClientError{&baseError{err: wrapError(err)}}
 	case clientConnectionErrorCode:
-		next := wrapErrorFromCode(clientErrorCode, err)
+		next := wrapErrorWithType(clientErrorCode, err)
 		return &ClientConnectionError{&baseError{err: next}}
 	case interfaceErrorCode:
-		next := wrapErrorFromCode(clientErrorCode, err)
+		next := wrapErrorWithType(clientErrorCode, err)
 		return &InterfaceError{&baseError{err: next}}
 	case queryArgumentErrorCode:
-		next := wrapErrorFromCode(interfaceErrorCode, err)
+		next := wrapErrorWithType(interfaceErrorCode, err)
 		return &QueryArgumentError{&baseError{err: next}}
 	case missingArgumentErrorCode:
-		next := wrapErrorFromCode(queryArgumentErrorCode, err)
+		next := wrapErrorWithType(queryArgumentErrorCode, err)
 		return &MissingArgumentError{&baseError{err: next}}
 	case unknownArgumentErrorCode:
-		next := wrapErrorFromCode(queryArgumentErrorCode, err)
+		next := wrapErrorWithType(queryArgumentErrorCode, err)
 		return &UnknownArgumentError{&baseError{err: next}}
 	case invalidArgumentErrorCode:
-		next := wrapErrorFromCode(queryArgumentErrorCode, err)
+		next := wrapErrorWithType(queryArgumentErrorCode, err)
 		return &InvalidArgumentError{&baseError{err: next}}
 	case noDataErrorCode:
-		next := wrapErrorFromCode(clientErrorCode, err)
+		next := wrapErrorWithType(clientErrorCode, err)
 		return &NoDataError{&baseError{err: next}}
 	default:
 		panic(fmt.Sprintf("unknown error code: %v", code))

--- a/generatederrors.go
+++ b/generatederrors.go
@@ -20,657 +20,2355 @@ package edgedb
 
 import "fmt"
 
-const (
-	internalServerErrorCode uint32 = 0x01_00_00_00
-	unsupportedFeatureErrorCode uint32 = 0x02_00_00_00
-	protocolErrorCode uint32 = 0x03_00_00_00
-	binaryProtocolErrorCode uint32 = 0x03_01_00_00
-	unsupportedProtocolVersionErrorCode uint32 = 0x03_01_00_01
-	typeSpecNotFoundErrorCode uint32 = 0x03_01_00_02
-	unexpectedMessageErrorCode uint32 = 0x03_01_00_03
-	inputDataErrorCode uint32 = 0x03_02_00_00
-	resultCardinalityMismatchErrorCode uint32 = 0x03_03_00_00
-	queryErrorCode uint32 = 0x04_00_00_00
-	invalidSyntaxErrorCode uint32 = 0x04_01_00_00
-	edgeQLSyntaxErrorCode uint32 = 0x04_01_01_00
-	schemaSyntaxErrorCode uint32 = 0x04_01_02_00
-	graphQLSyntaxErrorCode uint32 = 0x04_01_03_00
-	invalidTypeErrorCode uint32 = 0x04_02_00_00
-	invalidTargetErrorCode uint32 = 0x04_02_01_00
-	invalidLinkTargetErrorCode uint32 = 0x04_02_01_01
-	invalidPropertyTargetErrorCode uint32 = 0x04_02_01_02
-	invalidReferenceErrorCode uint32 = 0x04_03_00_00
-	unknownModuleErrorCode uint32 = 0x04_03_00_01
-	unknownLinkErrorCode uint32 = 0x04_03_00_02
-	unknownPropertyErrorCode uint32 = 0x04_03_00_03
-	unknownUserErrorCode uint32 = 0x04_03_00_04
-	unknownDatabaseErrorCode uint32 = 0x04_03_00_05
-	unknownParameterErrorCode uint32 = 0x04_03_00_06
-	schemaErrorCode uint32 = 0x04_04_00_00
-	schemaDefinitionErrorCode uint32 = 0x04_05_00_00
-	invalidDefinitionErrorCode uint32 = 0x04_05_01_00
-	invalidModuleDefinitionErrorCode uint32 = 0x04_05_01_01
-	invalidLinkDefinitionErrorCode uint32 = 0x04_05_01_02
-	invalidPropertyDefinitionErrorCode uint32 = 0x04_05_01_03
-	invalidUserDefinitionErrorCode uint32 = 0x04_05_01_04
-	invalidDatabaseDefinitionErrorCode uint32 = 0x04_05_01_05
-	invalidOperatorDefinitionErrorCode uint32 = 0x04_05_01_06
-	invalidAliasDefinitionErrorCode uint32 = 0x04_05_01_07
-	invalidFunctionDefinitionErrorCode uint32 = 0x04_05_01_08
-	invalidConstraintDefinitionErrorCode uint32 = 0x04_05_01_09
-	invalidCastDefinitionErrorCode uint32 = 0x04_05_01_0a
-	duplicateDefinitionErrorCode uint32 = 0x04_05_02_00
-	duplicateModuleDefinitionErrorCode uint32 = 0x04_05_02_01
-	duplicateLinkDefinitionErrorCode uint32 = 0x04_05_02_02
-	duplicatePropertyDefinitionErrorCode uint32 = 0x04_05_02_03
-	duplicateUserDefinitionErrorCode uint32 = 0x04_05_02_04
-	duplicateDatabaseDefinitionErrorCode uint32 = 0x04_05_02_05
-	duplicateOperatorDefinitionErrorCode uint32 = 0x04_05_02_06
-	duplicateViewDefinitionErrorCode uint32 = 0x04_05_02_07
-	duplicateFunctionDefinitionErrorCode uint32 = 0x04_05_02_08
-	duplicateConstraintDefinitionErrorCode uint32 = 0x04_05_02_09
-	duplicateCastDefinitionErrorCode uint32 = 0x04_05_02_0a
-	queryTimeoutErrorCode uint32 = 0x04_06_00_00
-	executionErrorCode uint32 = 0x05_00_00_00
-	invalidValueErrorCode uint32 = 0x05_01_00_00
-	divisionByZeroErrorCode uint32 = 0x05_01_00_01
-	numericOutOfRangeErrorCode uint32 = 0x05_01_00_02
-	integrityErrorCode uint32 = 0x05_02_00_00
-	constraintViolationErrorCode uint32 = 0x05_02_00_01
-	cardinalityViolationErrorCode uint32 = 0x05_02_00_02
-	missingRequiredErrorCode uint32 = 0x05_02_00_03
-	transactionErrorCode uint32 = 0x05_03_00_00
-	transactionSerializationErrorCode uint32 = 0x05_03_00_01
-	transactionDeadlockErrorCode uint32 = 0x05_03_00_02
-	configurationErrorCode uint32 = 0x06_00_00_00
-	accessErrorCode uint32 = 0x07_00_00_00
-	authenticationErrorCode uint32 = 0x07_01_00_00
-	clientErrorCode uint32 = 0xff_00_00_00
-	clientConnectionErrorCode uint32 = 0xff_01_00_00
-	interfaceErrorCode uint32 = 0xff_02_00_00
-	queryArgumentErrorCode uint32 = 0xff_02_01_00
-	missingArgumentErrorCode uint32 = 0xff_02_01_01
-	unknownArgumentErrorCode uint32 = 0xff_02_01_02
-	invalidArgumentErrorCode uint32 = 0xff_02_01_03
-	noDataErrorCode uint32 = 0xff_03_00_00
-)
-
-// wrapErrorWithType wraps an error in an edgedb error type.
-func wrapErrorWithType(code uint32, err error) error {
-	if err == nil {
-		return nil
-	}
-
-	switch code {
-	case internalServerErrorCode:
-		return &InternalServerError{&baseError{err: wrapError(err)}}
-	case unsupportedFeatureErrorCode:
-		return &UnsupportedFeatureError{&baseError{err: wrapError(err)}}
-	case protocolErrorCode:
-		return &ProtocolError{&baseError{err: wrapError(err)}}
-	case binaryProtocolErrorCode:
-		next := wrapErrorWithType(protocolErrorCode, err)
-		return &BinaryProtocolError{&baseError{err: next}}
-	case unsupportedProtocolVersionErrorCode:
-		next := wrapErrorWithType(binaryProtocolErrorCode, err)
-		return &UnsupportedProtocolVersionError{&baseError{err: next}}
-	case typeSpecNotFoundErrorCode:
-		next := wrapErrorWithType(binaryProtocolErrorCode, err)
-		return &TypeSpecNotFoundError{&baseError{err: next}}
-	case unexpectedMessageErrorCode:
-		next := wrapErrorWithType(binaryProtocolErrorCode, err)
-		return &UnexpectedMessageError{&baseError{err: next}}
-	case inputDataErrorCode:
-		next := wrapErrorWithType(protocolErrorCode, err)
-		return &InputDataError{&baseError{err: next}}
-	case resultCardinalityMismatchErrorCode:
-		next := wrapErrorWithType(protocolErrorCode, err)
-		return &ResultCardinalityMismatchError{&baseError{err: next}}
-	case queryErrorCode:
-		return &QueryError{&baseError{err: wrapError(err)}}
-	case invalidSyntaxErrorCode:
-		next := wrapErrorWithType(queryErrorCode, err)
-		return &InvalidSyntaxError{&baseError{err: next}}
-	case edgeQLSyntaxErrorCode:
-		next := wrapErrorWithType(invalidSyntaxErrorCode, err)
-		return &EdgeQLSyntaxError{&baseError{err: next}}
-	case schemaSyntaxErrorCode:
-		next := wrapErrorWithType(invalidSyntaxErrorCode, err)
-		return &SchemaSyntaxError{&baseError{err: next}}
-	case graphQLSyntaxErrorCode:
-		next := wrapErrorWithType(invalidSyntaxErrorCode, err)
-		return &GraphQLSyntaxError{&baseError{err: next}}
-	case invalidTypeErrorCode:
-		next := wrapErrorWithType(queryErrorCode, err)
-		return &InvalidTypeError{&baseError{err: next}}
-	case invalidTargetErrorCode:
-		next := wrapErrorWithType(invalidTypeErrorCode, err)
-		return &InvalidTargetError{&baseError{err: next}}
-	case invalidLinkTargetErrorCode:
-		next := wrapErrorWithType(invalidTargetErrorCode, err)
-		return &InvalidLinkTargetError{&baseError{err: next}}
-	case invalidPropertyTargetErrorCode:
-		next := wrapErrorWithType(invalidTargetErrorCode, err)
-		return &InvalidPropertyTargetError{&baseError{err: next}}
-	case invalidReferenceErrorCode:
-		next := wrapErrorWithType(queryErrorCode, err)
-		return &InvalidReferenceError{&baseError{err: next}}
-	case unknownModuleErrorCode:
-		next := wrapErrorWithType(invalidReferenceErrorCode, err)
-		return &UnknownModuleError{&baseError{err: next}}
-	case unknownLinkErrorCode:
-		next := wrapErrorWithType(invalidReferenceErrorCode, err)
-		return &UnknownLinkError{&baseError{err: next}}
-	case unknownPropertyErrorCode:
-		next := wrapErrorWithType(invalidReferenceErrorCode, err)
-		return &UnknownPropertyError{&baseError{err: next}}
-	case unknownUserErrorCode:
-		next := wrapErrorWithType(invalidReferenceErrorCode, err)
-		return &UnknownUserError{&baseError{err: next}}
-	case unknownDatabaseErrorCode:
-		next := wrapErrorWithType(invalidReferenceErrorCode, err)
-		return &UnknownDatabaseError{&baseError{err: next}}
-	case unknownParameterErrorCode:
-		next := wrapErrorWithType(invalidReferenceErrorCode, err)
-		return &UnknownParameterError{&baseError{err: next}}
-	case schemaErrorCode:
-		next := wrapErrorWithType(queryErrorCode, err)
-		return &SchemaError{&baseError{err: next}}
-	case schemaDefinitionErrorCode:
-		next := wrapErrorWithType(queryErrorCode, err)
-		return &SchemaDefinitionError{&baseError{err: next}}
-	case invalidDefinitionErrorCode:
-		next := wrapErrorWithType(schemaDefinitionErrorCode, err)
-		return &InvalidDefinitionError{&baseError{err: next}}
-	case invalidModuleDefinitionErrorCode:
-		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
-		return &InvalidModuleDefinitionError{&baseError{err: next}}
-	case invalidLinkDefinitionErrorCode:
-		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
-		return &InvalidLinkDefinitionError{&baseError{err: next}}
-	case invalidPropertyDefinitionErrorCode:
-		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
-		return &InvalidPropertyDefinitionError{&baseError{err: next}}
-	case invalidUserDefinitionErrorCode:
-		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
-		return &InvalidUserDefinitionError{&baseError{err: next}}
-	case invalidDatabaseDefinitionErrorCode:
-		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
-		return &InvalidDatabaseDefinitionError{&baseError{err: next}}
-	case invalidOperatorDefinitionErrorCode:
-		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
-		return &InvalidOperatorDefinitionError{&baseError{err: next}}
-	case invalidAliasDefinitionErrorCode:
-		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
-		return &InvalidAliasDefinitionError{&baseError{err: next}}
-	case invalidFunctionDefinitionErrorCode:
-		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
-		return &InvalidFunctionDefinitionError{&baseError{err: next}}
-	case invalidConstraintDefinitionErrorCode:
-		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
-		return &InvalidConstraintDefinitionError{&baseError{err: next}}
-	case invalidCastDefinitionErrorCode:
-		next := wrapErrorWithType(invalidDefinitionErrorCode, err)
-		return &InvalidCastDefinitionError{&baseError{err: next}}
-	case duplicateDefinitionErrorCode:
-		next := wrapErrorWithType(schemaDefinitionErrorCode, err)
-		return &DuplicateDefinitionError{&baseError{err: next}}
-	case duplicateModuleDefinitionErrorCode:
-		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
-		return &DuplicateModuleDefinitionError{&baseError{err: next}}
-	case duplicateLinkDefinitionErrorCode:
-		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
-		return &DuplicateLinkDefinitionError{&baseError{err: next}}
-	case duplicatePropertyDefinitionErrorCode:
-		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
-		return &DuplicatePropertyDefinitionError{&baseError{err: next}}
-	case duplicateUserDefinitionErrorCode:
-		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
-		return &DuplicateUserDefinitionError{&baseError{err: next}}
-	case duplicateDatabaseDefinitionErrorCode:
-		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
-		return &DuplicateDatabaseDefinitionError{&baseError{err: next}}
-	case duplicateOperatorDefinitionErrorCode:
-		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
-		return &DuplicateOperatorDefinitionError{&baseError{err: next}}
-	case duplicateViewDefinitionErrorCode:
-		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
-		return &DuplicateViewDefinitionError{&baseError{err: next}}
-	case duplicateFunctionDefinitionErrorCode:
-		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
-		return &DuplicateFunctionDefinitionError{&baseError{err: next}}
-	case duplicateConstraintDefinitionErrorCode:
-		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
-		return &DuplicateConstraintDefinitionError{&baseError{err: next}}
-	case duplicateCastDefinitionErrorCode:
-		next := wrapErrorWithType(duplicateDefinitionErrorCode, err)
-		return &DuplicateCastDefinitionError{&baseError{err: next}}
-	case queryTimeoutErrorCode:
-		next := wrapErrorWithType(queryErrorCode, err)
-		return &QueryTimeoutError{&baseError{err: next}}
-	case executionErrorCode:
-		return &ExecutionError{&baseError{err: wrapError(err)}}
-	case invalidValueErrorCode:
-		next := wrapErrorWithType(executionErrorCode, err)
-		return &InvalidValueError{&baseError{err: next}}
-	case divisionByZeroErrorCode:
-		next := wrapErrorWithType(invalidValueErrorCode, err)
-		return &DivisionByZeroError{&baseError{err: next}}
-	case numericOutOfRangeErrorCode:
-		next := wrapErrorWithType(invalidValueErrorCode, err)
-		return &NumericOutOfRangeError{&baseError{err: next}}
-	case integrityErrorCode:
-		next := wrapErrorWithType(executionErrorCode, err)
-		return &IntegrityError{&baseError{err: next}}
-	case constraintViolationErrorCode:
-		next := wrapErrorWithType(integrityErrorCode, err)
-		return &ConstraintViolationError{&baseError{err: next}}
-	case cardinalityViolationErrorCode:
-		next := wrapErrorWithType(integrityErrorCode, err)
-		return &CardinalityViolationError{&baseError{err: next}}
-	case missingRequiredErrorCode:
-		next := wrapErrorWithType(integrityErrorCode, err)
-		return &MissingRequiredError{&baseError{err: next}}
-	case transactionErrorCode:
-		next := wrapErrorWithType(executionErrorCode, err)
-		return &TransactionError{&baseError{err: next}}
-	case transactionSerializationErrorCode:
-		next := wrapErrorWithType(transactionErrorCode, err)
-		return &TransactionSerializationError{&baseError{err: next}}
-	case transactionDeadlockErrorCode:
-		next := wrapErrorWithType(transactionErrorCode, err)
-		return &TransactionDeadlockError{&baseError{err: next}}
-	case configurationErrorCode:
-		return &ConfigurationError{&baseError{err: wrapError(err)}}
-	case accessErrorCode:
-		return &AccessError{&baseError{err: wrapError(err)}}
-	case authenticationErrorCode:
-		next := wrapErrorWithType(accessErrorCode, err)
-		return &AuthenticationError{&baseError{err: next}}
-	case clientErrorCode:
-		return &ClientError{&baseError{err: wrapError(err)}}
-	case clientConnectionErrorCode:
-		next := wrapErrorWithType(clientErrorCode, err)
-		return &ClientConnectionError{&baseError{err: next}}
-	case interfaceErrorCode:
-		next := wrapErrorWithType(clientErrorCode, err)
-		return &InterfaceError{&baseError{err: next}}
-	case queryArgumentErrorCode:
-		next := wrapErrorWithType(interfaceErrorCode, err)
-		return &QueryArgumentError{&baseError{err: next}}
-	case missingArgumentErrorCode:
-		next := wrapErrorWithType(queryArgumentErrorCode, err)
-		return &MissingArgumentError{&baseError{err: next}}
-	case unknownArgumentErrorCode:
-		next := wrapErrorWithType(queryArgumentErrorCode, err)
-		return &UnknownArgumentError{&baseError{err: next}}
-	case invalidArgumentErrorCode:
-		next := wrapErrorWithType(queryArgumentErrorCode, err)
-		return &InvalidArgumentError{&baseError{err: next}}
-	case noDataErrorCode:
-		next := wrapErrorWithType(clientErrorCode, err)
-		return &NoDataError{&baseError{err: next}}
-	default:
-		panic(fmt.Sprintf("unknown error code: %v", code))
-	}
-}
-
 // InternalServerError is an error.
-type InternalServerError struct {
-	*baseError
+type InternalServerError interface {
+	Error
+	isInternalServerError()
 }
+
+type internalServerError struct {
+	msg string
+	err error
+}
+
+func (e *internalServerError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InternalServerError: " + msg
+}
+
+func (e *internalServerError) Unwrap() error { return e.err }
+
+func (e *internalServerError) isInternalServerError() {}
+
+func (e *internalServerError) isError() {}
 
 // UnsupportedFeatureError is an error.
-type UnsupportedFeatureError struct {
-	*baseError
+type UnsupportedFeatureError interface {
+	Error
+	isUnsupportedFeatureError()
 }
+
+type unsupportedFeatureError struct {
+	msg string
+	err error
+}
+
+func (e *unsupportedFeatureError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.UnsupportedFeatureError: " + msg
+}
+
+func (e *unsupportedFeatureError) Unwrap() error { return e.err }
+
+func (e *unsupportedFeatureError) isUnsupportedFeatureError() {}
+
+func (e *unsupportedFeatureError) isError() {}
 
 // ProtocolError is an error.
-type ProtocolError struct {
-	*baseError
+type ProtocolError interface {
+	Error
+	isProtocolError()
 }
+
+type protocolError struct {
+	msg string
+	err error
+}
+
+func (e *protocolError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.ProtocolError: " + msg
+}
+
+func (e *protocolError) Unwrap() error { return e.err }
+
+func (e *protocolError) isProtocolError() {}
+
+func (e *protocolError) isError() {}
 
 // BinaryProtocolError is an error.
-type BinaryProtocolError struct {
-	*baseError
+type BinaryProtocolError interface {
+	ProtocolError
+	isBinaryProtocolError()
 }
+
+type binaryProtocolError struct {
+	msg string
+	err error
+}
+
+func (e *binaryProtocolError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.BinaryProtocolError: " + msg
+}
+
+func (e *binaryProtocolError) Unwrap() error { return e.err }
+
+func (e *binaryProtocolError) isBinaryProtocolError() {}
+
+func (e *binaryProtocolError) isProtocolError() {}
+
+func (e *binaryProtocolError) isError() {}
 
 // UnsupportedProtocolVersionError is an error.
-type UnsupportedProtocolVersionError struct {
-	*baseError
+type UnsupportedProtocolVersionError interface {
+	BinaryProtocolError
+	isUnsupportedProtocolVersionError()
 }
+
+type unsupportedProtocolVersionError struct {
+	msg string
+	err error
+}
+
+func (e *unsupportedProtocolVersionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.UnsupportedProtocolVersionError: " + msg
+}
+
+func (e *unsupportedProtocolVersionError) Unwrap() error { return e.err }
+
+func (e *unsupportedProtocolVersionError) isUnsupportedProtocolVersionError() {}
+
+func (e *unsupportedProtocolVersionError) isBinaryProtocolError() {}
+
+func (e *unsupportedProtocolVersionError) isProtocolError() {}
+
+func (e *unsupportedProtocolVersionError) isError() {}
 
 // TypeSpecNotFoundError is an error.
-type TypeSpecNotFoundError struct {
-	*baseError
+type TypeSpecNotFoundError interface {
+	BinaryProtocolError
+	isTypeSpecNotFoundError()
 }
+
+type typeSpecNotFoundError struct {
+	msg string
+	err error
+}
+
+func (e *typeSpecNotFoundError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.TypeSpecNotFoundError: " + msg
+}
+
+func (e *typeSpecNotFoundError) Unwrap() error { return e.err }
+
+func (e *typeSpecNotFoundError) isTypeSpecNotFoundError() {}
+
+func (e *typeSpecNotFoundError) isBinaryProtocolError() {}
+
+func (e *typeSpecNotFoundError) isProtocolError() {}
+
+func (e *typeSpecNotFoundError) isError() {}
 
 // UnexpectedMessageError is an error.
-type UnexpectedMessageError struct {
-	*baseError
+type UnexpectedMessageError interface {
+	BinaryProtocolError
+	isUnexpectedMessageError()
 }
+
+type unexpectedMessageError struct {
+	msg string
+	err error
+}
+
+func (e *unexpectedMessageError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.UnexpectedMessageError: " + msg
+}
+
+func (e *unexpectedMessageError) Unwrap() error { return e.err }
+
+func (e *unexpectedMessageError) isUnexpectedMessageError() {}
+
+func (e *unexpectedMessageError) isBinaryProtocolError() {}
+
+func (e *unexpectedMessageError) isProtocolError() {}
+
+func (e *unexpectedMessageError) isError() {}
 
 // InputDataError is an error.
-type InputDataError struct {
-	*baseError
+type InputDataError interface {
+	ProtocolError
+	isInputDataError()
 }
+
+type inputDataError struct {
+	msg string
+	err error
+}
+
+func (e *inputDataError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InputDataError: " + msg
+}
+
+func (e *inputDataError) Unwrap() error { return e.err }
+
+func (e *inputDataError) isInputDataError() {}
+
+func (e *inputDataError) isProtocolError() {}
+
+func (e *inputDataError) isError() {}
 
 // ResultCardinalityMismatchError is an error.
-type ResultCardinalityMismatchError struct {
-	*baseError
+type ResultCardinalityMismatchError interface {
+	ProtocolError
+	isResultCardinalityMismatchError()
 }
+
+type resultCardinalityMismatchError struct {
+	msg string
+	err error
+}
+
+func (e *resultCardinalityMismatchError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.ResultCardinalityMismatchError: " + msg
+}
+
+func (e *resultCardinalityMismatchError) Unwrap() error { return e.err }
+
+func (e *resultCardinalityMismatchError) isResultCardinalityMismatchError() {}
+
+func (e *resultCardinalityMismatchError) isProtocolError() {}
+
+func (e *resultCardinalityMismatchError) isError() {}
 
 // QueryError is an error.
-type QueryError struct {
-	*baseError
+type QueryError interface {
+	Error
+	isQueryError()
 }
+
+type queryError struct {
+	msg string
+	err error
+}
+
+func (e *queryError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.QueryError: " + msg
+}
+
+func (e *queryError) Unwrap() error { return e.err }
+
+func (e *queryError) isQueryError() {}
+
+func (e *queryError) isError() {}
 
 // InvalidSyntaxError is an error.
-type InvalidSyntaxError struct {
-	*baseError
+type InvalidSyntaxError interface {
+	QueryError
+	isInvalidSyntaxError()
 }
+
+type invalidSyntaxError struct {
+	msg string
+	err error
+}
+
+func (e *invalidSyntaxError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidSyntaxError: " + msg
+}
+
+func (e *invalidSyntaxError) Unwrap() error { return e.err }
+
+func (e *invalidSyntaxError) isInvalidSyntaxError() {}
+
+func (e *invalidSyntaxError) isQueryError() {}
+
+func (e *invalidSyntaxError) isError() {}
 
 // EdgeQLSyntaxError is an error.
-type EdgeQLSyntaxError struct {
-	*baseError
+type EdgeQLSyntaxError interface {
+	InvalidSyntaxError
+	isEdgeQLSyntaxError()
 }
+
+type edgeQLSyntaxError struct {
+	msg string
+	err error
+}
+
+func (e *edgeQLSyntaxError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.EdgeQLSyntaxError: " + msg
+}
+
+func (e *edgeQLSyntaxError) Unwrap() error { return e.err }
+
+func (e *edgeQLSyntaxError) isEdgeQLSyntaxError() {}
+
+func (e *edgeQLSyntaxError) isInvalidSyntaxError() {}
+
+func (e *edgeQLSyntaxError) isQueryError() {}
+
+func (e *edgeQLSyntaxError) isError() {}
 
 // SchemaSyntaxError is an error.
-type SchemaSyntaxError struct {
-	*baseError
+type SchemaSyntaxError interface {
+	InvalidSyntaxError
+	isSchemaSyntaxError()
 }
+
+type schemaSyntaxError struct {
+	msg string
+	err error
+}
+
+func (e *schemaSyntaxError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.SchemaSyntaxError: " + msg
+}
+
+func (e *schemaSyntaxError) Unwrap() error { return e.err }
+
+func (e *schemaSyntaxError) isSchemaSyntaxError() {}
+
+func (e *schemaSyntaxError) isInvalidSyntaxError() {}
+
+func (e *schemaSyntaxError) isQueryError() {}
+
+func (e *schemaSyntaxError) isError() {}
 
 // GraphQLSyntaxError is an error.
-type GraphQLSyntaxError struct {
-	*baseError
+type GraphQLSyntaxError interface {
+	InvalidSyntaxError
+	isGraphQLSyntaxError()
 }
+
+type graphQLSyntaxError struct {
+	msg string
+	err error
+}
+
+func (e *graphQLSyntaxError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.GraphQLSyntaxError: " + msg
+}
+
+func (e *graphQLSyntaxError) Unwrap() error { return e.err }
+
+func (e *graphQLSyntaxError) isGraphQLSyntaxError() {}
+
+func (e *graphQLSyntaxError) isInvalidSyntaxError() {}
+
+func (e *graphQLSyntaxError) isQueryError() {}
+
+func (e *graphQLSyntaxError) isError() {}
 
 // InvalidTypeError is an error.
-type InvalidTypeError struct {
-	*baseError
+type InvalidTypeError interface {
+	QueryError
+	isInvalidTypeError()
 }
+
+type invalidTypeError struct {
+	msg string
+	err error
+}
+
+func (e *invalidTypeError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidTypeError: " + msg
+}
+
+func (e *invalidTypeError) Unwrap() error { return e.err }
+
+func (e *invalidTypeError) isInvalidTypeError() {}
+
+func (e *invalidTypeError) isQueryError() {}
+
+func (e *invalidTypeError) isError() {}
 
 // InvalidTargetError is an error.
-type InvalidTargetError struct {
-	*baseError
+type InvalidTargetError interface {
+	InvalidTypeError
+	isInvalidTargetError()
 }
+
+type invalidTargetError struct {
+	msg string
+	err error
+}
+
+func (e *invalidTargetError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidTargetError: " + msg
+}
+
+func (e *invalidTargetError) Unwrap() error { return e.err }
+
+func (e *invalidTargetError) isInvalidTargetError() {}
+
+func (e *invalidTargetError) isInvalidTypeError() {}
+
+func (e *invalidTargetError) isQueryError() {}
+
+func (e *invalidTargetError) isError() {}
 
 // InvalidLinkTargetError is an error.
-type InvalidLinkTargetError struct {
-	*baseError
+type InvalidLinkTargetError interface {
+	InvalidTargetError
+	isInvalidLinkTargetError()
 }
+
+type invalidLinkTargetError struct {
+	msg string
+	err error
+}
+
+func (e *invalidLinkTargetError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidLinkTargetError: " + msg
+}
+
+func (e *invalidLinkTargetError) Unwrap() error { return e.err }
+
+func (e *invalidLinkTargetError) isInvalidLinkTargetError() {}
+
+func (e *invalidLinkTargetError) isInvalidTargetError() {}
+
+func (e *invalidLinkTargetError) isInvalidTypeError() {}
+
+func (e *invalidLinkTargetError) isQueryError() {}
+
+func (e *invalidLinkTargetError) isError() {}
 
 // InvalidPropertyTargetError is an error.
-type InvalidPropertyTargetError struct {
-	*baseError
+type InvalidPropertyTargetError interface {
+	InvalidTargetError
+	isInvalidPropertyTargetError()
 }
+
+type invalidPropertyTargetError struct {
+	msg string
+	err error
+}
+
+func (e *invalidPropertyTargetError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidPropertyTargetError: " + msg
+}
+
+func (e *invalidPropertyTargetError) Unwrap() error { return e.err }
+
+func (e *invalidPropertyTargetError) isInvalidPropertyTargetError() {}
+
+func (e *invalidPropertyTargetError) isInvalidTargetError() {}
+
+func (e *invalidPropertyTargetError) isInvalidTypeError() {}
+
+func (e *invalidPropertyTargetError) isQueryError() {}
+
+func (e *invalidPropertyTargetError) isError() {}
 
 // InvalidReferenceError is an error.
-type InvalidReferenceError struct {
-	*baseError
+type InvalidReferenceError interface {
+	QueryError
+	isInvalidReferenceError()
 }
+
+type invalidReferenceError struct {
+	msg string
+	err error
+}
+
+func (e *invalidReferenceError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidReferenceError: " + msg
+}
+
+func (e *invalidReferenceError) Unwrap() error { return e.err }
+
+func (e *invalidReferenceError) isInvalidReferenceError() {}
+
+func (e *invalidReferenceError) isQueryError() {}
+
+func (e *invalidReferenceError) isError() {}
 
 // UnknownModuleError is an error.
-type UnknownModuleError struct {
-	*baseError
+type UnknownModuleError interface {
+	InvalidReferenceError
+	isUnknownModuleError()
 }
+
+type unknownModuleError struct {
+	msg string
+	err error
+}
+
+func (e *unknownModuleError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.UnknownModuleError: " + msg
+}
+
+func (e *unknownModuleError) Unwrap() error { return e.err }
+
+func (e *unknownModuleError) isUnknownModuleError() {}
+
+func (e *unknownModuleError) isInvalidReferenceError() {}
+
+func (e *unknownModuleError) isQueryError() {}
+
+func (e *unknownModuleError) isError() {}
 
 // UnknownLinkError is an error.
-type UnknownLinkError struct {
-	*baseError
+type UnknownLinkError interface {
+	InvalidReferenceError
+	isUnknownLinkError()
 }
+
+type unknownLinkError struct {
+	msg string
+	err error
+}
+
+func (e *unknownLinkError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.UnknownLinkError: " + msg
+}
+
+func (e *unknownLinkError) Unwrap() error { return e.err }
+
+func (e *unknownLinkError) isUnknownLinkError() {}
+
+func (e *unknownLinkError) isInvalidReferenceError() {}
+
+func (e *unknownLinkError) isQueryError() {}
+
+func (e *unknownLinkError) isError() {}
 
 // UnknownPropertyError is an error.
-type UnknownPropertyError struct {
-	*baseError
+type UnknownPropertyError interface {
+	InvalidReferenceError
+	isUnknownPropertyError()
 }
+
+type unknownPropertyError struct {
+	msg string
+	err error
+}
+
+func (e *unknownPropertyError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.UnknownPropertyError: " + msg
+}
+
+func (e *unknownPropertyError) Unwrap() error { return e.err }
+
+func (e *unknownPropertyError) isUnknownPropertyError() {}
+
+func (e *unknownPropertyError) isInvalidReferenceError() {}
+
+func (e *unknownPropertyError) isQueryError() {}
+
+func (e *unknownPropertyError) isError() {}
 
 // UnknownUserError is an error.
-type UnknownUserError struct {
-	*baseError
+type UnknownUserError interface {
+	InvalidReferenceError
+	isUnknownUserError()
 }
+
+type unknownUserError struct {
+	msg string
+	err error
+}
+
+func (e *unknownUserError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.UnknownUserError: " + msg
+}
+
+func (e *unknownUserError) Unwrap() error { return e.err }
+
+func (e *unknownUserError) isUnknownUserError() {}
+
+func (e *unknownUserError) isInvalidReferenceError() {}
+
+func (e *unknownUserError) isQueryError() {}
+
+func (e *unknownUserError) isError() {}
 
 // UnknownDatabaseError is an error.
-type UnknownDatabaseError struct {
-	*baseError
+type UnknownDatabaseError interface {
+	InvalidReferenceError
+	isUnknownDatabaseError()
 }
+
+type unknownDatabaseError struct {
+	msg string
+	err error
+}
+
+func (e *unknownDatabaseError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.UnknownDatabaseError: " + msg
+}
+
+func (e *unknownDatabaseError) Unwrap() error { return e.err }
+
+func (e *unknownDatabaseError) isUnknownDatabaseError() {}
+
+func (e *unknownDatabaseError) isInvalidReferenceError() {}
+
+func (e *unknownDatabaseError) isQueryError() {}
+
+func (e *unknownDatabaseError) isError() {}
 
 // UnknownParameterError is an error.
-type UnknownParameterError struct {
-	*baseError
+type UnknownParameterError interface {
+	InvalidReferenceError
+	isUnknownParameterError()
 }
+
+type unknownParameterError struct {
+	msg string
+	err error
+}
+
+func (e *unknownParameterError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.UnknownParameterError: " + msg
+}
+
+func (e *unknownParameterError) Unwrap() error { return e.err }
+
+func (e *unknownParameterError) isUnknownParameterError() {}
+
+func (e *unknownParameterError) isInvalidReferenceError() {}
+
+func (e *unknownParameterError) isQueryError() {}
+
+func (e *unknownParameterError) isError() {}
 
 // SchemaError is an error.
-type SchemaError struct {
-	*baseError
+type SchemaError interface {
+	QueryError
+	isSchemaError()
 }
+
+type schemaError struct {
+	msg string
+	err error
+}
+
+func (e *schemaError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.SchemaError: " + msg
+}
+
+func (e *schemaError) Unwrap() error { return e.err }
+
+func (e *schemaError) isSchemaError() {}
+
+func (e *schemaError) isQueryError() {}
+
+func (e *schemaError) isError() {}
 
 // SchemaDefinitionError is an error.
-type SchemaDefinitionError struct {
-	*baseError
+type SchemaDefinitionError interface {
+	QueryError
+	isSchemaDefinitionError()
 }
+
+type schemaDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *schemaDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.SchemaDefinitionError: " + msg
+}
+
+func (e *schemaDefinitionError) Unwrap() error { return e.err }
+
+func (e *schemaDefinitionError) isSchemaDefinitionError() {}
+
+func (e *schemaDefinitionError) isQueryError() {}
+
+func (e *schemaDefinitionError) isError() {}
 
 // InvalidDefinitionError is an error.
-type InvalidDefinitionError struct {
-	*baseError
+type InvalidDefinitionError interface {
+	SchemaDefinitionError
+	isInvalidDefinitionError()
 }
+
+type invalidDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *invalidDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidDefinitionError: " + msg
+}
+
+func (e *invalidDefinitionError) Unwrap() error { return e.err }
+
+func (e *invalidDefinitionError) isInvalidDefinitionError() {}
+
+func (e *invalidDefinitionError) isSchemaDefinitionError() {}
+
+func (e *invalidDefinitionError) isQueryError() {}
+
+func (e *invalidDefinitionError) isError() {}
 
 // InvalidModuleDefinitionError is an error.
-type InvalidModuleDefinitionError struct {
-	*baseError
+type InvalidModuleDefinitionError interface {
+	InvalidDefinitionError
+	isInvalidModuleDefinitionError()
 }
+
+type invalidModuleDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *invalidModuleDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidModuleDefinitionError: " + msg
+}
+
+func (e *invalidModuleDefinitionError) Unwrap() error { return e.err }
+
+func (e *invalidModuleDefinitionError) isInvalidModuleDefinitionError() {}
+
+func (e *invalidModuleDefinitionError) isInvalidDefinitionError() {}
+
+func (e *invalidModuleDefinitionError) isSchemaDefinitionError() {}
+
+func (e *invalidModuleDefinitionError) isQueryError() {}
+
+func (e *invalidModuleDefinitionError) isError() {}
 
 // InvalidLinkDefinitionError is an error.
-type InvalidLinkDefinitionError struct {
-	*baseError
+type InvalidLinkDefinitionError interface {
+	InvalidDefinitionError
+	isInvalidLinkDefinitionError()
 }
+
+type invalidLinkDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *invalidLinkDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidLinkDefinitionError: " + msg
+}
+
+func (e *invalidLinkDefinitionError) Unwrap() error { return e.err }
+
+func (e *invalidLinkDefinitionError) isInvalidLinkDefinitionError() {}
+
+func (e *invalidLinkDefinitionError) isInvalidDefinitionError() {}
+
+func (e *invalidLinkDefinitionError) isSchemaDefinitionError() {}
+
+func (e *invalidLinkDefinitionError) isQueryError() {}
+
+func (e *invalidLinkDefinitionError) isError() {}
 
 // InvalidPropertyDefinitionError is an error.
-type InvalidPropertyDefinitionError struct {
-	*baseError
+type InvalidPropertyDefinitionError interface {
+	InvalidDefinitionError
+	isInvalidPropertyDefinitionError()
 }
+
+type invalidPropertyDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *invalidPropertyDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidPropertyDefinitionError: " + msg
+}
+
+func (e *invalidPropertyDefinitionError) Unwrap() error { return e.err }
+
+func (e *invalidPropertyDefinitionError) isInvalidPropertyDefinitionError() {}
+
+func (e *invalidPropertyDefinitionError) isInvalidDefinitionError() {}
+
+func (e *invalidPropertyDefinitionError) isSchemaDefinitionError() {}
+
+func (e *invalidPropertyDefinitionError) isQueryError() {}
+
+func (e *invalidPropertyDefinitionError) isError() {}
 
 // InvalidUserDefinitionError is an error.
-type InvalidUserDefinitionError struct {
-	*baseError
+type InvalidUserDefinitionError interface {
+	InvalidDefinitionError
+	isInvalidUserDefinitionError()
 }
+
+type invalidUserDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *invalidUserDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidUserDefinitionError: " + msg
+}
+
+func (e *invalidUserDefinitionError) Unwrap() error { return e.err }
+
+func (e *invalidUserDefinitionError) isInvalidUserDefinitionError() {}
+
+func (e *invalidUserDefinitionError) isInvalidDefinitionError() {}
+
+func (e *invalidUserDefinitionError) isSchemaDefinitionError() {}
+
+func (e *invalidUserDefinitionError) isQueryError() {}
+
+func (e *invalidUserDefinitionError) isError() {}
 
 // InvalidDatabaseDefinitionError is an error.
-type InvalidDatabaseDefinitionError struct {
-	*baseError
+type InvalidDatabaseDefinitionError interface {
+	InvalidDefinitionError
+	isInvalidDatabaseDefinitionError()
 }
+
+type invalidDatabaseDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *invalidDatabaseDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidDatabaseDefinitionError: " + msg
+}
+
+func (e *invalidDatabaseDefinitionError) Unwrap() error { return e.err }
+
+func (e *invalidDatabaseDefinitionError) isInvalidDatabaseDefinitionError() {}
+
+func (e *invalidDatabaseDefinitionError) isInvalidDefinitionError() {}
+
+func (e *invalidDatabaseDefinitionError) isSchemaDefinitionError() {}
+
+func (e *invalidDatabaseDefinitionError) isQueryError() {}
+
+func (e *invalidDatabaseDefinitionError) isError() {}
 
 // InvalidOperatorDefinitionError is an error.
-type InvalidOperatorDefinitionError struct {
-	*baseError
+type InvalidOperatorDefinitionError interface {
+	InvalidDefinitionError
+	isInvalidOperatorDefinitionError()
 }
+
+type invalidOperatorDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *invalidOperatorDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidOperatorDefinitionError: " + msg
+}
+
+func (e *invalidOperatorDefinitionError) Unwrap() error { return e.err }
+
+func (e *invalidOperatorDefinitionError) isInvalidOperatorDefinitionError() {}
+
+func (e *invalidOperatorDefinitionError) isInvalidDefinitionError() {}
+
+func (e *invalidOperatorDefinitionError) isSchemaDefinitionError() {}
+
+func (e *invalidOperatorDefinitionError) isQueryError() {}
+
+func (e *invalidOperatorDefinitionError) isError() {}
 
 // InvalidAliasDefinitionError is an error.
-type InvalidAliasDefinitionError struct {
-	*baseError
+type InvalidAliasDefinitionError interface {
+	InvalidDefinitionError
+	isInvalidAliasDefinitionError()
 }
+
+type invalidAliasDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *invalidAliasDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidAliasDefinitionError: " + msg
+}
+
+func (e *invalidAliasDefinitionError) Unwrap() error { return e.err }
+
+func (e *invalidAliasDefinitionError) isInvalidAliasDefinitionError() {}
+
+func (e *invalidAliasDefinitionError) isInvalidDefinitionError() {}
+
+func (e *invalidAliasDefinitionError) isSchemaDefinitionError() {}
+
+func (e *invalidAliasDefinitionError) isQueryError() {}
+
+func (e *invalidAliasDefinitionError) isError() {}
 
 // InvalidFunctionDefinitionError is an error.
-type InvalidFunctionDefinitionError struct {
-	*baseError
+type InvalidFunctionDefinitionError interface {
+	InvalidDefinitionError
+	isInvalidFunctionDefinitionError()
 }
+
+type invalidFunctionDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *invalidFunctionDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidFunctionDefinitionError: " + msg
+}
+
+func (e *invalidFunctionDefinitionError) Unwrap() error { return e.err }
+
+func (e *invalidFunctionDefinitionError) isInvalidFunctionDefinitionError() {}
+
+func (e *invalidFunctionDefinitionError) isInvalidDefinitionError() {}
+
+func (e *invalidFunctionDefinitionError) isSchemaDefinitionError() {}
+
+func (e *invalidFunctionDefinitionError) isQueryError() {}
+
+func (e *invalidFunctionDefinitionError) isError() {}
 
 // InvalidConstraintDefinitionError is an error.
-type InvalidConstraintDefinitionError struct {
-	*baseError
+type InvalidConstraintDefinitionError interface {
+	InvalidDefinitionError
+	isInvalidConstraintDefinitionError()
 }
+
+type invalidConstraintDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *invalidConstraintDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidConstraintDefinitionError: " + msg
+}
+
+func (e *invalidConstraintDefinitionError) Unwrap() error { return e.err }
+
+func (e *invalidConstraintDefinitionError) isInvalidConstraintDefinitionError() {}
+
+func (e *invalidConstraintDefinitionError) isInvalidDefinitionError() {}
+
+func (e *invalidConstraintDefinitionError) isSchemaDefinitionError() {}
+
+func (e *invalidConstraintDefinitionError) isQueryError() {}
+
+func (e *invalidConstraintDefinitionError) isError() {}
 
 // InvalidCastDefinitionError is an error.
-type InvalidCastDefinitionError struct {
-	*baseError
+type InvalidCastDefinitionError interface {
+	InvalidDefinitionError
+	isInvalidCastDefinitionError()
 }
+
+type invalidCastDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *invalidCastDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidCastDefinitionError: " + msg
+}
+
+func (e *invalidCastDefinitionError) Unwrap() error { return e.err }
+
+func (e *invalidCastDefinitionError) isInvalidCastDefinitionError() {}
+
+func (e *invalidCastDefinitionError) isInvalidDefinitionError() {}
+
+func (e *invalidCastDefinitionError) isSchemaDefinitionError() {}
+
+func (e *invalidCastDefinitionError) isQueryError() {}
+
+func (e *invalidCastDefinitionError) isError() {}
 
 // DuplicateDefinitionError is an error.
-type DuplicateDefinitionError struct {
-	*baseError
+type DuplicateDefinitionError interface {
+	SchemaDefinitionError
+	isDuplicateDefinitionError()
 }
+
+type duplicateDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *duplicateDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.DuplicateDefinitionError: " + msg
+}
+
+func (e *duplicateDefinitionError) Unwrap() error { return e.err }
+
+func (e *duplicateDefinitionError) isDuplicateDefinitionError() {}
+
+func (e *duplicateDefinitionError) isSchemaDefinitionError() {}
+
+func (e *duplicateDefinitionError) isQueryError() {}
+
+func (e *duplicateDefinitionError) isError() {}
 
 // DuplicateModuleDefinitionError is an error.
-type DuplicateModuleDefinitionError struct {
-	*baseError
+type DuplicateModuleDefinitionError interface {
+	DuplicateDefinitionError
+	isDuplicateModuleDefinitionError()
 }
+
+type duplicateModuleDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *duplicateModuleDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.DuplicateModuleDefinitionError: " + msg
+}
+
+func (e *duplicateModuleDefinitionError) Unwrap() error { return e.err }
+
+func (e *duplicateModuleDefinitionError) isDuplicateModuleDefinitionError() {}
+
+func (e *duplicateModuleDefinitionError) isDuplicateDefinitionError() {}
+
+func (e *duplicateModuleDefinitionError) isSchemaDefinitionError() {}
+
+func (e *duplicateModuleDefinitionError) isQueryError() {}
+
+func (e *duplicateModuleDefinitionError) isError() {}
 
 // DuplicateLinkDefinitionError is an error.
-type DuplicateLinkDefinitionError struct {
-	*baseError
+type DuplicateLinkDefinitionError interface {
+	DuplicateDefinitionError
+	isDuplicateLinkDefinitionError()
 }
+
+type duplicateLinkDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *duplicateLinkDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.DuplicateLinkDefinitionError: " + msg
+}
+
+func (e *duplicateLinkDefinitionError) Unwrap() error { return e.err }
+
+func (e *duplicateLinkDefinitionError) isDuplicateLinkDefinitionError() {}
+
+func (e *duplicateLinkDefinitionError) isDuplicateDefinitionError() {}
+
+func (e *duplicateLinkDefinitionError) isSchemaDefinitionError() {}
+
+func (e *duplicateLinkDefinitionError) isQueryError() {}
+
+func (e *duplicateLinkDefinitionError) isError() {}
 
 // DuplicatePropertyDefinitionError is an error.
-type DuplicatePropertyDefinitionError struct {
-	*baseError
+type DuplicatePropertyDefinitionError interface {
+	DuplicateDefinitionError
+	isDuplicatePropertyDefinitionError()
 }
+
+type duplicatePropertyDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *duplicatePropertyDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.DuplicatePropertyDefinitionError: " + msg
+}
+
+func (e *duplicatePropertyDefinitionError) Unwrap() error { return e.err }
+
+func (e *duplicatePropertyDefinitionError) isDuplicatePropertyDefinitionError() {}
+
+func (e *duplicatePropertyDefinitionError) isDuplicateDefinitionError() {}
+
+func (e *duplicatePropertyDefinitionError) isSchemaDefinitionError() {}
+
+func (e *duplicatePropertyDefinitionError) isQueryError() {}
+
+func (e *duplicatePropertyDefinitionError) isError() {}
 
 // DuplicateUserDefinitionError is an error.
-type DuplicateUserDefinitionError struct {
-	*baseError
+type DuplicateUserDefinitionError interface {
+	DuplicateDefinitionError
+	isDuplicateUserDefinitionError()
 }
+
+type duplicateUserDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *duplicateUserDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.DuplicateUserDefinitionError: " + msg
+}
+
+func (e *duplicateUserDefinitionError) Unwrap() error { return e.err }
+
+func (e *duplicateUserDefinitionError) isDuplicateUserDefinitionError() {}
+
+func (e *duplicateUserDefinitionError) isDuplicateDefinitionError() {}
+
+func (e *duplicateUserDefinitionError) isSchemaDefinitionError() {}
+
+func (e *duplicateUserDefinitionError) isQueryError() {}
+
+func (e *duplicateUserDefinitionError) isError() {}
 
 // DuplicateDatabaseDefinitionError is an error.
-type DuplicateDatabaseDefinitionError struct {
-	*baseError
+type DuplicateDatabaseDefinitionError interface {
+	DuplicateDefinitionError
+	isDuplicateDatabaseDefinitionError()
 }
+
+type duplicateDatabaseDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *duplicateDatabaseDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.DuplicateDatabaseDefinitionError: " + msg
+}
+
+func (e *duplicateDatabaseDefinitionError) Unwrap() error { return e.err }
+
+func (e *duplicateDatabaseDefinitionError) isDuplicateDatabaseDefinitionError() {}
+
+func (e *duplicateDatabaseDefinitionError) isDuplicateDefinitionError() {}
+
+func (e *duplicateDatabaseDefinitionError) isSchemaDefinitionError() {}
+
+func (e *duplicateDatabaseDefinitionError) isQueryError() {}
+
+func (e *duplicateDatabaseDefinitionError) isError() {}
 
 // DuplicateOperatorDefinitionError is an error.
-type DuplicateOperatorDefinitionError struct {
-	*baseError
+type DuplicateOperatorDefinitionError interface {
+	DuplicateDefinitionError
+	isDuplicateOperatorDefinitionError()
 }
+
+type duplicateOperatorDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *duplicateOperatorDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.DuplicateOperatorDefinitionError: " + msg
+}
+
+func (e *duplicateOperatorDefinitionError) Unwrap() error { return e.err }
+
+func (e *duplicateOperatorDefinitionError) isDuplicateOperatorDefinitionError() {}
+
+func (e *duplicateOperatorDefinitionError) isDuplicateDefinitionError() {}
+
+func (e *duplicateOperatorDefinitionError) isSchemaDefinitionError() {}
+
+func (e *duplicateOperatorDefinitionError) isQueryError() {}
+
+func (e *duplicateOperatorDefinitionError) isError() {}
 
 // DuplicateViewDefinitionError is an error.
-type DuplicateViewDefinitionError struct {
-	*baseError
+type DuplicateViewDefinitionError interface {
+	DuplicateDefinitionError
+	isDuplicateViewDefinitionError()
 }
+
+type duplicateViewDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *duplicateViewDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.DuplicateViewDefinitionError: " + msg
+}
+
+func (e *duplicateViewDefinitionError) Unwrap() error { return e.err }
+
+func (e *duplicateViewDefinitionError) isDuplicateViewDefinitionError() {}
+
+func (e *duplicateViewDefinitionError) isDuplicateDefinitionError() {}
+
+func (e *duplicateViewDefinitionError) isSchemaDefinitionError() {}
+
+func (e *duplicateViewDefinitionError) isQueryError() {}
+
+func (e *duplicateViewDefinitionError) isError() {}
 
 // DuplicateFunctionDefinitionError is an error.
-type DuplicateFunctionDefinitionError struct {
-	*baseError
+type DuplicateFunctionDefinitionError interface {
+	DuplicateDefinitionError
+	isDuplicateFunctionDefinitionError()
 }
+
+type duplicateFunctionDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *duplicateFunctionDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.DuplicateFunctionDefinitionError: " + msg
+}
+
+func (e *duplicateFunctionDefinitionError) Unwrap() error { return e.err }
+
+func (e *duplicateFunctionDefinitionError) isDuplicateFunctionDefinitionError() {}
+
+func (e *duplicateFunctionDefinitionError) isDuplicateDefinitionError() {}
+
+func (e *duplicateFunctionDefinitionError) isSchemaDefinitionError() {}
+
+func (e *duplicateFunctionDefinitionError) isQueryError() {}
+
+func (e *duplicateFunctionDefinitionError) isError() {}
 
 // DuplicateConstraintDefinitionError is an error.
-type DuplicateConstraintDefinitionError struct {
-	*baseError
+type DuplicateConstraintDefinitionError interface {
+	DuplicateDefinitionError
+	isDuplicateConstraintDefinitionError()
 }
+
+type duplicateConstraintDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *duplicateConstraintDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.DuplicateConstraintDefinitionError: " + msg
+}
+
+func (e *duplicateConstraintDefinitionError) Unwrap() error { return e.err }
+
+func (e *duplicateConstraintDefinitionError) isDuplicateConstraintDefinitionError() {}
+
+func (e *duplicateConstraintDefinitionError) isDuplicateDefinitionError() {}
+
+func (e *duplicateConstraintDefinitionError) isSchemaDefinitionError() {}
+
+func (e *duplicateConstraintDefinitionError) isQueryError() {}
+
+func (e *duplicateConstraintDefinitionError) isError() {}
 
 // DuplicateCastDefinitionError is an error.
-type DuplicateCastDefinitionError struct {
-	*baseError
+type DuplicateCastDefinitionError interface {
+	DuplicateDefinitionError
+	isDuplicateCastDefinitionError()
 }
+
+type duplicateCastDefinitionError struct {
+	msg string
+	err error
+}
+
+func (e *duplicateCastDefinitionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.DuplicateCastDefinitionError: " + msg
+}
+
+func (e *duplicateCastDefinitionError) Unwrap() error { return e.err }
+
+func (e *duplicateCastDefinitionError) isDuplicateCastDefinitionError() {}
+
+func (e *duplicateCastDefinitionError) isDuplicateDefinitionError() {}
+
+func (e *duplicateCastDefinitionError) isSchemaDefinitionError() {}
+
+func (e *duplicateCastDefinitionError) isQueryError() {}
+
+func (e *duplicateCastDefinitionError) isError() {}
 
 // QueryTimeoutError is an error.
-type QueryTimeoutError struct {
-	*baseError
+type QueryTimeoutError interface {
+	QueryError
+	isQueryTimeoutError()
 }
+
+type queryTimeoutError struct {
+	msg string
+	err error
+}
+
+func (e *queryTimeoutError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.QueryTimeoutError: " + msg
+}
+
+func (e *queryTimeoutError) Unwrap() error { return e.err }
+
+func (e *queryTimeoutError) isQueryTimeoutError() {}
+
+func (e *queryTimeoutError) isQueryError() {}
+
+func (e *queryTimeoutError) isError() {}
 
 // ExecutionError is an error.
-type ExecutionError struct {
-	*baseError
+type ExecutionError interface {
+	Error
+	isExecutionError()
 }
+
+type executionError struct {
+	msg string
+	err error
+}
+
+func (e *executionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.ExecutionError: " + msg
+}
+
+func (e *executionError) Unwrap() error { return e.err }
+
+func (e *executionError) isExecutionError() {}
+
+func (e *executionError) isError() {}
 
 // InvalidValueError is an error.
-type InvalidValueError struct {
-	*baseError
+type InvalidValueError interface {
+	ExecutionError
+	isInvalidValueError()
 }
+
+type invalidValueError struct {
+	msg string
+	err error
+}
+
+func (e *invalidValueError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidValueError: " + msg
+}
+
+func (e *invalidValueError) Unwrap() error { return e.err }
+
+func (e *invalidValueError) isInvalidValueError() {}
+
+func (e *invalidValueError) isExecutionError() {}
+
+func (e *invalidValueError) isError() {}
 
 // DivisionByZeroError is an error.
-type DivisionByZeroError struct {
-	*baseError
+type DivisionByZeroError interface {
+	InvalidValueError
+	isDivisionByZeroError()
 }
+
+type divisionByZeroError struct {
+	msg string
+	err error
+}
+
+func (e *divisionByZeroError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.DivisionByZeroError: " + msg
+}
+
+func (e *divisionByZeroError) Unwrap() error { return e.err }
+
+func (e *divisionByZeroError) isDivisionByZeroError() {}
+
+func (e *divisionByZeroError) isInvalidValueError() {}
+
+func (e *divisionByZeroError) isExecutionError() {}
+
+func (e *divisionByZeroError) isError() {}
 
 // NumericOutOfRangeError is an error.
-type NumericOutOfRangeError struct {
-	*baseError
+type NumericOutOfRangeError interface {
+	InvalidValueError
+	isNumericOutOfRangeError()
 }
+
+type numericOutOfRangeError struct {
+	msg string
+	err error
+}
+
+func (e *numericOutOfRangeError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.NumericOutOfRangeError: " + msg
+}
+
+func (e *numericOutOfRangeError) Unwrap() error { return e.err }
+
+func (e *numericOutOfRangeError) isNumericOutOfRangeError() {}
+
+func (e *numericOutOfRangeError) isInvalidValueError() {}
+
+func (e *numericOutOfRangeError) isExecutionError() {}
+
+func (e *numericOutOfRangeError) isError() {}
 
 // IntegrityError is an error.
-type IntegrityError struct {
-	*baseError
+type IntegrityError interface {
+	ExecutionError
+	isIntegrityError()
 }
+
+type integrityError struct {
+	msg string
+	err error
+}
+
+func (e *integrityError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.IntegrityError: " + msg
+}
+
+func (e *integrityError) Unwrap() error { return e.err }
+
+func (e *integrityError) isIntegrityError() {}
+
+func (e *integrityError) isExecutionError() {}
+
+func (e *integrityError) isError() {}
 
 // ConstraintViolationError is an error.
-type ConstraintViolationError struct {
-	*baseError
+type ConstraintViolationError interface {
+	IntegrityError
+	isConstraintViolationError()
 }
+
+type constraintViolationError struct {
+	msg string
+	err error
+}
+
+func (e *constraintViolationError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.ConstraintViolationError: " + msg
+}
+
+func (e *constraintViolationError) Unwrap() error { return e.err }
+
+func (e *constraintViolationError) isConstraintViolationError() {}
+
+func (e *constraintViolationError) isIntegrityError() {}
+
+func (e *constraintViolationError) isExecutionError() {}
+
+func (e *constraintViolationError) isError() {}
 
 // CardinalityViolationError is an error.
-type CardinalityViolationError struct {
-	*baseError
+type CardinalityViolationError interface {
+	IntegrityError
+	isCardinalityViolationError()
 }
+
+type cardinalityViolationError struct {
+	msg string
+	err error
+}
+
+func (e *cardinalityViolationError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.CardinalityViolationError: " + msg
+}
+
+func (e *cardinalityViolationError) Unwrap() error { return e.err }
+
+func (e *cardinalityViolationError) isCardinalityViolationError() {}
+
+func (e *cardinalityViolationError) isIntegrityError() {}
+
+func (e *cardinalityViolationError) isExecutionError() {}
+
+func (e *cardinalityViolationError) isError() {}
 
 // MissingRequiredError is an error.
-type MissingRequiredError struct {
-	*baseError
+type MissingRequiredError interface {
+	IntegrityError
+	isMissingRequiredError()
 }
+
+type missingRequiredError struct {
+	msg string
+	err error
+}
+
+func (e *missingRequiredError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.MissingRequiredError: " + msg
+}
+
+func (e *missingRequiredError) Unwrap() error { return e.err }
+
+func (e *missingRequiredError) isMissingRequiredError() {}
+
+func (e *missingRequiredError) isIntegrityError() {}
+
+func (e *missingRequiredError) isExecutionError() {}
+
+func (e *missingRequiredError) isError() {}
 
 // TransactionError is an error.
-type TransactionError struct {
-	*baseError
+type TransactionError interface {
+	ExecutionError
+	isTransactionError()
 }
+
+type transactionError struct {
+	msg string
+	err error
+}
+
+func (e *transactionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.TransactionError: " + msg
+}
+
+func (e *transactionError) Unwrap() error { return e.err }
+
+func (e *transactionError) isTransactionError() {}
+
+func (e *transactionError) isExecutionError() {}
+
+func (e *transactionError) isError() {}
 
 // TransactionSerializationError is an error.
-type TransactionSerializationError struct {
-	*baseError
+type TransactionSerializationError interface {
+	TransactionError
+	isTransactionSerializationError()
 }
+
+type transactionSerializationError struct {
+	msg string
+	err error
+}
+
+func (e *transactionSerializationError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.TransactionSerializationError: " + msg
+}
+
+func (e *transactionSerializationError) Unwrap() error { return e.err }
+
+func (e *transactionSerializationError) isTransactionSerializationError() {}
+
+func (e *transactionSerializationError) isTransactionError() {}
+
+func (e *transactionSerializationError) isExecutionError() {}
+
+func (e *transactionSerializationError) isError() {}
 
 // TransactionDeadlockError is an error.
-type TransactionDeadlockError struct {
-	*baseError
+type TransactionDeadlockError interface {
+	TransactionError
+	isTransactionDeadlockError()
 }
+
+type transactionDeadlockError struct {
+	msg string
+	err error
+}
+
+func (e *transactionDeadlockError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.TransactionDeadlockError: " + msg
+}
+
+func (e *transactionDeadlockError) Unwrap() error { return e.err }
+
+func (e *transactionDeadlockError) isTransactionDeadlockError() {}
+
+func (e *transactionDeadlockError) isTransactionError() {}
+
+func (e *transactionDeadlockError) isExecutionError() {}
+
+func (e *transactionDeadlockError) isError() {}
 
 // ConfigurationError is an error.
-type ConfigurationError struct {
-	*baseError
+type ConfigurationError interface {
+	Error
+	isConfigurationError()
 }
+
+type configurationError struct {
+	msg string
+	err error
+}
+
+func (e *configurationError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.ConfigurationError: " + msg
+}
+
+func (e *configurationError) Unwrap() error { return e.err }
+
+func (e *configurationError) isConfigurationError() {}
+
+func (e *configurationError) isError() {}
 
 // AccessError is an error.
-type AccessError struct {
-	*baseError
+type AccessError interface {
+	Error
+	isAccessError()
 }
+
+type accessError struct {
+	msg string
+	err error
+}
+
+func (e *accessError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.AccessError: " + msg
+}
+
+func (e *accessError) Unwrap() error { return e.err }
+
+func (e *accessError) isAccessError() {}
+
+func (e *accessError) isError() {}
 
 // AuthenticationError is an error.
-type AuthenticationError struct {
-	*baseError
+type AuthenticationError interface {
+	AccessError
+	isAuthenticationError()
 }
+
+type authenticationError struct {
+	msg string
+	err error
+}
+
+func (e *authenticationError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.AuthenticationError: " + msg
+}
+
+func (e *authenticationError) Unwrap() error { return e.err }
+
+func (e *authenticationError) isAuthenticationError() {}
+
+func (e *authenticationError) isAccessError() {}
+
+func (e *authenticationError) isError() {}
+
+// LogMessage is an error.
+type LogMessage interface {
+	Error
+	isLogMessage()
+}
+
+type logMessage struct {
+	msg string
+	err error
+}
+
+func (e *logMessage) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.LogMessage: " + msg
+}
+
+func (e *logMessage) Unwrap() error { return e.err }
+
+func (e *logMessage) isLogMessage() {}
+
+func (e *logMessage) isError() {}
+
+// WarningMessage is an error.
+type WarningMessage interface {
+	Error
+	isWarningMessage()
+}
+
+type warningMessage struct {
+	msg string
+	err error
+}
+
+func (e *warningMessage) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.WarningMessage: " + msg
+}
+
+func (e *warningMessage) Unwrap() error { return e.err }
+
+func (e *warningMessage) isWarningMessage() {}
+
+func (e *warningMessage) isError() {}
 
 // ClientError is an error.
-type ClientError struct {
-	*baseError
+type ClientError interface {
+	Error
+	isClientError()
 }
+
+type clientError struct {
+	msg string
+	err error
+}
+
+func (e *clientError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.ClientError: " + msg
+}
+
+func (e *clientError) Unwrap() error { return e.err }
+
+func (e *clientError) isClientError() {}
+
+func (e *clientError) isError() {}
 
 // ClientConnectionError is an error.
-type ClientConnectionError struct {
-	*baseError
+type ClientConnectionError interface {
+	ClientError
+	isClientConnectionError()
 }
+
+type clientConnectionError struct {
+	msg string
+	err error
+}
+
+func (e *clientConnectionError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.ClientConnectionError: " + msg
+}
+
+func (e *clientConnectionError) Unwrap() error { return e.err }
+
+func (e *clientConnectionError) isClientConnectionError() {}
+
+func (e *clientConnectionError) isClientError() {}
+
+func (e *clientConnectionError) isError() {}
 
 // InterfaceError is an error.
-type InterfaceError struct {
-	*baseError
+type InterfaceError interface {
+	ClientError
+	isInterfaceError()
 }
+
+type interfaceError struct {
+	msg string
+	err error
+}
+
+func (e *interfaceError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InterfaceError: " + msg
+}
+
+func (e *interfaceError) Unwrap() error { return e.err }
+
+func (e *interfaceError) isInterfaceError() {}
+
+func (e *interfaceError) isClientError() {}
+
+func (e *interfaceError) isError() {}
 
 // QueryArgumentError is an error.
-type QueryArgumentError struct {
-	*baseError
+type QueryArgumentError interface {
+	InterfaceError
+	isQueryArgumentError()
 }
+
+type queryArgumentError struct {
+	msg string
+	err error
+}
+
+func (e *queryArgumentError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.QueryArgumentError: " + msg
+}
+
+func (e *queryArgumentError) Unwrap() error { return e.err }
+
+func (e *queryArgumentError) isQueryArgumentError() {}
+
+func (e *queryArgumentError) isInterfaceError() {}
+
+func (e *queryArgumentError) isClientError() {}
+
+func (e *queryArgumentError) isError() {}
 
 // MissingArgumentError is an error.
-type MissingArgumentError struct {
-	*baseError
+type MissingArgumentError interface {
+	QueryArgumentError
+	isMissingArgumentError()
 }
+
+type missingArgumentError struct {
+	msg string
+	err error
+}
+
+func (e *missingArgumentError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.MissingArgumentError: " + msg
+}
+
+func (e *missingArgumentError) Unwrap() error { return e.err }
+
+func (e *missingArgumentError) isMissingArgumentError() {}
+
+func (e *missingArgumentError) isQueryArgumentError() {}
+
+func (e *missingArgumentError) isInterfaceError() {}
+
+func (e *missingArgumentError) isClientError() {}
+
+func (e *missingArgumentError) isError() {}
 
 // UnknownArgumentError is an error.
-type UnknownArgumentError struct {
-	*baseError
+type UnknownArgumentError interface {
+	QueryArgumentError
+	isUnknownArgumentError()
 }
+
+type unknownArgumentError struct {
+	msg string
+	err error
+}
+
+func (e *unknownArgumentError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.UnknownArgumentError: " + msg
+}
+
+func (e *unknownArgumentError) Unwrap() error { return e.err }
+
+func (e *unknownArgumentError) isUnknownArgumentError() {}
+
+func (e *unknownArgumentError) isQueryArgumentError() {}
+
+func (e *unknownArgumentError) isInterfaceError() {}
+
+func (e *unknownArgumentError) isClientError() {}
+
+func (e *unknownArgumentError) isError() {}
 
 // InvalidArgumentError is an error.
-type InvalidArgumentError struct {
-	*baseError
+type InvalidArgumentError interface {
+	QueryArgumentError
+	isInvalidArgumentError()
 }
 
+type invalidArgumentError struct {
+	msg string
+	err error
+}
+
+func (e *invalidArgumentError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.InvalidArgumentError: " + msg
+}
+
+func (e *invalidArgumentError) Unwrap() error { return e.err }
+
+func (e *invalidArgumentError) isInvalidArgumentError() {}
+
+func (e *invalidArgumentError) isQueryArgumentError() {}
+
+func (e *invalidArgumentError) isInterfaceError() {}
+
+func (e *invalidArgumentError) isClientError() {}
+
+func (e *invalidArgumentError) isError() {}
+
 // NoDataError is an error.
-type NoDataError struct {
-	*baseError
+type NoDataError interface {
+	ClientError
+	isNoDataError()
+}
+
+type noDataError struct {
+	msg string
+	err error
+}
+
+func (e *noDataError) Error() string {
+	msg := e.msg
+	if e.err != nil {
+		msg = e.err.Error()
+	}
+
+	return "edgedb.NoDataError: " + msg
+}
+
+func (e *noDataError) Unwrap() error { return e.err }
+
+func (e *noDataError) isNoDataError() {}
+
+func (e *noDataError) isClientError() {}
+
+func (e *noDataError) isError() {}
+
+func errorFromCode(code uint32, msg string) error {
+	switch code {
+	case 0x01_00_00_00:
+		return &internalServerError{msg: msg}
+	case 0x02_00_00_00:
+		return &unsupportedFeatureError{msg: msg}
+	case 0x03_00_00_00:
+		return &protocolError{msg: msg}
+	case 0x03_01_00_00:
+		return &binaryProtocolError{msg: msg}
+	case 0x03_01_00_01:
+		return &unsupportedProtocolVersionError{msg: msg}
+	case 0x03_01_00_02:
+		return &typeSpecNotFoundError{msg: msg}
+	case 0x03_01_00_03:
+		return &unexpectedMessageError{msg: msg}
+	case 0x03_02_00_00:
+		return &inputDataError{msg: msg}
+	case 0x03_03_00_00:
+		return &resultCardinalityMismatchError{msg: msg}
+	case 0x04_00_00_00:
+		return &queryError{msg: msg}
+	case 0x04_01_00_00:
+		return &invalidSyntaxError{msg: msg}
+	case 0x04_01_01_00:
+		return &edgeQLSyntaxError{msg: msg}
+	case 0x04_01_02_00:
+		return &schemaSyntaxError{msg: msg}
+	case 0x04_01_03_00:
+		return &graphQLSyntaxError{msg: msg}
+	case 0x04_02_00_00:
+		return &invalidTypeError{msg: msg}
+	case 0x04_02_01_00:
+		return &invalidTargetError{msg: msg}
+	case 0x04_02_01_01:
+		return &invalidLinkTargetError{msg: msg}
+	case 0x04_02_01_02:
+		return &invalidPropertyTargetError{msg: msg}
+	case 0x04_03_00_00:
+		return &invalidReferenceError{msg: msg}
+	case 0x04_03_00_01:
+		return &unknownModuleError{msg: msg}
+	case 0x04_03_00_02:
+		return &unknownLinkError{msg: msg}
+	case 0x04_03_00_03:
+		return &unknownPropertyError{msg: msg}
+	case 0x04_03_00_04:
+		return &unknownUserError{msg: msg}
+	case 0x04_03_00_05:
+		return &unknownDatabaseError{msg: msg}
+	case 0x04_03_00_06:
+		return &unknownParameterError{msg: msg}
+	case 0x04_04_00_00:
+		return &schemaError{msg: msg}
+	case 0x04_05_00_00:
+		return &schemaDefinitionError{msg: msg}
+	case 0x04_05_01_00:
+		return &invalidDefinitionError{msg: msg}
+	case 0x04_05_01_01:
+		return &invalidModuleDefinitionError{msg: msg}
+	case 0x04_05_01_02:
+		return &invalidLinkDefinitionError{msg: msg}
+	case 0x04_05_01_03:
+		return &invalidPropertyDefinitionError{msg: msg}
+	case 0x04_05_01_04:
+		return &invalidUserDefinitionError{msg: msg}
+	case 0x04_05_01_05:
+		return &invalidDatabaseDefinitionError{msg: msg}
+	case 0x04_05_01_06:
+		return &invalidOperatorDefinitionError{msg: msg}
+	case 0x04_05_01_07:
+		return &invalidAliasDefinitionError{msg: msg}
+	case 0x04_05_01_08:
+		return &invalidFunctionDefinitionError{msg: msg}
+	case 0x04_05_01_09:
+		return &invalidConstraintDefinitionError{msg: msg}
+	case 0x04_05_01_0a:
+		return &invalidCastDefinitionError{msg: msg}
+	case 0x04_05_02_00:
+		return &duplicateDefinitionError{msg: msg}
+	case 0x04_05_02_01:
+		return &duplicateModuleDefinitionError{msg: msg}
+	case 0x04_05_02_02:
+		return &duplicateLinkDefinitionError{msg: msg}
+	case 0x04_05_02_03:
+		return &duplicatePropertyDefinitionError{msg: msg}
+	case 0x04_05_02_04:
+		return &duplicateUserDefinitionError{msg: msg}
+	case 0x04_05_02_05:
+		return &duplicateDatabaseDefinitionError{msg: msg}
+	case 0x04_05_02_06:
+		return &duplicateOperatorDefinitionError{msg: msg}
+	case 0x04_05_02_07:
+		return &duplicateViewDefinitionError{msg: msg}
+	case 0x04_05_02_08:
+		return &duplicateFunctionDefinitionError{msg: msg}
+	case 0x04_05_02_09:
+		return &duplicateConstraintDefinitionError{msg: msg}
+	case 0x04_05_02_0a:
+		return &duplicateCastDefinitionError{msg: msg}
+	case 0x04_06_00_00:
+		return &queryTimeoutError{msg: msg}
+	case 0x05_00_00_00:
+		return &executionError{msg: msg}
+	case 0x05_01_00_00:
+		return &invalidValueError{msg: msg}
+	case 0x05_01_00_01:
+		return &divisionByZeroError{msg: msg}
+	case 0x05_01_00_02:
+		return &numericOutOfRangeError{msg: msg}
+	case 0x05_02_00_00:
+		return &integrityError{msg: msg}
+	case 0x05_02_00_01:
+		return &constraintViolationError{msg: msg}
+	case 0x05_02_00_02:
+		return &cardinalityViolationError{msg: msg}
+	case 0x05_02_00_03:
+		return &missingRequiredError{msg: msg}
+	case 0x05_03_00_00:
+		return &transactionError{msg: msg}
+	case 0x05_03_00_01:
+		return &transactionSerializationError{msg: msg}
+	case 0x05_03_00_02:
+		return &transactionDeadlockError{msg: msg}
+	case 0x06_00_00_00:
+		return &configurationError{msg: msg}
+	case 0x07_00_00_00:
+		return &accessError{msg: msg}
+	case 0x07_01_00_00:
+		return &authenticationError{msg: msg}
+	case 0xf0_00_00_00:
+		return &logMessage{msg: msg}
+	case 0xf0_01_00_00:
+		return &warningMessage{msg: msg}
+	case 0xff_00_00_00:
+		return &clientError{msg: msg}
+	case 0xff_01_00_00:
+		return &clientConnectionError{msg: msg}
+	case 0xff_02_00_00:
+		return &interfaceError{msg: msg}
+	case 0xff_02_01_00:
+		return &queryArgumentError{msg: msg}
+	case 0xff_02_01_01:
+		return &missingArgumentError{msg: msg}
+	case 0xff_02_01_02:
+		return &unknownArgumentError{msg: msg}
+	case 0xff_02_01_03:
+		return &invalidArgumentError{msg: msg}
+	case 0xff_03_00_00:
+		return &noDataError{msg: msg}
+	default:
+		panic(fmt.Sprintf("invalid error code 0x%x", code))
+	}
 }

--- a/generatederrors.go
+++ b/generatederrors.go
@@ -95,233 +95,221 @@ const (
 	noDataErrorCode uint32 = 0xff_03_00_00
 )
 
-// newErrorFromCode returns a new edgedb error.
-func newErrorFromCode(code uint32, msg string) error {
+// wrapErrorFromCode wraps an error in an edgedb error type.
+func wrapErrorFromCode(code uint32, err error) error {
+	if err == nil {
+		return nil
+	}
+
 	switch code {
 	case internalServerErrorCode:
-		tail := &baseError{msg: "edgedb: " + msg}
-		base := &baseError{err: &Error{tail}}
-		return &InternalServerError{base}
+		return &InternalServerError{&baseError{err: wrapError(err)}}
 	case unsupportedFeatureErrorCode:
-		tail := &baseError{msg: "edgedb: " + msg}
-		base := &baseError{err: &Error{tail}}
-		return &UnsupportedFeatureError{base}
+		return &UnsupportedFeatureError{&baseError{err: wrapError(err)}}
 	case protocolErrorCode:
-		tail := &baseError{msg: "edgedb: " + msg}
-		base := &baseError{err: &Error{tail}}
-		return &ProtocolError{base}
+		return &ProtocolError{&baseError{err: wrapError(err)}}
 	case binaryProtocolErrorCode:
-		base := &baseError{err: newErrorFromCode(protocolErrorCode, msg)}
-		return &BinaryProtocolError{base}
+		next := wrapErrorFromCode(protocolErrorCode, err)
+		return &BinaryProtocolError{&baseError{err: next}}
 	case unsupportedProtocolVersionErrorCode:
-		base := &baseError{err: newErrorFromCode(binaryProtocolErrorCode, msg)}
-		return &UnsupportedProtocolVersionError{base}
+		next := wrapErrorFromCode(binaryProtocolErrorCode, err)
+		return &UnsupportedProtocolVersionError{&baseError{err: next}}
 	case typeSpecNotFoundErrorCode:
-		base := &baseError{err: newErrorFromCode(binaryProtocolErrorCode, msg)}
-		return &TypeSpecNotFoundError{base}
+		next := wrapErrorFromCode(binaryProtocolErrorCode, err)
+		return &TypeSpecNotFoundError{&baseError{err: next}}
 	case unexpectedMessageErrorCode:
-		base := &baseError{err: newErrorFromCode(binaryProtocolErrorCode, msg)}
-		return &UnexpectedMessageError{base}
+		next := wrapErrorFromCode(binaryProtocolErrorCode, err)
+		return &UnexpectedMessageError{&baseError{err: next}}
 	case inputDataErrorCode:
-		base := &baseError{err: newErrorFromCode(protocolErrorCode, msg)}
-		return &InputDataError{base}
+		next := wrapErrorFromCode(protocolErrorCode, err)
+		return &InputDataError{&baseError{err: next}}
 	case resultCardinalityMismatchErrorCode:
-		base := &baseError{err: newErrorFromCode(protocolErrorCode, msg)}
-		return &ResultCardinalityMismatchError{base}
+		next := wrapErrorFromCode(protocolErrorCode, err)
+		return &ResultCardinalityMismatchError{&baseError{err: next}}
 	case queryErrorCode:
-		tail := &baseError{msg: "edgedb: " + msg}
-		base := &baseError{err: &Error{tail}}
-		return &QueryError{base}
+		return &QueryError{&baseError{err: wrapError(err)}}
 	case invalidSyntaxErrorCode:
-		base := &baseError{err: newErrorFromCode(queryErrorCode, msg)}
-		return &InvalidSyntaxError{base}
+		next := wrapErrorFromCode(queryErrorCode, err)
+		return &InvalidSyntaxError{&baseError{err: next}}
 	case edgeQLSyntaxErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidSyntaxErrorCode, msg)}
-		return &EdgeQLSyntaxError{base}
+		next := wrapErrorFromCode(invalidSyntaxErrorCode, err)
+		return &EdgeQLSyntaxError{&baseError{err: next}}
 	case schemaSyntaxErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidSyntaxErrorCode, msg)}
-		return &SchemaSyntaxError{base}
+		next := wrapErrorFromCode(invalidSyntaxErrorCode, err)
+		return &SchemaSyntaxError{&baseError{err: next}}
 	case graphQLSyntaxErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidSyntaxErrorCode, msg)}
-		return &GraphQLSyntaxError{base}
+		next := wrapErrorFromCode(invalidSyntaxErrorCode, err)
+		return &GraphQLSyntaxError{&baseError{err: next}}
 	case invalidTypeErrorCode:
-		base := &baseError{err: newErrorFromCode(queryErrorCode, msg)}
-		return &InvalidTypeError{base}
+		next := wrapErrorFromCode(queryErrorCode, err)
+		return &InvalidTypeError{&baseError{err: next}}
 	case invalidTargetErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidTypeErrorCode, msg)}
-		return &InvalidTargetError{base}
+		next := wrapErrorFromCode(invalidTypeErrorCode, err)
+		return &InvalidTargetError{&baseError{err: next}}
 	case invalidLinkTargetErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidTargetErrorCode, msg)}
-		return &InvalidLinkTargetError{base}
+		next := wrapErrorFromCode(invalidTargetErrorCode, err)
+		return &InvalidLinkTargetError{&baseError{err: next}}
 	case invalidPropertyTargetErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidTargetErrorCode, msg)}
-		return &InvalidPropertyTargetError{base}
+		next := wrapErrorFromCode(invalidTargetErrorCode, err)
+		return &InvalidPropertyTargetError{&baseError{err: next}}
 	case invalidReferenceErrorCode:
-		base := &baseError{err: newErrorFromCode(queryErrorCode, msg)}
-		return &InvalidReferenceError{base}
+		next := wrapErrorFromCode(queryErrorCode, err)
+		return &InvalidReferenceError{&baseError{err: next}}
 	case unknownModuleErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidReferenceErrorCode, msg)}
-		return &UnknownModuleError{base}
+		next := wrapErrorFromCode(invalidReferenceErrorCode, err)
+		return &UnknownModuleError{&baseError{err: next}}
 	case unknownLinkErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidReferenceErrorCode, msg)}
-		return &UnknownLinkError{base}
+		next := wrapErrorFromCode(invalidReferenceErrorCode, err)
+		return &UnknownLinkError{&baseError{err: next}}
 	case unknownPropertyErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidReferenceErrorCode, msg)}
-		return &UnknownPropertyError{base}
+		next := wrapErrorFromCode(invalidReferenceErrorCode, err)
+		return &UnknownPropertyError{&baseError{err: next}}
 	case unknownUserErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidReferenceErrorCode, msg)}
-		return &UnknownUserError{base}
+		next := wrapErrorFromCode(invalidReferenceErrorCode, err)
+		return &UnknownUserError{&baseError{err: next}}
 	case unknownDatabaseErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidReferenceErrorCode, msg)}
-		return &UnknownDatabaseError{base}
+		next := wrapErrorFromCode(invalidReferenceErrorCode, err)
+		return &UnknownDatabaseError{&baseError{err: next}}
 	case unknownParameterErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidReferenceErrorCode, msg)}
-		return &UnknownParameterError{base}
+		next := wrapErrorFromCode(invalidReferenceErrorCode, err)
+		return &UnknownParameterError{&baseError{err: next}}
 	case schemaErrorCode:
-		base := &baseError{err: newErrorFromCode(queryErrorCode, msg)}
-		return &SchemaError{base}
+		next := wrapErrorFromCode(queryErrorCode, err)
+		return &SchemaError{&baseError{err: next}}
 	case schemaDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(queryErrorCode, msg)}
-		return &SchemaDefinitionError{base}
+		next := wrapErrorFromCode(queryErrorCode, err)
+		return &SchemaDefinitionError{&baseError{err: next}}
 	case invalidDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(schemaDefinitionErrorCode, msg)}
-		return &InvalidDefinitionError{base}
+		next := wrapErrorFromCode(schemaDefinitionErrorCode, err)
+		return &InvalidDefinitionError{&baseError{err: next}}
 	case invalidModuleDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
-		return &InvalidModuleDefinitionError{base}
+		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		return &InvalidModuleDefinitionError{&baseError{err: next}}
 	case invalidLinkDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
-		return &InvalidLinkDefinitionError{base}
+		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		return &InvalidLinkDefinitionError{&baseError{err: next}}
 	case invalidPropertyDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
-		return &InvalidPropertyDefinitionError{base}
+		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		return &InvalidPropertyDefinitionError{&baseError{err: next}}
 	case invalidUserDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
-		return &InvalidUserDefinitionError{base}
+		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		return &InvalidUserDefinitionError{&baseError{err: next}}
 	case invalidDatabaseDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
-		return &InvalidDatabaseDefinitionError{base}
+		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		return &InvalidDatabaseDefinitionError{&baseError{err: next}}
 	case invalidOperatorDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
-		return &InvalidOperatorDefinitionError{base}
+		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		return &InvalidOperatorDefinitionError{&baseError{err: next}}
 	case invalidAliasDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
-		return &InvalidAliasDefinitionError{base}
+		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		return &InvalidAliasDefinitionError{&baseError{err: next}}
 	case invalidFunctionDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
-		return &InvalidFunctionDefinitionError{base}
+		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		return &InvalidFunctionDefinitionError{&baseError{err: next}}
 	case invalidConstraintDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
-		return &InvalidConstraintDefinitionError{base}
+		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		return &InvalidConstraintDefinitionError{&baseError{err: next}}
 	case invalidCastDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
-		return &InvalidCastDefinitionError{base}
+		next := wrapErrorFromCode(invalidDefinitionErrorCode, err)
+		return &InvalidCastDefinitionError{&baseError{err: next}}
 	case duplicateDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(schemaDefinitionErrorCode, msg)}
-		return &DuplicateDefinitionError{base}
+		next := wrapErrorFromCode(schemaDefinitionErrorCode, err)
+		return &DuplicateDefinitionError{&baseError{err: next}}
 	case duplicateModuleDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
-		return &DuplicateModuleDefinitionError{base}
+		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		return &DuplicateModuleDefinitionError{&baseError{err: next}}
 	case duplicateLinkDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
-		return &DuplicateLinkDefinitionError{base}
+		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		return &DuplicateLinkDefinitionError{&baseError{err: next}}
 	case duplicatePropertyDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
-		return &DuplicatePropertyDefinitionError{base}
+		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		return &DuplicatePropertyDefinitionError{&baseError{err: next}}
 	case duplicateUserDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
-		return &DuplicateUserDefinitionError{base}
+		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		return &DuplicateUserDefinitionError{&baseError{err: next}}
 	case duplicateDatabaseDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
-		return &DuplicateDatabaseDefinitionError{base}
+		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		return &DuplicateDatabaseDefinitionError{&baseError{err: next}}
 	case duplicateOperatorDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
-		return &DuplicateOperatorDefinitionError{base}
+		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		return &DuplicateOperatorDefinitionError{&baseError{err: next}}
 	case duplicateViewDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
-		return &DuplicateViewDefinitionError{base}
+		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		return &DuplicateViewDefinitionError{&baseError{err: next}}
 	case duplicateFunctionDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
-		return &DuplicateFunctionDefinitionError{base}
+		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		return &DuplicateFunctionDefinitionError{&baseError{err: next}}
 	case duplicateConstraintDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
-		return &DuplicateConstraintDefinitionError{base}
+		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		return &DuplicateConstraintDefinitionError{&baseError{err: next}}
 	case duplicateCastDefinitionErrorCode:
-		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
-		return &DuplicateCastDefinitionError{base}
+		next := wrapErrorFromCode(duplicateDefinitionErrorCode, err)
+		return &DuplicateCastDefinitionError{&baseError{err: next}}
 	case queryTimeoutErrorCode:
-		base := &baseError{err: newErrorFromCode(queryErrorCode, msg)}
-		return &QueryTimeoutError{base}
+		next := wrapErrorFromCode(queryErrorCode, err)
+		return &QueryTimeoutError{&baseError{err: next}}
 	case executionErrorCode:
-		tail := &baseError{msg: "edgedb: " + msg}
-		base := &baseError{err: &Error{tail}}
-		return &ExecutionError{base}
+		return &ExecutionError{&baseError{err: wrapError(err)}}
 	case invalidValueErrorCode:
-		base := &baseError{err: newErrorFromCode(executionErrorCode, msg)}
-		return &InvalidValueError{base}
+		next := wrapErrorFromCode(executionErrorCode, err)
+		return &InvalidValueError{&baseError{err: next}}
 	case divisionByZeroErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidValueErrorCode, msg)}
-		return &DivisionByZeroError{base}
+		next := wrapErrorFromCode(invalidValueErrorCode, err)
+		return &DivisionByZeroError{&baseError{err: next}}
 	case numericOutOfRangeErrorCode:
-		base := &baseError{err: newErrorFromCode(invalidValueErrorCode, msg)}
-		return &NumericOutOfRangeError{base}
+		next := wrapErrorFromCode(invalidValueErrorCode, err)
+		return &NumericOutOfRangeError{&baseError{err: next}}
 	case integrityErrorCode:
-		base := &baseError{err: newErrorFromCode(executionErrorCode, msg)}
-		return &IntegrityError{base}
+		next := wrapErrorFromCode(executionErrorCode, err)
+		return &IntegrityError{&baseError{err: next}}
 	case constraintViolationErrorCode:
-		base := &baseError{err: newErrorFromCode(integrityErrorCode, msg)}
-		return &ConstraintViolationError{base}
+		next := wrapErrorFromCode(integrityErrorCode, err)
+		return &ConstraintViolationError{&baseError{err: next}}
 	case cardinalityViolationErrorCode:
-		base := &baseError{err: newErrorFromCode(integrityErrorCode, msg)}
-		return &CardinalityViolationError{base}
+		next := wrapErrorFromCode(integrityErrorCode, err)
+		return &CardinalityViolationError{&baseError{err: next}}
 	case missingRequiredErrorCode:
-		base := &baseError{err: newErrorFromCode(integrityErrorCode, msg)}
-		return &MissingRequiredError{base}
+		next := wrapErrorFromCode(integrityErrorCode, err)
+		return &MissingRequiredError{&baseError{err: next}}
 	case transactionErrorCode:
-		base := &baseError{err: newErrorFromCode(executionErrorCode, msg)}
-		return &TransactionError{base}
+		next := wrapErrorFromCode(executionErrorCode, err)
+		return &TransactionError{&baseError{err: next}}
 	case transactionSerializationErrorCode:
-		base := &baseError{err: newErrorFromCode(transactionErrorCode, msg)}
-		return &TransactionSerializationError{base}
+		next := wrapErrorFromCode(transactionErrorCode, err)
+		return &TransactionSerializationError{&baseError{err: next}}
 	case transactionDeadlockErrorCode:
-		base := &baseError{err: newErrorFromCode(transactionErrorCode, msg)}
-		return &TransactionDeadlockError{base}
+		next := wrapErrorFromCode(transactionErrorCode, err)
+		return &TransactionDeadlockError{&baseError{err: next}}
 	case configurationErrorCode:
-		tail := &baseError{msg: "edgedb: " + msg}
-		base := &baseError{err: &Error{tail}}
-		return &ConfigurationError{base}
+		return &ConfigurationError{&baseError{err: wrapError(err)}}
 	case accessErrorCode:
-		tail := &baseError{msg: "edgedb: " + msg}
-		base := &baseError{err: &Error{tail}}
-		return &AccessError{base}
+		return &AccessError{&baseError{err: wrapError(err)}}
 	case authenticationErrorCode:
-		base := &baseError{err: newErrorFromCode(accessErrorCode, msg)}
-		return &AuthenticationError{base}
+		next := wrapErrorFromCode(accessErrorCode, err)
+		return &AuthenticationError{&baseError{err: next}}
 	case clientErrorCode:
-		tail := &baseError{msg: "edgedb: " + msg}
-		base := &baseError{err: &Error{tail}}
-		return &ClientError{base}
+		return &ClientError{&baseError{err: wrapError(err)}}
 	case clientConnectionErrorCode:
-		base := &baseError{err: newErrorFromCode(clientErrorCode, msg)}
-		return &ClientConnectionError{base}
+		next := wrapErrorFromCode(clientErrorCode, err)
+		return &ClientConnectionError{&baseError{err: next}}
 	case interfaceErrorCode:
-		base := &baseError{err: newErrorFromCode(clientErrorCode, msg)}
-		return &InterfaceError{base}
+		next := wrapErrorFromCode(clientErrorCode, err)
+		return &InterfaceError{&baseError{err: next}}
 	case queryArgumentErrorCode:
-		base := &baseError{err: newErrorFromCode(interfaceErrorCode, msg)}
-		return &QueryArgumentError{base}
+		next := wrapErrorFromCode(interfaceErrorCode, err)
+		return &QueryArgumentError{&baseError{err: next}}
 	case missingArgumentErrorCode:
-		base := &baseError{err: newErrorFromCode(queryArgumentErrorCode, msg)}
-		return &MissingArgumentError{base}
+		next := wrapErrorFromCode(queryArgumentErrorCode, err)
+		return &MissingArgumentError{&baseError{err: next}}
 	case unknownArgumentErrorCode:
-		base := &baseError{err: newErrorFromCode(queryArgumentErrorCode, msg)}
-		return &UnknownArgumentError{base}
+		next := wrapErrorFromCode(queryArgumentErrorCode, err)
+		return &UnknownArgumentError{&baseError{err: next}}
 	case invalidArgumentErrorCode:
-		base := &baseError{err: newErrorFromCode(queryArgumentErrorCode, msg)}
-		return &InvalidArgumentError{base}
+		next := wrapErrorFromCode(queryArgumentErrorCode, err)
+		return &InvalidArgumentError{&baseError{err: next}}
 	case noDataErrorCode:
-		base := &baseError{err: newErrorFromCode(clientErrorCode, msg)}
-		return &NoDataError{base}
+		next := wrapErrorFromCode(clientErrorCode, err)
+		return &NoDataError{&baseError{err: next}}
 	default:
 		panic(fmt.Sprintf("unknown error code: %v", code))
 	}

--- a/generatederrors.go
+++ b/generatederrors.go
@@ -24,7 +24,7 @@ import "fmt"
 // InternalServerError is an error.
 type InternalServerError interface {
 	Error
-	isInternalServerError()
+	isEdgeDBInternalServerError()
 }
 
 type internalServerError struct {
@@ -43,14 +43,14 @@ func (e *internalServerError) Error() string {
 
 func (e *internalServerError) Unwrap() error { return e.err }
 
-func (e *internalServerError) isInternalServerError() {}
+func (e *internalServerError) isEdgeDBInternalServerError() {}
 
-func (e *internalServerError) isError() {}
+func (e *internalServerError) isEdgeDBError() {}
 
 // UnsupportedFeatureError is an error.
 type UnsupportedFeatureError interface {
 	Error
-	isUnsupportedFeatureError()
+	isEdgeDBUnsupportedFeatureError()
 }
 
 type unsupportedFeatureError struct {
@@ -69,14 +69,14 @@ func (e *unsupportedFeatureError) Error() string {
 
 func (e *unsupportedFeatureError) Unwrap() error { return e.err }
 
-func (e *unsupportedFeatureError) isUnsupportedFeatureError() {}
+func (e *unsupportedFeatureError) isEdgeDBUnsupportedFeatureError() {}
 
-func (e *unsupportedFeatureError) isError() {}
+func (e *unsupportedFeatureError) isEdgeDBError() {}
 
 // ProtocolError is an error.
 type ProtocolError interface {
 	Error
-	isProtocolError()
+	isEdgeDBProtocolError()
 }
 
 type protocolError struct {
@@ -95,14 +95,14 @@ func (e *protocolError) Error() string {
 
 func (e *protocolError) Unwrap() error { return e.err }
 
-func (e *protocolError) isProtocolError() {}
+func (e *protocolError) isEdgeDBProtocolError() {}
 
-func (e *protocolError) isError() {}
+func (e *protocolError) isEdgeDBError() {}
 
 // BinaryProtocolError is an error.
 type BinaryProtocolError interface {
 	ProtocolError
-	isBinaryProtocolError()
+	isEdgeDBBinaryProtocolError()
 }
 
 type binaryProtocolError struct {
@@ -121,16 +121,16 @@ func (e *binaryProtocolError) Error() string {
 
 func (e *binaryProtocolError) Unwrap() error { return e.err }
 
-func (e *binaryProtocolError) isBinaryProtocolError() {}
+func (e *binaryProtocolError) isEdgeDBBinaryProtocolError() {}
 
-func (e *binaryProtocolError) isProtocolError() {}
+func (e *binaryProtocolError) isEdgeDBProtocolError() {}
 
-func (e *binaryProtocolError) isError() {}
+func (e *binaryProtocolError) isEdgeDBError() {}
 
 // UnsupportedProtocolVersionError is an error.
 type UnsupportedProtocolVersionError interface {
 	BinaryProtocolError
-	isUnsupportedProtocolVersionError()
+	isEdgeDBUnsupportedProtocolVersionError()
 }
 
 type unsupportedProtocolVersionError struct {
@@ -149,18 +149,18 @@ func (e *unsupportedProtocolVersionError) Error() string {
 
 func (e *unsupportedProtocolVersionError) Unwrap() error { return e.err }
 
-func (e *unsupportedProtocolVersionError) isUnsupportedProtocolVersionError() {}
+func (e *unsupportedProtocolVersionError) isEdgeDBUnsupportedProtocolVersionError() {}
 
-func (e *unsupportedProtocolVersionError) isBinaryProtocolError() {}
+func (e *unsupportedProtocolVersionError) isEdgeDBBinaryProtocolError() {}
 
-func (e *unsupportedProtocolVersionError) isProtocolError() {}
+func (e *unsupportedProtocolVersionError) isEdgeDBProtocolError() {}
 
-func (e *unsupportedProtocolVersionError) isError() {}
+func (e *unsupportedProtocolVersionError) isEdgeDBError() {}
 
 // TypeSpecNotFoundError is an error.
 type TypeSpecNotFoundError interface {
 	BinaryProtocolError
-	isTypeSpecNotFoundError()
+	isEdgeDBTypeSpecNotFoundError()
 }
 
 type typeSpecNotFoundError struct {
@@ -179,18 +179,18 @@ func (e *typeSpecNotFoundError) Error() string {
 
 func (e *typeSpecNotFoundError) Unwrap() error { return e.err }
 
-func (e *typeSpecNotFoundError) isTypeSpecNotFoundError() {}
+func (e *typeSpecNotFoundError) isEdgeDBTypeSpecNotFoundError() {}
 
-func (e *typeSpecNotFoundError) isBinaryProtocolError() {}
+func (e *typeSpecNotFoundError) isEdgeDBBinaryProtocolError() {}
 
-func (e *typeSpecNotFoundError) isProtocolError() {}
+func (e *typeSpecNotFoundError) isEdgeDBProtocolError() {}
 
-func (e *typeSpecNotFoundError) isError() {}
+func (e *typeSpecNotFoundError) isEdgeDBError() {}
 
 // UnexpectedMessageError is an error.
 type UnexpectedMessageError interface {
 	BinaryProtocolError
-	isUnexpectedMessageError()
+	isEdgeDBUnexpectedMessageError()
 }
 
 type unexpectedMessageError struct {
@@ -209,18 +209,18 @@ func (e *unexpectedMessageError) Error() string {
 
 func (e *unexpectedMessageError) Unwrap() error { return e.err }
 
-func (e *unexpectedMessageError) isUnexpectedMessageError() {}
+func (e *unexpectedMessageError) isEdgeDBUnexpectedMessageError() {}
 
-func (e *unexpectedMessageError) isBinaryProtocolError() {}
+func (e *unexpectedMessageError) isEdgeDBBinaryProtocolError() {}
 
-func (e *unexpectedMessageError) isProtocolError() {}
+func (e *unexpectedMessageError) isEdgeDBProtocolError() {}
 
-func (e *unexpectedMessageError) isError() {}
+func (e *unexpectedMessageError) isEdgeDBError() {}
 
 // InputDataError is an error.
 type InputDataError interface {
 	ProtocolError
-	isInputDataError()
+	isEdgeDBInputDataError()
 }
 
 type inputDataError struct {
@@ -239,16 +239,16 @@ func (e *inputDataError) Error() string {
 
 func (e *inputDataError) Unwrap() error { return e.err }
 
-func (e *inputDataError) isInputDataError() {}
+func (e *inputDataError) isEdgeDBInputDataError() {}
 
-func (e *inputDataError) isProtocolError() {}
+func (e *inputDataError) isEdgeDBProtocolError() {}
 
-func (e *inputDataError) isError() {}
+func (e *inputDataError) isEdgeDBError() {}
 
 // ResultCardinalityMismatchError is an error.
 type ResultCardinalityMismatchError interface {
 	ProtocolError
-	isResultCardinalityMismatchError()
+	isEdgeDBResultCardinalityMismatchError()
 }
 
 type resultCardinalityMismatchError struct {
@@ -267,16 +267,16 @@ func (e *resultCardinalityMismatchError) Error() string {
 
 func (e *resultCardinalityMismatchError) Unwrap() error { return e.err }
 
-func (e *resultCardinalityMismatchError) isResultCardinalityMismatchError() {}
+func (e *resultCardinalityMismatchError) isEdgeDBResultCardinalityMismatchError() {}
 
-func (e *resultCardinalityMismatchError) isProtocolError() {}
+func (e *resultCardinalityMismatchError) isEdgeDBProtocolError() {}
 
-func (e *resultCardinalityMismatchError) isError() {}
+func (e *resultCardinalityMismatchError) isEdgeDBError() {}
 
 // QueryError is an error.
 type QueryError interface {
 	Error
-	isQueryError()
+	isEdgeDBQueryError()
 }
 
 type queryError struct {
@@ -295,14 +295,14 @@ func (e *queryError) Error() string {
 
 func (e *queryError) Unwrap() error { return e.err }
 
-func (e *queryError) isQueryError() {}
+func (e *queryError) isEdgeDBQueryError() {}
 
-func (e *queryError) isError() {}
+func (e *queryError) isEdgeDBError() {}
 
 // InvalidSyntaxError is an error.
 type InvalidSyntaxError interface {
 	QueryError
-	isInvalidSyntaxError()
+	isEdgeDBInvalidSyntaxError()
 }
 
 type invalidSyntaxError struct {
@@ -321,16 +321,16 @@ func (e *invalidSyntaxError) Error() string {
 
 func (e *invalidSyntaxError) Unwrap() error { return e.err }
 
-func (e *invalidSyntaxError) isInvalidSyntaxError() {}
+func (e *invalidSyntaxError) isEdgeDBInvalidSyntaxError() {}
 
-func (e *invalidSyntaxError) isQueryError() {}
+func (e *invalidSyntaxError) isEdgeDBQueryError() {}
 
-func (e *invalidSyntaxError) isError() {}
+func (e *invalidSyntaxError) isEdgeDBError() {}
 
 // EdgeQLSyntaxError is an error.
 type EdgeQLSyntaxError interface {
 	InvalidSyntaxError
-	isEdgeQLSyntaxError()
+	isEdgeDBEdgeQLSyntaxError()
 }
 
 type edgeQLSyntaxError struct {
@@ -349,18 +349,18 @@ func (e *edgeQLSyntaxError) Error() string {
 
 func (e *edgeQLSyntaxError) Unwrap() error { return e.err }
 
-func (e *edgeQLSyntaxError) isEdgeQLSyntaxError() {}
+func (e *edgeQLSyntaxError) isEdgeDBEdgeQLSyntaxError() {}
 
-func (e *edgeQLSyntaxError) isInvalidSyntaxError() {}
+func (e *edgeQLSyntaxError) isEdgeDBInvalidSyntaxError() {}
 
-func (e *edgeQLSyntaxError) isQueryError() {}
+func (e *edgeQLSyntaxError) isEdgeDBQueryError() {}
 
-func (e *edgeQLSyntaxError) isError() {}
+func (e *edgeQLSyntaxError) isEdgeDBError() {}
 
 // SchemaSyntaxError is an error.
 type SchemaSyntaxError interface {
 	InvalidSyntaxError
-	isSchemaSyntaxError()
+	isEdgeDBSchemaSyntaxError()
 }
 
 type schemaSyntaxError struct {
@@ -379,18 +379,18 @@ func (e *schemaSyntaxError) Error() string {
 
 func (e *schemaSyntaxError) Unwrap() error { return e.err }
 
-func (e *schemaSyntaxError) isSchemaSyntaxError() {}
+func (e *schemaSyntaxError) isEdgeDBSchemaSyntaxError() {}
 
-func (e *schemaSyntaxError) isInvalidSyntaxError() {}
+func (e *schemaSyntaxError) isEdgeDBInvalidSyntaxError() {}
 
-func (e *schemaSyntaxError) isQueryError() {}
+func (e *schemaSyntaxError) isEdgeDBQueryError() {}
 
-func (e *schemaSyntaxError) isError() {}
+func (e *schemaSyntaxError) isEdgeDBError() {}
 
 // GraphQLSyntaxError is an error.
 type GraphQLSyntaxError interface {
 	InvalidSyntaxError
-	isGraphQLSyntaxError()
+	isEdgeDBGraphQLSyntaxError()
 }
 
 type graphQLSyntaxError struct {
@@ -409,18 +409,18 @@ func (e *graphQLSyntaxError) Error() string {
 
 func (e *graphQLSyntaxError) Unwrap() error { return e.err }
 
-func (e *graphQLSyntaxError) isGraphQLSyntaxError() {}
+func (e *graphQLSyntaxError) isEdgeDBGraphQLSyntaxError() {}
 
-func (e *graphQLSyntaxError) isInvalidSyntaxError() {}
+func (e *graphQLSyntaxError) isEdgeDBInvalidSyntaxError() {}
 
-func (e *graphQLSyntaxError) isQueryError() {}
+func (e *graphQLSyntaxError) isEdgeDBQueryError() {}
 
-func (e *graphQLSyntaxError) isError() {}
+func (e *graphQLSyntaxError) isEdgeDBError() {}
 
 // InvalidTypeError is an error.
 type InvalidTypeError interface {
 	QueryError
-	isInvalidTypeError()
+	isEdgeDBInvalidTypeError()
 }
 
 type invalidTypeError struct {
@@ -439,16 +439,16 @@ func (e *invalidTypeError) Error() string {
 
 func (e *invalidTypeError) Unwrap() error { return e.err }
 
-func (e *invalidTypeError) isInvalidTypeError() {}
+func (e *invalidTypeError) isEdgeDBInvalidTypeError() {}
 
-func (e *invalidTypeError) isQueryError() {}
+func (e *invalidTypeError) isEdgeDBQueryError() {}
 
-func (e *invalidTypeError) isError() {}
+func (e *invalidTypeError) isEdgeDBError() {}
 
 // InvalidTargetError is an error.
 type InvalidTargetError interface {
 	InvalidTypeError
-	isInvalidTargetError()
+	isEdgeDBInvalidTargetError()
 }
 
 type invalidTargetError struct {
@@ -467,18 +467,18 @@ func (e *invalidTargetError) Error() string {
 
 func (e *invalidTargetError) Unwrap() error { return e.err }
 
-func (e *invalidTargetError) isInvalidTargetError() {}
+func (e *invalidTargetError) isEdgeDBInvalidTargetError() {}
 
-func (e *invalidTargetError) isInvalidTypeError() {}
+func (e *invalidTargetError) isEdgeDBInvalidTypeError() {}
 
-func (e *invalidTargetError) isQueryError() {}
+func (e *invalidTargetError) isEdgeDBQueryError() {}
 
-func (e *invalidTargetError) isError() {}
+func (e *invalidTargetError) isEdgeDBError() {}
 
 // InvalidLinkTargetError is an error.
 type InvalidLinkTargetError interface {
 	InvalidTargetError
-	isInvalidLinkTargetError()
+	isEdgeDBInvalidLinkTargetError()
 }
 
 type invalidLinkTargetError struct {
@@ -497,20 +497,20 @@ func (e *invalidLinkTargetError) Error() string {
 
 func (e *invalidLinkTargetError) Unwrap() error { return e.err }
 
-func (e *invalidLinkTargetError) isInvalidLinkTargetError() {}
+func (e *invalidLinkTargetError) isEdgeDBInvalidLinkTargetError() {}
 
-func (e *invalidLinkTargetError) isInvalidTargetError() {}
+func (e *invalidLinkTargetError) isEdgeDBInvalidTargetError() {}
 
-func (e *invalidLinkTargetError) isInvalidTypeError() {}
+func (e *invalidLinkTargetError) isEdgeDBInvalidTypeError() {}
 
-func (e *invalidLinkTargetError) isQueryError() {}
+func (e *invalidLinkTargetError) isEdgeDBQueryError() {}
 
-func (e *invalidLinkTargetError) isError() {}
+func (e *invalidLinkTargetError) isEdgeDBError() {}
 
 // InvalidPropertyTargetError is an error.
 type InvalidPropertyTargetError interface {
 	InvalidTargetError
-	isInvalidPropertyTargetError()
+	isEdgeDBInvalidPropertyTargetError()
 }
 
 type invalidPropertyTargetError struct {
@@ -529,20 +529,20 @@ func (e *invalidPropertyTargetError) Error() string {
 
 func (e *invalidPropertyTargetError) Unwrap() error { return e.err }
 
-func (e *invalidPropertyTargetError) isInvalidPropertyTargetError() {}
+func (e *invalidPropertyTargetError) isEdgeDBInvalidPropertyTargetError() {}
 
-func (e *invalidPropertyTargetError) isInvalidTargetError() {}
+func (e *invalidPropertyTargetError) isEdgeDBInvalidTargetError() {}
 
-func (e *invalidPropertyTargetError) isInvalidTypeError() {}
+func (e *invalidPropertyTargetError) isEdgeDBInvalidTypeError() {}
 
-func (e *invalidPropertyTargetError) isQueryError() {}
+func (e *invalidPropertyTargetError) isEdgeDBQueryError() {}
 
-func (e *invalidPropertyTargetError) isError() {}
+func (e *invalidPropertyTargetError) isEdgeDBError() {}
 
 // InvalidReferenceError is an error.
 type InvalidReferenceError interface {
 	QueryError
-	isInvalidReferenceError()
+	isEdgeDBInvalidReferenceError()
 }
 
 type invalidReferenceError struct {
@@ -561,16 +561,16 @@ func (e *invalidReferenceError) Error() string {
 
 func (e *invalidReferenceError) Unwrap() error { return e.err }
 
-func (e *invalidReferenceError) isInvalidReferenceError() {}
+func (e *invalidReferenceError) isEdgeDBInvalidReferenceError() {}
 
-func (e *invalidReferenceError) isQueryError() {}
+func (e *invalidReferenceError) isEdgeDBQueryError() {}
 
-func (e *invalidReferenceError) isError() {}
+func (e *invalidReferenceError) isEdgeDBError() {}
 
 // UnknownModuleError is an error.
 type UnknownModuleError interface {
 	InvalidReferenceError
-	isUnknownModuleError()
+	isEdgeDBUnknownModuleError()
 }
 
 type unknownModuleError struct {
@@ -589,18 +589,18 @@ func (e *unknownModuleError) Error() string {
 
 func (e *unknownModuleError) Unwrap() error { return e.err }
 
-func (e *unknownModuleError) isUnknownModuleError() {}
+func (e *unknownModuleError) isEdgeDBUnknownModuleError() {}
 
-func (e *unknownModuleError) isInvalidReferenceError() {}
+func (e *unknownModuleError) isEdgeDBInvalidReferenceError() {}
 
-func (e *unknownModuleError) isQueryError() {}
+func (e *unknownModuleError) isEdgeDBQueryError() {}
 
-func (e *unknownModuleError) isError() {}
+func (e *unknownModuleError) isEdgeDBError() {}
 
 // UnknownLinkError is an error.
 type UnknownLinkError interface {
 	InvalidReferenceError
-	isUnknownLinkError()
+	isEdgeDBUnknownLinkError()
 }
 
 type unknownLinkError struct {
@@ -619,18 +619,18 @@ func (e *unknownLinkError) Error() string {
 
 func (e *unknownLinkError) Unwrap() error { return e.err }
 
-func (e *unknownLinkError) isUnknownLinkError() {}
+func (e *unknownLinkError) isEdgeDBUnknownLinkError() {}
 
-func (e *unknownLinkError) isInvalidReferenceError() {}
+func (e *unknownLinkError) isEdgeDBInvalidReferenceError() {}
 
-func (e *unknownLinkError) isQueryError() {}
+func (e *unknownLinkError) isEdgeDBQueryError() {}
 
-func (e *unknownLinkError) isError() {}
+func (e *unknownLinkError) isEdgeDBError() {}
 
 // UnknownPropertyError is an error.
 type UnknownPropertyError interface {
 	InvalidReferenceError
-	isUnknownPropertyError()
+	isEdgeDBUnknownPropertyError()
 }
 
 type unknownPropertyError struct {
@@ -649,18 +649,18 @@ func (e *unknownPropertyError) Error() string {
 
 func (e *unknownPropertyError) Unwrap() error { return e.err }
 
-func (e *unknownPropertyError) isUnknownPropertyError() {}
+func (e *unknownPropertyError) isEdgeDBUnknownPropertyError() {}
 
-func (e *unknownPropertyError) isInvalidReferenceError() {}
+func (e *unknownPropertyError) isEdgeDBInvalidReferenceError() {}
 
-func (e *unknownPropertyError) isQueryError() {}
+func (e *unknownPropertyError) isEdgeDBQueryError() {}
 
-func (e *unknownPropertyError) isError() {}
+func (e *unknownPropertyError) isEdgeDBError() {}
 
 // UnknownUserError is an error.
 type UnknownUserError interface {
 	InvalidReferenceError
-	isUnknownUserError()
+	isEdgeDBUnknownUserError()
 }
 
 type unknownUserError struct {
@@ -679,18 +679,18 @@ func (e *unknownUserError) Error() string {
 
 func (e *unknownUserError) Unwrap() error { return e.err }
 
-func (e *unknownUserError) isUnknownUserError() {}
+func (e *unknownUserError) isEdgeDBUnknownUserError() {}
 
-func (e *unknownUserError) isInvalidReferenceError() {}
+func (e *unknownUserError) isEdgeDBInvalidReferenceError() {}
 
-func (e *unknownUserError) isQueryError() {}
+func (e *unknownUserError) isEdgeDBQueryError() {}
 
-func (e *unknownUserError) isError() {}
+func (e *unknownUserError) isEdgeDBError() {}
 
 // UnknownDatabaseError is an error.
 type UnknownDatabaseError interface {
 	InvalidReferenceError
-	isUnknownDatabaseError()
+	isEdgeDBUnknownDatabaseError()
 }
 
 type unknownDatabaseError struct {
@@ -709,18 +709,18 @@ func (e *unknownDatabaseError) Error() string {
 
 func (e *unknownDatabaseError) Unwrap() error { return e.err }
 
-func (e *unknownDatabaseError) isUnknownDatabaseError() {}
+func (e *unknownDatabaseError) isEdgeDBUnknownDatabaseError() {}
 
-func (e *unknownDatabaseError) isInvalidReferenceError() {}
+func (e *unknownDatabaseError) isEdgeDBInvalidReferenceError() {}
 
-func (e *unknownDatabaseError) isQueryError() {}
+func (e *unknownDatabaseError) isEdgeDBQueryError() {}
 
-func (e *unknownDatabaseError) isError() {}
+func (e *unknownDatabaseError) isEdgeDBError() {}
 
 // UnknownParameterError is an error.
 type UnknownParameterError interface {
 	InvalidReferenceError
-	isUnknownParameterError()
+	isEdgeDBUnknownParameterError()
 }
 
 type unknownParameterError struct {
@@ -739,18 +739,18 @@ func (e *unknownParameterError) Error() string {
 
 func (e *unknownParameterError) Unwrap() error { return e.err }
 
-func (e *unknownParameterError) isUnknownParameterError() {}
+func (e *unknownParameterError) isEdgeDBUnknownParameterError() {}
 
-func (e *unknownParameterError) isInvalidReferenceError() {}
+func (e *unknownParameterError) isEdgeDBInvalidReferenceError() {}
 
-func (e *unknownParameterError) isQueryError() {}
+func (e *unknownParameterError) isEdgeDBQueryError() {}
 
-func (e *unknownParameterError) isError() {}
+func (e *unknownParameterError) isEdgeDBError() {}
 
 // SchemaError is an error.
 type SchemaError interface {
 	QueryError
-	isSchemaError()
+	isEdgeDBSchemaError()
 }
 
 type schemaError struct {
@@ -769,16 +769,16 @@ func (e *schemaError) Error() string {
 
 func (e *schemaError) Unwrap() error { return e.err }
 
-func (e *schemaError) isSchemaError() {}
+func (e *schemaError) isEdgeDBSchemaError() {}
 
-func (e *schemaError) isQueryError() {}
+func (e *schemaError) isEdgeDBQueryError() {}
 
-func (e *schemaError) isError() {}
+func (e *schemaError) isEdgeDBError() {}
 
 // SchemaDefinitionError is an error.
 type SchemaDefinitionError interface {
 	QueryError
-	isSchemaDefinitionError()
+	isEdgeDBSchemaDefinitionError()
 }
 
 type schemaDefinitionError struct {
@@ -797,16 +797,16 @@ func (e *schemaDefinitionError) Error() string {
 
 func (e *schemaDefinitionError) Unwrap() error { return e.err }
 
-func (e *schemaDefinitionError) isSchemaDefinitionError() {}
+func (e *schemaDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *schemaDefinitionError) isQueryError() {}
+func (e *schemaDefinitionError) isEdgeDBQueryError() {}
 
-func (e *schemaDefinitionError) isError() {}
+func (e *schemaDefinitionError) isEdgeDBError() {}
 
 // InvalidDefinitionError is an error.
 type InvalidDefinitionError interface {
 	SchemaDefinitionError
-	isInvalidDefinitionError()
+	isEdgeDBInvalidDefinitionError()
 }
 
 type invalidDefinitionError struct {
@@ -825,18 +825,18 @@ func (e *invalidDefinitionError) Error() string {
 
 func (e *invalidDefinitionError) Unwrap() error { return e.err }
 
-func (e *invalidDefinitionError) isInvalidDefinitionError() {}
+func (e *invalidDefinitionError) isEdgeDBInvalidDefinitionError() {}
 
-func (e *invalidDefinitionError) isSchemaDefinitionError() {}
+func (e *invalidDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *invalidDefinitionError) isQueryError() {}
+func (e *invalidDefinitionError) isEdgeDBQueryError() {}
 
-func (e *invalidDefinitionError) isError() {}
+func (e *invalidDefinitionError) isEdgeDBError() {}
 
 // InvalidModuleDefinitionError is an error.
 type InvalidModuleDefinitionError interface {
 	InvalidDefinitionError
-	isInvalidModuleDefinitionError()
+	isEdgeDBInvalidModuleDefinitionError()
 }
 
 type invalidModuleDefinitionError struct {
@@ -855,20 +855,20 @@ func (e *invalidModuleDefinitionError) Error() string {
 
 func (e *invalidModuleDefinitionError) Unwrap() error { return e.err }
 
-func (e *invalidModuleDefinitionError) isInvalidModuleDefinitionError() {}
+func (e *invalidModuleDefinitionError) isEdgeDBInvalidModuleDefinitionError() {}
 
-func (e *invalidModuleDefinitionError) isInvalidDefinitionError() {}
+func (e *invalidModuleDefinitionError) isEdgeDBInvalidDefinitionError() {}
 
-func (e *invalidModuleDefinitionError) isSchemaDefinitionError() {}
+func (e *invalidModuleDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *invalidModuleDefinitionError) isQueryError() {}
+func (e *invalidModuleDefinitionError) isEdgeDBQueryError() {}
 
-func (e *invalidModuleDefinitionError) isError() {}
+func (e *invalidModuleDefinitionError) isEdgeDBError() {}
 
 // InvalidLinkDefinitionError is an error.
 type InvalidLinkDefinitionError interface {
 	InvalidDefinitionError
-	isInvalidLinkDefinitionError()
+	isEdgeDBInvalidLinkDefinitionError()
 }
 
 type invalidLinkDefinitionError struct {
@@ -887,20 +887,20 @@ func (e *invalidLinkDefinitionError) Error() string {
 
 func (e *invalidLinkDefinitionError) Unwrap() error { return e.err }
 
-func (e *invalidLinkDefinitionError) isInvalidLinkDefinitionError() {}
+func (e *invalidLinkDefinitionError) isEdgeDBInvalidLinkDefinitionError() {}
 
-func (e *invalidLinkDefinitionError) isInvalidDefinitionError() {}
+func (e *invalidLinkDefinitionError) isEdgeDBInvalidDefinitionError() {}
 
-func (e *invalidLinkDefinitionError) isSchemaDefinitionError() {}
+func (e *invalidLinkDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *invalidLinkDefinitionError) isQueryError() {}
+func (e *invalidLinkDefinitionError) isEdgeDBQueryError() {}
 
-func (e *invalidLinkDefinitionError) isError() {}
+func (e *invalidLinkDefinitionError) isEdgeDBError() {}
 
 // InvalidPropertyDefinitionError is an error.
 type InvalidPropertyDefinitionError interface {
 	InvalidDefinitionError
-	isInvalidPropertyDefinitionError()
+	isEdgeDBInvalidPropertyDefinitionError()
 }
 
 type invalidPropertyDefinitionError struct {
@@ -919,20 +919,20 @@ func (e *invalidPropertyDefinitionError) Error() string {
 
 func (e *invalidPropertyDefinitionError) Unwrap() error { return e.err }
 
-func (e *invalidPropertyDefinitionError) isInvalidPropertyDefinitionError() {}
+func (e *invalidPropertyDefinitionError) isEdgeDBInvalidPropertyDefinitionError() {}
 
-func (e *invalidPropertyDefinitionError) isInvalidDefinitionError() {}
+func (e *invalidPropertyDefinitionError) isEdgeDBInvalidDefinitionError() {}
 
-func (e *invalidPropertyDefinitionError) isSchemaDefinitionError() {}
+func (e *invalidPropertyDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *invalidPropertyDefinitionError) isQueryError() {}
+func (e *invalidPropertyDefinitionError) isEdgeDBQueryError() {}
 
-func (e *invalidPropertyDefinitionError) isError() {}
+func (e *invalidPropertyDefinitionError) isEdgeDBError() {}
 
 // InvalidUserDefinitionError is an error.
 type InvalidUserDefinitionError interface {
 	InvalidDefinitionError
-	isInvalidUserDefinitionError()
+	isEdgeDBInvalidUserDefinitionError()
 }
 
 type invalidUserDefinitionError struct {
@@ -951,20 +951,20 @@ func (e *invalidUserDefinitionError) Error() string {
 
 func (e *invalidUserDefinitionError) Unwrap() error { return e.err }
 
-func (e *invalidUserDefinitionError) isInvalidUserDefinitionError() {}
+func (e *invalidUserDefinitionError) isEdgeDBInvalidUserDefinitionError() {}
 
-func (e *invalidUserDefinitionError) isInvalidDefinitionError() {}
+func (e *invalidUserDefinitionError) isEdgeDBInvalidDefinitionError() {}
 
-func (e *invalidUserDefinitionError) isSchemaDefinitionError() {}
+func (e *invalidUserDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *invalidUserDefinitionError) isQueryError() {}
+func (e *invalidUserDefinitionError) isEdgeDBQueryError() {}
 
-func (e *invalidUserDefinitionError) isError() {}
+func (e *invalidUserDefinitionError) isEdgeDBError() {}
 
 // InvalidDatabaseDefinitionError is an error.
 type InvalidDatabaseDefinitionError interface {
 	InvalidDefinitionError
-	isInvalidDatabaseDefinitionError()
+	isEdgeDBInvalidDatabaseDefinitionError()
 }
 
 type invalidDatabaseDefinitionError struct {
@@ -983,20 +983,20 @@ func (e *invalidDatabaseDefinitionError) Error() string {
 
 func (e *invalidDatabaseDefinitionError) Unwrap() error { return e.err }
 
-func (e *invalidDatabaseDefinitionError) isInvalidDatabaseDefinitionError() {}
+func (e *invalidDatabaseDefinitionError) isEdgeDBInvalidDatabaseDefinitionError() {}
 
-func (e *invalidDatabaseDefinitionError) isInvalidDefinitionError() {}
+func (e *invalidDatabaseDefinitionError) isEdgeDBInvalidDefinitionError() {}
 
-func (e *invalidDatabaseDefinitionError) isSchemaDefinitionError() {}
+func (e *invalidDatabaseDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *invalidDatabaseDefinitionError) isQueryError() {}
+func (e *invalidDatabaseDefinitionError) isEdgeDBQueryError() {}
 
-func (e *invalidDatabaseDefinitionError) isError() {}
+func (e *invalidDatabaseDefinitionError) isEdgeDBError() {}
 
 // InvalidOperatorDefinitionError is an error.
 type InvalidOperatorDefinitionError interface {
 	InvalidDefinitionError
-	isInvalidOperatorDefinitionError()
+	isEdgeDBInvalidOperatorDefinitionError()
 }
 
 type invalidOperatorDefinitionError struct {
@@ -1015,20 +1015,20 @@ func (e *invalidOperatorDefinitionError) Error() string {
 
 func (e *invalidOperatorDefinitionError) Unwrap() error { return e.err }
 
-func (e *invalidOperatorDefinitionError) isInvalidOperatorDefinitionError() {}
+func (e *invalidOperatorDefinitionError) isEdgeDBInvalidOperatorDefinitionError() {}
 
-func (e *invalidOperatorDefinitionError) isInvalidDefinitionError() {}
+func (e *invalidOperatorDefinitionError) isEdgeDBInvalidDefinitionError() {}
 
-func (e *invalidOperatorDefinitionError) isSchemaDefinitionError() {}
+func (e *invalidOperatorDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *invalidOperatorDefinitionError) isQueryError() {}
+func (e *invalidOperatorDefinitionError) isEdgeDBQueryError() {}
 
-func (e *invalidOperatorDefinitionError) isError() {}
+func (e *invalidOperatorDefinitionError) isEdgeDBError() {}
 
 // InvalidAliasDefinitionError is an error.
 type InvalidAliasDefinitionError interface {
 	InvalidDefinitionError
-	isInvalidAliasDefinitionError()
+	isEdgeDBInvalidAliasDefinitionError()
 }
 
 type invalidAliasDefinitionError struct {
@@ -1047,20 +1047,20 @@ func (e *invalidAliasDefinitionError) Error() string {
 
 func (e *invalidAliasDefinitionError) Unwrap() error { return e.err }
 
-func (e *invalidAliasDefinitionError) isInvalidAliasDefinitionError() {}
+func (e *invalidAliasDefinitionError) isEdgeDBInvalidAliasDefinitionError() {}
 
-func (e *invalidAliasDefinitionError) isInvalidDefinitionError() {}
+func (e *invalidAliasDefinitionError) isEdgeDBInvalidDefinitionError() {}
 
-func (e *invalidAliasDefinitionError) isSchemaDefinitionError() {}
+func (e *invalidAliasDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *invalidAliasDefinitionError) isQueryError() {}
+func (e *invalidAliasDefinitionError) isEdgeDBQueryError() {}
 
-func (e *invalidAliasDefinitionError) isError() {}
+func (e *invalidAliasDefinitionError) isEdgeDBError() {}
 
 // InvalidFunctionDefinitionError is an error.
 type InvalidFunctionDefinitionError interface {
 	InvalidDefinitionError
-	isInvalidFunctionDefinitionError()
+	isEdgeDBInvalidFunctionDefinitionError()
 }
 
 type invalidFunctionDefinitionError struct {
@@ -1079,20 +1079,20 @@ func (e *invalidFunctionDefinitionError) Error() string {
 
 func (e *invalidFunctionDefinitionError) Unwrap() error { return e.err }
 
-func (e *invalidFunctionDefinitionError) isInvalidFunctionDefinitionError() {}
+func (e *invalidFunctionDefinitionError) isEdgeDBInvalidFunctionDefinitionError() {}
 
-func (e *invalidFunctionDefinitionError) isInvalidDefinitionError() {}
+func (e *invalidFunctionDefinitionError) isEdgeDBInvalidDefinitionError() {}
 
-func (e *invalidFunctionDefinitionError) isSchemaDefinitionError() {}
+func (e *invalidFunctionDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *invalidFunctionDefinitionError) isQueryError() {}
+func (e *invalidFunctionDefinitionError) isEdgeDBQueryError() {}
 
-func (e *invalidFunctionDefinitionError) isError() {}
+func (e *invalidFunctionDefinitionError) isEdgeDBError() {}
 
 // InvalidConstraintDefinitionError is an error.
 type InvalidConstraintDefinitionError interface {
 	InvalidDefinitionError
-	isInvalidConstraintDefinitionError()
+	isEdgeDBInvalidConstraintDefinitionError()
 }
 
 type invalidConstraintDefinitionError struct {
@@ -1111,20 +1111,20 @@ func (e *invalidConstraintDefinitionError) Error() string {
 
 func (e *invalidConstraintDefinitionError) Unwrap() error { return e.err }
 
-func (e *invalidConstraintDefinitionError) isInvalidConstraintDefinitionError() {}
+func (e *invalidConstraintDefinitionError) isEdgeDBInvalidConstraintDefinitionError() {}
 
-func (e *invalidConstraintDefinitionError) isInvalidDefinitionError() {}
+func (e *invalidConstraintDefinitionError) isEdgeDBInvalidDefinitionError() {}
 
-func (e *invalidConstraintDefinitionError) isSchemaDefinitionError() {}
+func (e *invalidConstraintDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *invalidConstraintDefinitionError) isQueryError() {}
+func (e *invalidConstraintDefinitionError) isEdgeDBQueryError() {}
 
-func (e *invalidConstraintDefinitionError) isError() {}
+func (e *invalidConstraintDefinitionError) isEdgeDBError() {}
 
 // InvalidCastDefinitionError is an error.
 type InvalidCastDefinitionError interface {
 	InvalidDefinitionError
-	isInvalidCastDefinitionError()
+	isEdgeDBInvalidCastDefinitionError()
 }
 
 type invalidCastDefinitionError struct {
@@ -1143,20 +1143,20 @@ func (e *invalidCastDefinitionError) Error() string {
 
 func (e *invalidCastDefinitionError) Unwrap() error { return e.err }
 
-func (e *invalidCastDefinitionError) isInvalidCastDefinitionError() {}
+func (e *invalidCastDefinitionError) isEdgeDBInvalidCastDefinitionError() {}
 
-func (e *invalidCastDefinitionError) isInvalidDefinitionError() {}
+func (e *invalidCastDefinitionError) isEdgeDBInvalidDefinitionError() {}
 
-func (e *invalidCastDefinitionError) isSchemaDefinitionError() {}
+func (e *invalidCastDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *invalidCastDefinitionError) isQueryError() {}
+func (e *invalidCastDefinitionError) isEdgeDBQueryError() {}
 
-func (e *invalidCastDefinitionError) isError() {}
+func (e *invalidCastDefinitionError) isEdgeDBError() {}
 
 // DuplicateDefinitionError is an error.
 type DuplicateDefinitionError interface {
 	SchemaDefinitionError
-	isDuplicateDefinitionError()
+	isEdgeDBDuplicateDefinitionError()
 }
 
 type duplicateDefinitionError struct {
@@ -1175,18 +1175,18 @@ func (e *duplicateDefinitionError) Error() string {
 
 func (e *duplicateDefinitionError) Unwrap() error { return e.err }
 
-func (e *duplicateDefinitionError) isDuplicateDefinitionError() {}
+func (e *duplicateDefinitionError) isEdgeDBDuplicateDefinitionError() {}
 
-func (e *duplicateDefinitionError) isSchemaDefinitionError() {}
+func (e *duplicateDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *duplicateDefinitionError) isQueryError() {}
+func (e *duplicateDefinitionError) isEdgeDBQueryError() {}
 
-func (e *duplicateDefinitionError) isError() {}
+func (e *duplicateDefinitionError) isEdgeDBError() {}
 
 // DuplicateModuleDefinitionError is an error.
 type DuplicateModuleDefinitionError interface {
 	DuplicateDefinitionError
-	isDuplicateModuleDefinitionError()
+	isEdgeDBDuplicateModuleDefinitionError()
 }
 
 type duplicateModuleDefinitionError struct {
@@ -1205,20 +1205,20 @@ func (e *duplicateModuleDefinitionError) Error() string {
 
 func (e *duplicateModuleDefinitionError) Unwrap() error { return e.err }
 
-func (e *duplicateModuleDefinitionError) isDuplicateModuleDefinitionError() {}
+func (e *duplicateModuleDefinitionError) isEdgeDBDuplicateModuleDefinitionError() {}
 
-func (e *duplicateModuleDefinitionError) isDuplicateDefinitionError() {}
+func (e *duplicateModuleDefinitionError) isEdgeDBDuplicateDefinitionError() {}
 
-func (e *duplicateModuleDefinitionError) isSchemaDefinitionError() {}
+func (e *duplicateModuleDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *duplicateModuleDefinitionError) isQueryError() {}
+func (e *duplicateModuleDefinitionError) isEdgeDBQueryError() {}
 
-func (e *duplicateModuleDefinitionError) isError() {}
+func (e *duplicateModuleDefinitionError) isEdgeDBError() {}
 
 // DuplicateLinkDefinitionError is an error.
 type DuplicateLinkDefinitionError interface {
 	DuplicateDefinitionError
-	isDuplicateLinkDefinitionError()
+	isEdgeDBDuplicateLinkDefinitionError()
 }
 
 type duplicateLinkDefinitionError struct {
@@ -1237,20 +1237,20 @@ func (e *duplicateLinkDefinitionError) Error() string {
 
 func (e *duplicateLinkDefinitionError) Unwrap() error { return e.err }
 
-func (e *duplicateLinkDefinitionError) isDuplicateLinkDefinitionError() {}
+func (e *duplicateLinkDefinitionError) isEdgeDBDuplicateLinkDefinitionError() {}
 
-func (e *duplicateLinkDefinitionError) isDuplicateDefinitionError() {}
+func (e *duplicateLinkDefinitionError) isEdgeDBDuplicateDefinitionError() {}
 
-func (e *duplicateLinkDefinitionError) isSchemaDefinitionError() {}
+func (e *duplicateLinkDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *duplicateLinkDefinitionError) isQueryError() {}
+func (e *duplicateLinkDefinitionError) isEdgeDBQueryError() {}
 
-func (e *duplicateLinkDefinitionError) isError() {}
+func (e *duplicateLinkDefinitionError) isEdgeDBError() {}
 
 // DuplicatePropertyDefinitionError is an error.
 type DuplicatePropertyDefinitionError interface {
 	DuplicateDefinitionError
-	isDuplicatePropertyDefinitionError()
+	isEdgeDBDuplicatePropertyDefinitionError()
 }
 
 type duplicatePropertyDefinitionError struct {
@@ -1269,20 +1269,20 @@ func (e *duplicatePropertyDefinitionError) Error() string {
 
 func (e *duplicatePropertyDefinitionError) Unwrap() error { return e.err }
 
-func (e *duplicatePropertyDefinitionError) isDuplicatePropertyDefinitionError() {}
+func (e *duplicatePropertyDefinitionError) isEdgeDBDuplicatePropertyDefinitionError() {}
 
-func (e *duplicatePropertyDefinitionError) isDuplicateDefinitionError() {}
+func (e *duplicatePropertyDefinitionError) isEdgeDBDuplicateDefinitionError() {}
 
-func (e *duplicatePropertyDefinitionError) isSchemaDefinitionError() {}
+func (e *duplicatePropertyDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *duplicatePropertyDefinitionError) isQueryError() {}
+func (e *duplicatePropertyDefinitionError) isEdgeDBQueryError() {}
 
-func (e *duplicatePropertyDefinitionError) isError() {}
+func (e *duplicatePropertyDefinitionError) isEdgeDBError() {}
 
 // DuplicateUserDefinitionError is an error.
 type DuplicateUserDefinitionError interface {
 	DuplicateDefinitionError
-	isDuplicateUserDefinitionError()
+	isEdgeDBDuplicateUserDefinitionError()
 }
 
 type duplicateUserDefinitionError struct {
@@ -1301,20 +1301,20 @@ func (e *duplicateUserDefinitionError) Error() string {
 
 func (e *duplicateUserDefinitionError) Unwrap() error { return e.err }
 
-func (e *duplicateUserDefinitionError) isDuplicateUserDefinitionError() {}
+func (e *duplicateUserDefinitionError) isEdgeDBDuplicateUserDefinitionError() {}
 
-func (e *duplicateUserDefinitionError) isDuplicateDefinitionError() {}
+func (e *duplicateUserDefinitionError) isEdgeDBDuplicateDefinitionError() {}
 
-func (e *duplicateUserDefinitionError) isSchemaDefinitionError() {}
+func (e *duplicateUserDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *duplicateUserDefinitionError) isQueryError() {}
+func (e *duplicateUserDefinitionError) isEdgeDBQueryError() {}
 
-func (e *duplicateUserDefinitionError) isError() {}
+func (e *duplicateUserDefinitionError) isEdgeDBError() {}
 
 // DuplicateDatabaseDefinitionError is an error.
 type DuplicateDatabaseDefinitionError interface {
 	DuplicateDefinitionError
-	isDuplicateDatabaseDefinitionError()
+	isEdgeDBDuplicateDatabaseDefinitionError()
 }
 
 type duplicateDatabaseDefinitionError struct {
@@ -1333,20 +1333,20 @@ func (e *duplicateDatabaseDefinitionError) Error() string {
 
 func (e *duplicateDatabaseDefinitionError) Unwrap() error { return e.err }
 
-func (e *duplicateDatabaseDefinitionError) isDuplicateDatabaseDefinitionError() {}
+func (e *duplicateDatabaseDefinitionError) isEdgeDBDuplicateDatabaseDefinitionError() {}
 
-func (e *duplicateDatabaseDefinitionError) isDuplicateDefinitionError() {}
+func (e *duplicateDatabaseDefinitionError) isEdgeDBDuplicateDefinitionError() {}
 
-func (e *duplicateDatabaseDefinitionError) isSchemaDefinitionError() {}
+func (e *duplicateDatabaseDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *duplicateDatabaseDefinitionError) isQueryError() {}
+func (e *duplicateDatabaseDefinitionError) isEdgeDBQueryError() {}
 
-func (e *duplicateDatabaseDefinitionError) isError() {}
+func (e *duplicateDatabaseDefinitionError) isEdgeDBError() {}
 
 // DuplicateOperatorDefinitionError is an error.
 type DuplicateOperatorDefinitionError interface {
 	DuplicateDefinitionError
-	isDuplicateOperatorDefinitionError()
+	isEdgeDBDuplicateOperatorDefinitionError()
 }
 
 type duplicateOperatorDefinitionError struct {
@@ -1365,20 +1365,20 @@ func (e *duplicateOperatorDefinitionError) Error() string {
 
 func (e *duplicateOperatorDefinitionError) Unwrap() error { return e.err }
 
-func (e *duplicateOperatorDefinitionError) isDuplicateOperatorDefinitionError() {}
+func (e *duplicateOperatorDefinitionError) isEdgeDBDuplicateOperatorDefinitionError() {}
 
-func (e *duplicateOperatorDefinitionError) isDuplicateDefinitionError() {}
+func (e *duplicateOperatorDefinitionError) isEdgeDBDuplicateDefinitionError() {}
 
-func (e *duplicateOperatorDefinitionError) isSchemaDefinitionError() {}
+func (e *duplicateOperatorDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *duplicateOperatorDefinitionError) isQueryError() {}
+func (e *duplicateOperatorDefinitionError) isEdgeDBQueryError() {}
 
-func (e *duplicateOperatorDefinitionError) isError() {}
+func (e *duplicateOperatorDefinitionError) isEdgeDBError() {}
 
 // DuplicateViewDefinitionError is an error.
 type DuplicateViewDefinitionError interface {
 	DuplicateDefinitionError
-	isDuplicateViewDefinitionError()
+	isEdgeDBDuplicateViewDefinitionError()
 }
 
 type duplicateViewDefinitionError struct {
@@ -1397,20 +1397,20 @@ func (e *duplicateViewDefinitionError) Error() string {
 
 func (e *duplicateViewDefinitionError) Unwrap() error { return e.err }
 
-func (e *duplicateViewDefinitionError) isDuplicateViewDefinitionError() {}
+func (e *duplicateViewDefinitionError) isEdgeDBDuplicateViewDefinitionError() {}
 
-func (e *duplicateViewDefinitionError) isDuplicateDefinitionError() {}
+func (e *duplicateViewDefinitionError) isEdgeDBDuplicateDefinitionError() {}
 
-func (e *duplicateViewDefinitionError) isSchemaDefinitionError() {}
+func (e *duplicateViewDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *duplicateViewDefinitionError) isQueryError() {}
+func (e *duplicateViewDefinitionError) isEdgeDBQueryError() {}
 
-func (e *duplicateViewDefinitionError) isError() {}
+func (e *duplicateViewDefinitionError) isEdgeDBError() {}
 
 // DuplicateFunctionDefinitionError is an error.
 type DuplicateFunctionDefinitionError interface {
 	DuplicateDefinitionError
-	isDuplicateFunctionDefinitionError()
+	isEdgeDBDuplicateFunctionDefinitionError()
 }
 
 type duplicateFunctionDefinitionError struct {
@@ -1429,20 +1429,20 @@ func (e *duplicateFunctionDefinitionError) Error() string {
 
 func (e *duplicateFunctionDefinitionError) Unwrap() error { return e.err }
 
-func (e *duplicateFunctionDefinitionError) isDuplicateFunctionDefinitionError() {}
+func (e *duplicateFunctionDefinitionError) isEdgeDBDuplicateFunctionDefinitionError() {}
 
-func (e *duplicateFunctionDefinitionError) isDuplicateDefinitionError() {}
+func (e *duplicateFunctionDefinitionError) isEdgeDBDuplicateDefinitionError() {}
 
-func (e *duplicateFunctionDefinitionError) isSchemaDefinitionError() {}
+func (e *duplicateFunctionDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *duplicateFunctionDefinitionError) isQueryError() {}
+func (e *duplicateFunctionDefinitionError) isEdgeDBQueryError() {}
 
-func (e *duplicateFunctionDefinitionError) isError() {}
+func (e *duplicateFunctionDefinitionError) isEdgeDBError() {}
 
 // DuplicateConstraintDefinitionError is an error.
 type DuplicateConstraintDefinitionError interface {
 	DuplicateDefinitionError
-	isDuplicateConstraintDefinitionError()
+	isEdgeDBDuplicateConstraintDefinitionError()
 }
 
 type duplicateConstraintDefinitionError struct {
@@ -1461,20 +1461,20 @@ func (e *duplicateConstraintDefinitionError) Error() string {
 
 func (e *duplicateConstraintDefinitionError) Unwrap() error { return e.err }
 
-func (e *duplicateConstraintDefinitionError) isDuplicateConstraintDefinitionError() {}
+func (e *duplicateConstraintDefinitionError) isEdgeDBDuplicateConstraintDefinitionError() {}
 
-func (e *duplicateConstraintDefinitionError) isDuplicateDefinitionError() {}
+func (e *duplicateConstraintDefinitionError) isEdgeDBDuplicateDefinitionError() {}
 
-func (e *duplicateConstraintDefinitionError) isSchemaDefinitionError() {}
+func (e *duplicateConstraintDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *duplicateConstraintDefinitionError) isQueryError() {}
+func (e *duplicateConstraintDefinitionError) isEdgeDBQueryError() {}
 
-func (e *duplicateConstraintDefinitionError) isError() {}
+func (e *duplicateConstraintDefinitionError) isEdgeDBError() {}
 
 // DuplicateCastDefinitionError is an error.
 type DuplicateCastDefinitionError interface {
 	DuplicateDefinitionError
-	isDuplicateCastDefinitionError()
+	isEdgeDBDuplicateCastDefinitionError()
 }
 
 type duplicateCastDefinitionError struct {
@@ -1493,20 +1493,20 @@ func (e *duplicateCastDefinitionError) Error() string {
 
 func (e *duplicateCastDefinitionError) Unwrap() error { return e.err }
 
-func (e *duplicateCastDefinitionError) isDuplicateCastDefinitionError() {}
+func (e *duplicateCastDefinitionError) isEdgeDBDuplicateCastDefinitionError() {}
 
-func (e *duplicateCastDefinitionError) isDuplicateDefinitionError() {}
+func (e *duplicateCastDefinitionError) isEdgeDBDuplicateDefinitionError() {}
 
-func (e *duplicateCastDefinitionError) isSchemaDefinitionError() {}
+func (e *duplicateCastDefinitionError) isEdgeDBSchemaDefinitionError() {}
 
-func (e *duplicateCastDefinitionError) isQueryError() {}
+func (e *duplicateCastDefinitionError) isEdgeDBQueryError() {}
 
-func (e *duplicateCastDefinitionError) isError() {}
+func (e *duplicateCastDefinitionError) isEdgeDBError() {}
 
 // QueryTimeoutError is an error.
 type QueryTimeoutError interface {
 	QueryError
-	isQueryTimeoutError()
+	isEdgeDBQueryTimeoutError()
 }
 
 type queryTimeoutError struct {
@@ -1525,16 +1525,16 @@ func (e *queryTimeoutError) Error() string {
 
 func (e *queryTimeoutError) Unwrap() error { return e.err }
 
-func (e *queryTimeoutError) isQueryTimeoutError() {}
+func (e *queryTimeoutError) isEdgeDBQueryTimeoutError() {}
 
-func (e *queryTimeoutError) isQueryError() {}
+func (e *queryTimeoutError) isEdgeDBQueryError() {}
 
-func (e *queryTimeoutError) isError() {}
+func (e *queryTimeoutError) isEdgeDBError() {}
 
 // ExecutionError is an error.
 type ExecutionError interface {
 	Error
-	isExecutionError()
+	isEdgeDBExecutionError()
 }
 
 type executionError struct {
@@ -1553,14 +1553,14 @@ func (e *executionError) Error() string {
 
 func (e *executionError) Unwrap() error { return e.err }
 
-func (e *executionError) isExecutionError() {}
+func (e *executionError) isEdgeDBExecutionError() {}
 
-func (e *executionError) isError() {}
+func (e *executionError) isEdgeDBError() {}
 
 // InvalidValueError is an error.
 type InvalidValueError interface {
 	ExecutionError
-	isInvalidValueError()
+	isEdgeDBInvalidValueError()
 }
 
 type invalidValueError struct {
@@ -1579,16 +1579,16 @@ func (e *invalidValueError) Error() string {
 
 func (e *invalidValueError) Unwrap() error { return e.err }
 
-func (e *invalidValueError) isInvalidValueError() {}
+func (e *invalidValueError) isEdgeDBInvalidValueError() {}
 
-func (e *invalidValueError) isExecutionError() {}
+func (e *invalidValueError) isEdgeDBExecutionError() {}
 
-func (e *invalidValueError) isError() {}
+func (e *invalidValueError) isEdgeDBError() {}
 
 // DivisionByZeroError is an error.
 type DivisionByZeroError interface {
 	InvalidValueError
-	isDivisionByZeroError()
+	isEdgeDBDivisionByZeroError()
 }
 
 type divisionByZeroError struct {
@@ -1607,18 +1607,18 @@ func (e *divisionByZeroError) Error() string {
 
 func (e *divisionByZeroError) Unwrap() error { return e.err }
 
-func (e *divisionByZeroError) isDivisionByZeroError() {}
+func (e *divisionByZeroError) isEdgeDBDivisionByZeroError() {}
 
-func (e *divisionByZeroError) isInvalidValueError() {}
+func (e *divisionByZeroError) isEdgeDBInvalidValueError() {}
 
-func (e *divisionByZeroError) isExecutionError() {}
+func (e *divisionByZeroError) isEdgeDBExecutionError() {}
 
-func (e *divisionByZeroError) isError() {}
+func (e *divisionByZeroError) isEdgeDBError() {}
 
 // NumericOutOfRangeError is an error.
 type NumericOutOfRangeError interface {
 	InvalidValueError
-	isNumericOutOfRangeError()
+	isEdgeDBNumericOutOfRangeError()
 }
 
 type numericOutOfRangeError struct {
@@ -1637,18 +1637,18 @@ func (e *numericOutOfRangeError) Error() string {
 
 func (e *numericOutOfRangeError) Unwrap() error { return e.err }
 
-func (e *numericOutOfRangeError) isNumericOutOfRangeError() {}
+func (e *numericOutOfRangeError) isEdgeDBNumericOutOfRangeError() {}
 
-func (e *numericOutOfRangeError) isInvalidValueError() {}
+func (e *numericOutOfRangeError) isEdgeDBInvalidValueError() {}
 
-func (e *numericOutOfRangeError) isExecutionError() {}
+func (e *numericOutOfRangeError) isEdgeDBExecutionError() {}
 
-func (e *numericOutOfRangeError) isError() {}
+func (e *numericOutOfRangeError) isEdgeDBError() {}
 
 // IntegrityError is an error.
 type IntegrityError interface {
 	ExecutionError
-	isIntegrityError()
+	isEdgeDBIntegrityError()
 }
 
 type integrityError struct {
@@ -1667,16 +1667,16 @@ func (e *integrityError) Error() string {
 
 func (e *integrityError) Unwrap() error { return e.err }
 
-func (e *integrityError) isIntegrityError() {}
+func (e *integrityError) isEdgeDBIntegrityError() {}
 
-func (e *integrityError) isExecutionError() {}
+func (e *integrityError) isEdgeDBExecutionError() {}
 
-func (e *integrityError) isError() {}
+func (e *integrityError) isEdgeDBError() {}
 
 // ConstraintViolationError is an error.
 type ConstraintViolationError interface {
 	IntegrityError
-	isConstraintViolationError()
+	isEdgeDBConstraintViolationError()
 }
 
 type constraintViolationError struct {
@@ -1695,18 +1695,18 @@ func (e *constraintViolationError) Error() string {
 
 func (e *constraintViolationError) Unwrap() error { return e.err }
 
-func (e *constraintViolationError) isConstraintViolationError() {}
+func (e *constraintViolationError) isEdgeDBConstraintViolationError() {}
 
-func (e *constraintViolationError) isIntegrityError() {}
+func (e *constraintViolationError) isEdgeDBIntegrityError() {}
 
-func (e *constraintViolationError) isExecutionError() {}
+func (e *constraintViolationError) isEdgeDBExecutionError() {}
 
-func (e *constraintViolationError) isError() {}
+func (e *constraintViolationError) isEdgeDBError() {}
 
 // CardinalityViolationError is an error.
 type CardinalityViolationError interface {
 	IntegrityError
-	isCardinalityViolationError()
+	isEdgeDBCardinalityViolationError()
 }
 
 type cardinalityViolationError struct {
@@ -1725,18 +1725,18 @@ func (e *cardinalityViolationError) Error() string {
 
 func (e *cardinalityViolationError) Unwrap() error { return e.err }
 
-func (e *cardinalityViolationError) isCardinalityViolationError() {}
+func (e *cardinalityViolationError) isEdgeDBCardinalityViolationError() {}
 
-func (e *cardinalityViolationError) isIntegrityError() {}
+func (e *cardinalityViolationError) isEdgeDBIntegrityError() {}
 
-func (e *cardinalityViolationError) isExecutionError() {}
+func (e *cardinalityViolationError) isEdgeDBExecutionError() {}
 
-func (e *cardinalityViolationError) isError() {}
+func (e *cardinalityViolationError) isEdgeDBError() {}
 
 // MissingRequiredError is an error.
 type MissingRequiredError interface {
 	IntegrityError
-	isMissingRequiredError()
+	isEdgeDBMissingRequiredError()
 }
 
 type missingRequiredError struct {
@@ -1755,18 +1755,18 @@ func (e *missingRequiredError) Error() string {
 
 func (e *missingRequiredError) Unwrap() error { return e.err }
 
-func (e *missingRequiredError) isMissingRequiredError() {}
+func (e *missingRequiredError) isEdgeDBMissingRequiredError() {}
 
-func (e *missingRequiredError) isIntegrityError() {}
+func (e *missingRequiredError) isEdgeDBIntegrityError() {}
 
-func (e *missingRequiredError) isExecutionError() {}
+func (e *missingRequiredError) isEdgeDBExecutionError() {}
 
-func (e *missingRequiredError) isError() {}
+func (e *missingRequiredError) isEdgeDBError() {}
 
 // TransactionError is an error.
 type TransactionError interface {
 	ExecutionError
-	isTransactionError()
+	isEdgeDBTransactionError()
 }
 
 type transactionError struct {
@@ -1785,16 +1785,16 @@ func (e *transactionError) Error() string {
 
 func (e *transactionError) Unwrap() error { return e.err }
 
-func (e *transactionError) isTransactionError() {}
+func (e *transactionError) isEdgeDBTransactionError() {}
 
-func (e *transactionError) isExecutionError() {}
+func (e *transactionError) isEdgeDBExecutionError() {}
 
-func (e *transactionError) isError() {}
+func (e *transactionError) isEdgeDBError() {}
 
 // TransactionSerializationError is an error.
 type TransactionSerializationError interface {
 	TransactionError
-	isTransactionSerializationError()
+	isEdgeDBTransactionSerializationError()
 }
 
 type transactionSerializationError struct {
@@ -1813,18 +1813,18 @@ func (e *transactionSerializationError) Error() string {
 
 func (e *transactionSerializationError) Unwrap() error { return e.err }
 
-func (e *transactionSerializationError) isTransactionSerializationError() {}
+func (e *transactionSerializationError) isEdgeDBTransactionSerializationError() {}
 
-func (e *transactionSerializationError) isTransactionError() {}
+func (e *transactionSerializationError) isEdgeDBTransactionError() {}
 
-func (e *transactionSerializationError) isExecutionError() {}
+func (e *transactionSerializationError) isEdgeDBExecutionError() {}
 
-func (e *transactionSerializationError) isError() {}
+func (e *transactionSerializationError) isEdgeDBError() {}
 
 // TransactionDeadlockError is an error.
 type TransactionDeadlockError interface {
 	TransactionError
-	isTransactionDeadlockError()
+	isEdgeDBTransactionDeadlockError()
 }
 
 type transactionDeadlockError struct {
@@ -1843,18 +1843,18 @@ func (e *transactionDeadlockError) Error() string {
 
 func (e *transactionDeadlockError) Unwrap() error { return e.err }
 
-func (e *transactionDeadlockError) isTransactionDeadlockError() {}
+func (e *transactionDeadlockError) isEdgeDBTransactionDeadlockError() {}
 
-func (e *transactionDeadlockError) isTransactionError() {}
+func (e *transactionDeadlockError) isEdgeDBTransactionError() {}
 
-func (e *transactionDeadlockError) isExecutionError() {}
+func (e *transactionDeadlockError) isEdgeDBExecutionError() {}
 
-func (e *transactionDeadlockError) isError() {}
+func (e *transactionDeadlockError) isEdgeDBError() {}
 
 // ConfigurationError is an error.
 type ConfigurationError interface {
 	Error
-	isConfigurationError()
+	isEdgeDBConfigurationError()
 }
 
 type configurationError struct {
@@ -1873,14 +1873,14 @@ func (e *configurationError) Error() string {
 
 func (e *configurationError) Unwrap() error { return e.err }
 
-func (e *configurationError) isConfigurationError() {}
+func (e *configurationError) isEdgeDBConfigurationError() {}
 
-func (e *configurationError) isError() {}
+func (e *configurationError) isEdgeDBError() {}
 
 // AccessError is an error.
 type AccessError interface {
 	Error
-	isAccessError()
+	isEdgeDBAccessError()
 }
 
 type accessError struct {
@@ -1899,14 +1899,14 @@ func (e *accessError) Error() string {
 
 func (e *accessError) Unwrap() error { return e.err }
 
-func (e *accessError) isAccessError() {}
+func (e *accessError) isEdgeDBAccessError() {}
 
-func (e *accessError) isError() {}
+func (e *accessError) isEdgeDBError() {}
 
 // AuthenticationError is an error.
 type AuthenticationError interface {
 	AccessError
-	isAuthenticationError()
+	isEdgeDBAuthenticationError()
 }
 
 type authenticationError struct {
@@ -1925,16 +1925,16 @@ func (e *authenticationError) Error() string {
 
 func (e *authenticationError) Unwrap() error { return e.err }
 
-func (e *authenticationError) isAuthenticationError() {}
+func (e *authenticationError) isEdgeDBAuthenticationError() {}
 
-func (e *authenticationError) isAccessError() {}
+func (e *authenticationError) isEdgeDBAccessError() {}
 
-func (e *authenticationError) isError() {}
+func (e *authenticationError) isEdgeDBError() {}
 
 // LogMessage is an error.
 type LogMessage interface {
 	Error
-	isLogMessage()
+	isEdgeDBLogMessage()
 }
 
 type logMessage struct {
@@ -1953,14 +1953,14 @@ func (e *logMessage) Error() string {
 
 func (e *logMessage) Unwrap() error { return e.err }
 
-func (e *logMessage) isLogMessage() {}
+func (e *logMessage) isEdgeDBLogMessage() {}
 
-func (e *logMessage) isError() {}
+func (e *logMessage) isEdgeDBError() {}
 
 // WarningMessage is an error.
 type WarningMessage interface {
 	Error
-	isWarningMessage()
+	isEdgeDBWarningMessage()
 }
 
 type warningMessage struct {
@@ -1979,14 +1979,14 @@ func (e *warningMessage) Error() string {
 
 func (e *warningMessage) Unwrap() error { return e.err }
 
-func (e *warningMessage) isWarningMessage() {}
+func (e *warningMessage) isEdgeDBWarningMessage() {}
 
-func (e *warningMessage) isError() {}
+func (e *warningMessage) isEdgeDBError() {}
 
 // ClientError is an error.
 type ClientError interface {
 	Error
-	isClientError()
+	isEdgeDBClientError()
 }
 
 type clientError struct {
@@ -2005,14 +2005,14 @@ func (e *clientError) Error() string {
 
 func (e *clientError) Unwrap() error { return e.err }
 
-func (e *clientError) isClientError() {}
+func (e *clientError) isEdgeDBClientError() {}
 
-func (e *clientError) isError() {}
+func (e *clientError) isEdgeDBError() {}
 
 // ClientConnectionError is an error.
 type ClientConnectionError interface {
 	ClientError
-	isClientConnectionError()
+	isEdgeDBClientConnectionError()
 }
 
 type clientConnectionError struct {
@@ -2031,16 +2031,16 @@ func (e *clientConnectionError) Error() string {
 
 func (e *clientConnectionError) Unwrap() error { return e.err }
 
-func (e *clientConnectionError) isClientConnectionError() {}
+func (e *clientConnectionError) isEdgeDBClientConnectionError() {}
 
-func (e *clientConnectionError) isClientError() {}
+func (e *clientConnectionError) isEdgeDBClientError() {}
 
-func (e *clientConnectionError) isError() {}
+func (e *clientConnectionError) isEdgeDBError() {}
 
 // InterfaceError is an error.
 type InterfaceError interface {
 	ClientError
-	isInterfaceError()
+	isEdgeDBInterfaceError()
 }
 
 type interfaceError struct {
@@ -2059,16 +2059,16 @@ func (e *interfaceError) Error() string {
 
 func (e *interfaceError) Unwrap() error { return e.err }
 
-func (e *interfaceError) isInterfaceError() {}
+func (e *interfaceError) isEdgeDBInterfaceError() {}
 
-func (e *interfaceError) isClientError() {}
+func (e *interfaceError) isEdgeDBClientError() {}
 
-func (e *interfaceError) isError() {}
+func (e *interfaceError) isEdgeDBError() {}
 
 // QueryArgumentError is an error.
 type QueryArgumentError interface {
 	InterfaceError
-	isQueryArgumentError()
+	isEdgeDBQueryArgumentError()
 }
 
 type queryArgumentError struct {
@@ -2087,18 +2087,18 @@ func (e *queryArgumentError) Error() string {
 
 func (e *queryArgumentError) Unwrap() error { return e.err }
 
-func (e *queryArgumentError) isQueryArgumentError() {}
+func (e *queryArgumentError) isEdgeDBQueryArgumentError() {}
 
-func (e *queryArgumentError) isInterfaceError() {}
+func (e *queryArgumentError) isEdgeDBInterfaceError() {}
 
-func (e *queryArgumentError) isClientError() {}
+func (e *queryArgumentError) isEdgeDBClientError() {}
 
-func (e *queryArgumentError) isError() {}
+func (e *queryArgumentError) isEdgeDBError() {}
 
 // MissingArgumentError is an error.
 type MissingArgumentError interface {
 	QueryArgumentError
-	isMissingArgumentError()
+	isEdgeDBMissingArgumentError()
 }
 
 type missingArgumentError struct {
@@ -2117,20 +2117,20 @@ func (e *missingArgumentError) Error() string {
 
 func (e *missingArgumentError) Unwrap() error { return e.err }
 
-func (e *missingArgumentError) isMissingArgumentError() {}
+func (e *missingArgumentError) isEdgeDBMissingArgumentError() {}
 
-func (e *missingArgumentError) isQueryArgumentError() {}
+func (e *missingArgumentError) isEdgeDBQueryArgumentError() {}
 
-func (e *missingArgumentError) isInterfaceError() {}
+func (e *missingArgumentError) isEdgeDBInterfaceError() {}
 
-func (e *missingArgumentError) isClientError() {}
+func (e *missingArgumentError) isEdgeDBClientError() {}
 
-func (e *missingArgumentError) isError() {}
+func (e *missingArgumentError) isEdgeDBError() {}
 
 // UnknownArgumentError is an error.
 type UnknownArgumentError interface {
 	QueryArgumentError
-	isUnknownArgumentError()
+	isEdgeDBUnknownArgumentError()
 }
 
 type unknownArgumentError struct {
@@ -2149,20 +2149,20 @@ func (e *unknownArgumentError) Error() string {
 
 func (e *unknownArgumentError) Unwrap() error { return e.err }
 
-func (e *unknownArgumentError) isUnknownArgumentError() {}
+func (e *unknownArgumentError) isEdgeDBUnknownArgumentError() {}
 
-func (e *unknownArgumentError) isQueryArgumentError() {}
+func (e *unknownArgumentError) isEdgeDBQueryArgumentError() {}
 
-func (e *unknownArgumentError) isInterfaceError() {}
+func (e *unknownArgumentError) isEdgeDBInterfaceError() {}
 
-func (e *unknownArgumentError) isClientError() {}
+func (e *unknownArgumentError) isEdgeDBClientError() {}
 
-func (e *unknownArgumentError) isError() {}
+func (e *unknownArgumentError) isEdgeDBError() {}
 
 // InvalidArgumentError is an error.
 type InvalidArgumentError interface {
 	QueryArgumentError
-	isInvalidArgumentError()
+	isEdgeDBInvalidArgumentError()
 }
 
 type invalidArgumentError struct {
@@ -2181,20 +2181,20 @@ func (e *invalidArgumentError) Error() string {
 
 func (e *invalidArgumentError) Unwrap() error { return e.err }
 
-func (e *invalidArgumentError) isInvalidArgumentError() {}
+func (e *invalidArgumentError) isEdgeDBInvalidArgumentError() {}
 
-func (e *invalidArgumentError) isQueryArgumentError() {}
+func (e *invalidArgumentError) isEdgeDBQueryArgumentError() {}
 
-func (e *invalidArgumentError) isInterfaceError() {}
+func (e *invalidArgumentError) isEdgeDBInterfaceError() {}
 
-func (e *invalidArgumentError) isClientError() {}
+func (e *invalidArgumentError) isEdgeDBClientError() {}
 
-func (e *invalidArgumentError) isError() {}
+func (e *invalidArgumentError) isEdgeDBError() {}
 
 // NoDataError is an error.
 type NoDataError interface {
 	ClientError
-	isNoDataError()
+	isEdgeDBNoDataError()
 }
 
 type noDataError struct {
@@ -2213,11 +2213,11 @@ func (e *noDataError) Error() string {
 
 func (e *noDataError) Unwrap() error { return e.err }
 
-func (e *noDataError) isNoDataError() {}
+func (e *noDataError) isEdgeDBNoDataError() {}
 
-func (e *noDataError) isClientError() {}
+func (e *noDataError) isEdgeDBClientError() {}
 
-func (e *noDataError) isError() {}
+func (e *noDataError) isEdgeDBError() {}
 
 func errorFromCode(code uint32, msg string) error {
 	switch code {

--- a/generatederrors.go
+++ b/generatederrors.go
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 // This file is auto generated. Do not edit!
+// run 'make errors' to regenerate
 
 package edgedb
 

--- a/generatederrors.go
+++ b/generatederrors.go
@@ -1,0 +1,688 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is auto generated. Do not edit!
+
+package edgedb
+
+import "fmt"
+
+const (
+	internalServerErrorCode uint32 = 0x01_00_00_00
+	unsupportedFeatureErrorCode uint32 = 0x02_00_00_00
+	protocolErrorCode uint32 = 0x03_00_00_00
+	binaryProtocolErrorCode uint32 = 0x03_01_00_00
+	unsupportedProtocolVersionErrorCode uint32 = 0x03_01_00_01
+	typeSpecNotFoundErrorCode uint32 = 0x03_01_00_02
+	unexpectedMessageErrorCode uint32 = 0x03_01_00_03
+	inputDataErrorCode uint32 = 0x03_02_00_00
+	resultCardinalityMismatchErrorCode uint32 = 0x03_03_00_00
+	queryErrorCode uint32 = 0x04_00_00_00
+	invalidSyntaxErrorCode uint32 = 0x04_01_00_00
+	edgeQLSyntaxErrorCode uint32 = 0x04_01_01_00
+	schemaSyntaxErrorCode uint32 = 0x04_01_02_00
+	graphQLSyntaxErrorCode uint32 = 0x04_01_03_00
+	invalidTypeErrorCode uint32 = 0x04_02_00_00
+	invalidTargetErrorCode uint32 = 0x04_02_01_00
+	invalidLinkTargetErrorCode uint32 = 0x04_02_01_01
+	invalidPropertyTargetErrorCode uint32 = 0x04_02_01_02
+	invalidReferenceErrorCode uint32 = 0x04_03_00_00
+	unknownModuleErrorCode uint32 = 0x04_03_00_01
+	unknownLinkErrorCode uint32 = 0x04_03_00_02
+	unknownPropertyErrorCode uint32 = 0x04_03_00_03
+	unknownUserErrorCode uint32 = 0x04_03_00_04
+	unknownDatabaseErrorCode uint32 = 0x04_03_00_05
+	unknownParameterErrorCode uint32 = 0x04_03_00_06
+	schemaErrorCode uint32 = 0x04_04_00_00
+	schemaDefinitionErrorCode uint32 = 0x04_05_00_00
+	invalidDefinitionErrorCode uint32 = 0x04_05_01_00
+	invalidModuleDefinitionErrorCode uint32 = 0x04_05_01_01
+	invalidLinkDefinitionErrorCode uint32 = 0x04_05_01_02
+	invalidPropertyDefinitionErrorCode uint32 = 0x04_05_01_03
+	invalidUserDefinitionErrorCode uint32 = 0x04_05_01_04
+	invalidDatabaseDefinitionErrorCode uint32 = 0x04_05_01_05
+	invalidOperatorDefinitionErrorCode uint32 = 0x04_05_01_06
+	invalidAliasDefinitionErrorCode uint32 = 0x04_05_01_07
+	invalidFunctionDefinitionErrorCode uint32 = 0x04_05_01_08
+	invalidConstraintDefinitionErrorCode uint32 = 0x04_05_01_09
+	invalidCastDefinitionErrorCode uint32 = 0x04_05_01_0a
+	duplicateDefinitionErrorCode uint32 = 0x04_05_02_00
+	duplicateModuleDefinitionErrorCode uint32 = 0x04_05_02_01
+	duplicateLinkDefinitionErrorCode uint32 = 0x04_05_02_02
+	duplicatePropertyDefinitionErrorCode uint32 = 0x04_05_02_03
+	duplicateUserDefinitionErrorCode uint32 = 0x04_05_02_04
+	duplicateDatabaseDefinitionErrorCode uint32 = 0x04_05_02_05
+	duplicateOperatorDefinitionErrorCode uint32 = 0x04_05_02_06
+	duplicateViewDefinitionErrorCode uint32 = 0x04_05_02_07
+	duplicateFunctionDefinitionErrorCode uint32 = 0x04_05_02_08
+	duplicateConstraintDefinitionErrorCode uint32 = 0x04_05_02_09
+	duplicateCastDefinitionErrorCode uint32 = 0x04_05_02_0a
+	queryTimeoutErrorCode uint32 = 0x04_06_00_00
+	executionErrorCode uint32 = 0x05_00_00_00
+	invalidValueErrorCode uint32 = 0x05_01_00_00
+	divisionByZeroErrorCode uint32 = 0x05_01_00_01
+	numericOutOfRangeErrorCode uint32 = 0x05_01_00_02
+	integrityErrorCode uint32 = 0x05_02_00_00
+	constraintViolationErrorCode uint32 = 0x05_02_00_01
+	cardinalityViolationErrorCode uint32 = 0x05_02_00_02
+	missingRequiredErrorCode uint32 = 0x05_02_00_03
+	transactionErrorCode uint32 = 0x05_03_00_00
+	transactionSerializationErrorCode uint32 = 0x05_03_00_01
+	transactionDeadlockErrorCode uint32 = 0x05_03_00_02
+	configurationErrorCode uint32 = 0x06_00_00_00
+	accessErrorCode uint32 = 0x07_00_00_00
+	authenticationErrorCode uint32 = 0x07_01_00_00
+	clientErrorCode uint32 = 0xff_00_00_00
+	clientConnectionErrorCode uint32 = 0xff_01_00_00
+	interfaceErrorCode uint32 = 0xff_02_00_00
+	queryArgumentErrorCode uint32 = 0xff_02_01_00
+	missingArgumentErrorCode uint32 = 0xff_02_01_01
+	unknownArgumentErrorCode uint32 = 0xff_02_01_02
+	invalidArgumentErrorCode uint32 = 0xff_02_01_03
+	noDataErrorCode uint32 = 0xff_03_00_00
+)
+
+// newErrorFromCode returns a new edgedb error.
+func newErrorFromCode(code uint32, msg string) error {
+	switch code {
+	case internalServerErrorCode:
+		tail := &baseError{msg: "edgedb: " + msg}
+		base := &baseError{err: &Error{tail}}
+		return &InternalServerError{base}
+	case unsupportedFeatureErrorCode:
+		tail := &baseError{msg: "edgedb: " + msg}
+		base := &baseError{err: &Error{tail}}
+		return &UnsupportedFeatureError{base}
+	case protocolErrorCode:
+		tail := &baseError{msg: "edgedb: " + msg}
+		base := &baseError{err: &Error{tail}}
+		return &ProtocolError{base}
+	case binaryProtocolErrorCode:
+		base := &baseError{err: newErrorFromCode(protocolErrorCode, msg)}
+		return &BinaryProtocolError{base}
+	case unsupportedProtocolVersionErrorCode:
+		base := &baseError{err: newErrorFromCode(binaryProtocolErrorCode, msg)}
+		return &UnsupportedProtocolVersionError{base}
+	case typeSpecNotFoundErrorCode:
+		base := &baseError{err: newErrorFromCode(binaryProtocolErrorCode, msg)}
+		return &TypeSpecNotFoundError{base}
+	case unexpectedMessageErrorCode:
+		base := &baseError{err: newErrorFromCode(binaryProtocolErrorCode, msg)}
+		return &UnexpectedMessageError{base}
+	case inputDataErrorCode:
+		base := &baseError{err: newErrorFromCode(protocolErrorCode, msg)}
+		return &InputDataError{base}
+	case resultCardinalityMismatchErrorCode:
+		base := &baseError{err: newErrorFromCode(protocolErrorCode, msg)}
+		return &ResultCardinalityMismatchError{base}
+	case queryErrorCode:
+		tail := &baseError{msg: "edgedb: " + msg}
+		base := &baseError{err: &Error{tail}}
+		return &QueryError{base}
+	case invalidSyntaxErrorCode:
+		base := &baseError{err: newErrorFromCode(queryErrorCode, msg)}
+		return &InvalidSyntaxError{base}
+	case edgeQLSyntaxErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidSyntaxErrorCode, msg)}
+		return &EdgeQLSyntaxError{base}
+	case schemaSyntaxErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidSyntaxErrorCode, msg)}
+		return &SchemaSyntaxError{base}
+	case graphQLSyntaxErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidSyntaxErrorCode, msg)}
+		return &GraphQLSyntaxError{base}
+	case invalidTypeErrorCode:
+		base := &baseError{err: newErrorFromCode(queryErrorCode, msg)}
+		return &InvalidTypeError{base}
+	case invalidTargetErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidTypeErrorCode, msg)}
+		return &InvalidTargetError{base}
+	case invalidLinkTargetErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidTargetErrorCode, msg)}
+		return &InvalidLinkTargetError{base}
+	case invalidPropertyTargetErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidTargetErrorCode, msg)}
+		return &InvalidPropertyTargetError{base}
+	case invalidReferenceErrorCode:
+		base := &baseError{err: newErrorFromCode(queryErrorCode, msg)}
+		return &InvalidReferenceError{base}
+	case unknownModuleErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidReferenceErrorCode, msg)}
+		return &UnknownModuleError{base}
+	case unknownLinkErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidReferenceErrorCode, msg)}
+		return &UnknownLinkError{base}
+	case unknownPropertyErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidReferenceErrorCode, msg)}
+		return &UnknownPropertyError{base}
+	case unknownUserErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidReferenceErrorCode, msg)}
+		return &UnknownUserError{base}
+	case unknownDatabaseErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidReferenceErrorCode, msg)}
+		return &UnknownDatabaseError{base}
+	case unknownParameterErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidReferenceErrorCode, msg)}
+		return &UnknownParameterError{base}
+	case schemaErrorCode:
+		base := &baseError{err: newErrorFromCode(queryErrorCode, msg)}
+		return &SchemaError{base}
+	case schemaDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(queryErrorCode, msg)}
+		return &SchemaDefinitionError{base}
+	case invalidDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(schemaDefinitionErrorCode, msg)}
+		return &InvalidDefinitionError{base}
+	case invalidModuleDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
+		return &InvalidModuleDefinitionError{base}
+	case invalidLinkDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
+		return &InvalidLinkDefinitionError{base}
+	case invalidPropertyDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
+		return &InvalidPropertyDefinitionError{base}
+	case invalidUserDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
+		return &InvalidUserDefinitionError{base}
+	case invalidDatabaseDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
+		return &InvalidDatabaseDefinitionError{base}
+	case invalidOperatorDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
+		return &InvalidOperatorDefinitionError{base}
+	case invalidAliasDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
+		return &InvalidAliasDefinitionError{base}
+	case invalidFunctionDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
+		return &InvalidFunctionDefinitionError{base}
+	case invalidConstraintDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
+		return &InvalidConstraintDefinitionError{base}
+	case invalidCastDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidDefinitionErrorCode, msg)}
+		return &InvalidCastDefinitionError{base}
+	case duplicateDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(schemaDefinitionErrorCode, msg)}
+		return &DuplicateDefinitionError{base}
+	case duplicateModuleDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
+		return &DuplicateModuleDefinitionError{base}
+	case duplicateLinkDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
+		return &DuplicateLinkDefinitionError{base}
+	case duplicatePropertyDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
+		return &DuplicatePropertyDefinitionError{base}
+	case duplicateUserDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
+		return &DuplicateUserDefinitionError{base}
+	case duplicateDatabaseDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
+		return &DuplicateDatabaseDefinitionError{base}
+	case duplicateOperatorDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
+		return &DuplicateOperatorDefinitionError{base}
+	case duplicateViewDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
+		return &DuplicateViewDefinitionError{base}
+	case duplicateFunctionDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
+		return &DuplicateFunctionDefinitionError{base}
+	case duplicateConstraintDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
+		return &DuplicateConstraintDefinitionError{base}
+	case duplicateCastDefinitionErrorCode:
+		base := &baseError{err: newErrorFromCode(duplicateDefinitionErrorCode, msg)}
+		return &DuplicateCastDefinitionError{base}
+	case queryTimeoutErrorCode:
+		base := &baseError{err: newErrorFromCode(queryErrorCode, msg)}
+		return &QueryTimeoutError{base}
+	case executionErrorCode:
+		tail := &baseError{msg: "edgedb: " + msg}
+		base := &baseError{err: &Error{tail}}
+		return &ExecutionError{base}
+	case invalidValueErrorCode:
+		base := &baseError{err: newErrorFromCode(executionErrorCode, msg)}
+		return &InvalidValueError{base}
+	case divisionByZeroErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidValueErrorCode, msg)}
+		return &DivisionByZeroError{base}
+	case numericOutOfRangeErrorCode:
+		base := &baseError{err: newErrorFromCode(invalidValueErrorCode, msg)}
+		return &NumericOutOfRangeError{base}
+	case integrityErrorCode:
+		base := &baseError{err: newErrorFromCode(executionErrorCode, msg)}
+		return &IntegrityError{base}
+	case constraintViolationErrorCode:
+		base := &baseError{err: newErrorFromCode(integrityErrorCode, msg)}
+		return &ConstraintViolationError{base}
+	case cardinalityViolationErrorCode:
+		base := &baseError{err: newErrorFromCode(integrityErrorCode, msg)}
+		return &CardinalityViolationError{base}
+	case missingRequiredErrorCode:
+		base := &baseError{err: newErrorFromCode(integrityErrorCode, msg)}
+		return &MissingRequiredError{base}
+	case transactionErrorCode:
+		base := &baseError{err: newErrorFromCode(executionErrorCode, msg)}
+		return &TransactionError{base}
+	case transactionSerializationErrorCode:
+		base := &baseError{err: newErrorFromCode(transactionErrorCode, msg)}
+		return &TransactionSerializationError{base}
+	case transactionDeadlockErrorCode:
+		base := &baseError{err: newErrorFromCode(transactionErrorCode, msg)}
+		return &TransactionDeadlockError{base}
+	case configurationErrorCode:
+		tail := &baseError{msg: "edgedb: " + msg}
+		base := &baseError{err: &Error{tail}}
+		return &ConfigurationError{base}
+	case accessErrorCode:
+		tail := &baseError{msg: "edgedb: " + msg}
+		base := &baseError{err: &Error{tail}}
+		return &AccessError{base}
+	case authenticationErrorCode:
+		base := &baseError{err: newErrorFromCode(accessErrorCode, msg)}
+		return &AuthenticationError{base}
+	case clientErrorCode:
+		tail := &baseError{msg: "edgedb: " + msg}
+		base := &baseError{err: &Error{tail}}
+		return &ClientError{base}
+	case clientConnectionErrorCode:
+		base := &baseError{err: newErrorFromCode(clientErrorCode, msg)}
+		return &ClientConnectionError{base}
+	case interfaceErrorCode:
+		base := &baseError{err: newErrorFromCode(clientErrorCode, msg)}
+		return &InterfaceError{base}
+	case queryArgumentErrorCode:
+		base := &baseError{err: newErrorFromCode(interfaceErrorCode, msg)}
+		return &QueryArgumentError{base}
+	case missingArgumentErrorCode:
+		base := &baseError{err: newErrorFromCode(queryArgumentErrorCode, msg)}
+		return &MissingArgumentError{base}
+	case unknownArgumentErrorCode:
+		base := &baseError{err: newErrorFromCode(queryArgumentErrorCode, msg)}
+		return &UnknownArgumentError{base}
+	case invalidArgumentErrorCode:
+		base := &baseError{err: newErrorFromCode(queryArgumentErrorCode, msg)}
+		return &InvalidArgumentError{base}
+	case noDataErrorCode:
+		base := &baseError{err: newErrorFromCode(clientErrorCode, msg)}
+		return &NoDataError{base}
+	default:
+		panic(fmt.Sprintf("unknown error code: %v", code))
+	}
+}
+
+// InternalServerError is an error.
+type InternalServerError struct {
+	*baseError
+}
+
+// UnsupportedFeatureError is an error.
+type UnsupportedFeatureError struct {
+	*baseError
+}
+
+// ProtocolError is an error.
+type ProtocolError struct {
+	*baseError
+}
+
+// BinaryProtocolError is an error.
+type BinaryProtocolError struct {
+	*baseError
+}
+
+// UnsupportedProtocolVersionError is an error.
+type UnsupportedProtocolVersionError struct {
+	*baseError
+}
+
+// TypeSpecNotFoundError is an error.
+type TypeSpecNotFoundError struct {
+	*baseError
+}
+
+// UnexpectedMessageError is an error.
+type UnexpectedMessageError struct {
+	*baseError
+}
+
+// InputDataError is an error.
+type InputDataError struct {
+	*baseError
+}
+
+// ResultCardinalityMismatchError is an error.
+type ResultCardinalityMismatchError struct {
+	*baseError
+}
+
+// QueryError is an error.
+type QueryError struct {
+	*baseError
+}
+
+// InvalidSyntaxError is an error.
+type InvalidSyntaxError struct {
+	*baseError
+}
+
+// EdgeQLSyntaxError is an error.
+type EdgeQLSyntaxError struct {
+	*baseError
+}
+
+// SchemaSyntaxError is an error.
+type SchemaSyntaxError struct {
+	*baseError
+}
+
+// GraphQLSyntaxError is an error.
+type GraphQLSyntaxError struct {
+	*baseError
+}
+
+// InvalidTypeError is an error.
+type InvalidTypeError struct {
+	*baseError
+}
+
+// InvalidTargetError is an error.
+type InvalidTargetError struct {
+	*baseError
+}
+
+// InvalidLinkTargetError is an error.
+type InvalidLinkTargetError struct {
+	*baseError
+}
+
+// InvalidPropertyTargetError is an error.
+type InvalidPropertyTargetError struct {
+	*baseError
+}
+
+// InvalidReferenceError is an error.
+type InvalidReferenceError struct {
+	*baseError
+}
+
+// UnknownModuleError is an error.
+type UnknownModuleError struct {
+	*baseError
+}
+
+// UnknownLinkError is an error.
+type UnknownLinkError struct {
+	*baseError
+}
+
+// UnknownPropertyError is an error.
+type UnknownPropertyError struct {
+	*baseError
+}
+
+// UnknownUserError is an error.
+type UnknownUserError struct {
+	*baseError
+}
+
+// UnknownDatabaseError is an error.
+type UnknownDatabaseError struct {
+	*baseError
+}
+
+// UnknownParameterError is an error.
+type UnknownParameterError struct {
+	*baseError
+}
+
+// SchemaError is an error.
+type SchemaError struct {
+	*baseError
+}
+
+// SchemaDefinitionError is an error.
+type SchemaDefinitionError struct {
+	*baseError
+}
+
+// InvalidDefinitionError is an error.
+type InvalidDefinitionError struct {
+	*baseError
+}
+
+// InvalidModuleDefinitionError is an error.
+type InvalidModuleDefinitionError struct {
+	*baseError
+}
+
+// InvalidLinkDefinitionError is an error.
+type InvalidLinkDefinitionError struct {
+	*baseError
+}
+
+// InvalidPropertyDefinitionError is an error.
+type InvalidPropertyDefinitionError struct {
+	*baseError
+}
+
+// InvalidUserDefinitionError is an error.
+type InvalidUserDefinitionError struct {
+	*baseError
+}
+
+// InvalidDatabaseDefinitionError is an error.
+type InvalidDatabaseDefinitionError struct {
+	*baseError
+}
+
+// InvalidOperatorDefinitionError is an error.
+type InvalidOperatorDefinitionError struct {
+	*baseError
+}
+
+// InvalidAliasDefinitionError is an error.
+type InvalidAliasDefinitionError struct {
+	*baseError
+}
+
+// InvalidFunctionDefinitionError is an error.
+type InvalidFunctionDefinitionError struct {
+	*baseError
+}
+
+// InvalidConstraintDefinitionError is an error.
+type InvalidConstraintDefinitionError struct {
+	*baseError
+}
+
+// InvalidCastDefinitionError is an error.
+type InvalidCastDefinitionError struct {
+	*baseError
+}
+
+// DuplicateDefinitionError is an error.
+type DuplicateDefinitionError struct {
+	*baseError
+}
+
+// DuplicateModuleDefinitionError is an error.
+type DuplicateModuleDefinitionError struct {
+	*baseError
+}
+
+// DuplicateLinkDefinitionError is an error.
+type DuplicateLinkDefinitionError struct {
+	*baseError
+}
+
+// DuplicatePropertyDefinitionError is an error.
+type DuplicatePropertyDefinitionError struct {
+	*baseError
+}
+
+// DuplicateUserDefinitionError is an error.
+type DuplicateUserDefinitionError struct {
+	*baseError
+}
+
+// DuplicateDatabaseDefinitionError is an error.
+type DuplicateDatabaseDefinitionError struct {
+	*baseError
+}
+
+// DuplicateOperatorDefinitionError is an error.
+type DuplicateOperatorDefinitionError struct {
+	*baseError
+}
+
+// DuplicateViewDefinitionError is an error.
+type DuplicateViewDefinitionError struct {
+	*baseError
+}
+
+// DuplicateFunctionDefinitionError is an error.
+type DuplicateFunctionDefinitionError struct {
+	*baseError
+}
+
+// DuplicateConstraintDefinitionError is an error.
+type DuplicateConstraintDefinitionError struct {
+	*baseError
+}
+
+// DuplicateCastDefinitionError is an error.
+type DuplicateCastDefinitionError struct {
+	*baseError
+}
+
+// QueryTimeoutError is an error.
+type QueryTimeoutError struct {
+	*baseError
+}
+
+// ExecutionError is an error.
+type ExecutionError struct {
+	*baseError
+}
+
+// InvalidValueError is an error.
+type InvalidValueError struct {
+	*baseError
+}
+
+// DivisionByZeroError is an error.
+type DivisionByZeroError struct {
+	*baseError
+}
+
+// NumericOutOfRangeError is an error.
+type NumericOutOfRangeError struct {
+	*baseError
+}
+
+// IntegrityError is an error.
+type IntegrityError struct {
+	*baseError
+}
+
+// ConstraintViolationError is an error.
+type ConstraintViolationError struct {
+	*baseError
+}
+
+// CardinalityViolationError is an error.
+type CardinalityViolationError struct {
+	*baseError
+}
+
+// MissingRequiredError is an error.
+type MissingRequiredError struct {
+	*baseError
+}
+
+// TransactionError is an error.
+type TransactionError struct {
+	*baseError
+}
+
+// TransactionSerializationError is an error.
+type TransactionSerializationError struct {
+	*baseError
+}
+
+// TransactionDeadlockError is an error.
+type TransactionDeadlockError struct {
+	*baseError
+}
+
+// ConfigurationError is an error.
+type ConfigurationError struct {
+	*baseError
+}
+
+// AccessError is an error.
+type AccessError struct {
+	*baseError
+}
+
+// AuthenticationError is an error.
+type AuthenticationError struct {
+	*baseError
+}
+
+// ClientError is an error.
+type ClientError struct {
+	*baseError
+}
+
+// ClientConnectionError is an error.
+type ClientConnectionError struct {
+	*baseError
+}
+
+// InterfaceError is an error.
+type InterfaceError struct {
+	*baseError
+}
+
+// QueryArgumentError is an error.
+type QueryArgumentError struct {
+	*baseError
+}
+
+// MissingArgumentError is an error.
+type MissingArgumentError struct {
+	*baseError
+}
+
+// UnknownArgumentError is an error.
+type UnknownArgumentError struct {
+	*baseError
+}
+
+// InvalidArgumentError is an error.
+type InvalidArgumentError struct {
+	*baseError
+}
+
+// NoDataError is an error.
+type NoDataError struct {
+	*baseError
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/pool v3.0.0+incompatible
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fatih/pool v3.0.0+incompatible h1:3xXzI/t5o6aEU/R+xe7ed44CTw41lV3oB0gB5pNXS5U=
-github.com/fatih/pool v3.0.0+incompatible/go.mod h1:v+kkrv3f2oJ1P9NHaKArMYdTVtNCwfR0DlXwnhA2L4k=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/granular_flow.go
+++ b/granular_flow.go
@@ -126,7 +126,7 @@ func (c *baseConn) prepare(r *buff.Reader, q query) (idPair, error) {
 	c.writer.EndMessage()
 
 	if e := c.writer.Send(c.conn); e != nil {
-		return idPair{}, wrapErrorFromCode(clientConnectionErrorCode, e)
+		return idPair{}, wrapErrorWithType(clientConnectionErrorCode, e)
 	}
 
 	var (
@@ -163,7 +163,7 @@ func (c *baseConn) prepare(r *buff.Reader, q query) (idPair, error) {
 	}
 
 	if r.Err != nil {
-		return idPair{}, wrapErrorFromCode(clientConnectionErrorCode, r.Err)
+		return idPair{}, wrapErrorWithType(clientConnectionErrorCode, r.Err)
 	}
 
 	return ids, err
@@ -181,7 +181,7 @@ func (c *baseConn) describe(r *buff.Reader) (descPair, error) {
 
 	var descs descPair
 	if e := c.writer.Send(c.conn); e != nil {
-		return descPair{}, wrapErrorFromCode(clientConnectionErrorCode, e)
+		return descPair{}, wrapErrorWithType(clientConnectionErrorCode, e)
 	}
 
 	var err error
@@ -219,7 +219,7 @@ func (c *baseConn) describe(r *buff.Reader) (descPair, error) {
 	}
 
 	if r.Err != nil {
-		return descPair{}, wrapErrorFromCode(clientConnectionErrorCode, r.Err)
+		return descPair{}, wrapErrorWithType(clientConnectionErrorCode, r.Err)
 	}
 
 	return descs, err
@@ -244,7 +244,7 @@ func (c *baseConn) execute(
 	c.writer.EndMessage()
 
 	if e := c.writer.Send(c.conn); e != nil {
-		return wrapErrorFromCode(clientConnectionErrorCode, e)
+		return wrapErrorWithType(clientConnectionErrorCode, e)
 	}
 
 	tmp := out
@@ -291,7 +291,7 @@ func (c *baseConn) execute(
 	}
 
 	if r.Err != nil {
-		return wrapErrorFromCode(clientConnectionErrorCode, r.Err)
+		return wrapErrorWithType(clientConnectionErrorCode, r.Err)
 	}
 
 	if !q.flat() {
@@ -324,7 +324,7 @@ func (c *baseConn) optimistic(
 	c.writer.EndMessage()
 
 	if e := c.writer.Send(c.conn); e != nil {
-		return wrapErrorFromCode(clientConnectionErrorCode, e)
+		return wrapErrorWithType(clientConnectionErrorCode, e)
 	}
 
 	tmp := out
@@ -371,7 +371,7 @@ func (c *baseConn) optimistic(
 	}
 
 	if r.Err != nil {
-		return wrapErrorFromCode(clientConnectionErrorCode, r.Err)
+		return wrapErrorWithType(clientConnectionErrorCode, r.Err)
 	}
 
 	if !q.flat() {

--- a/granular_flow.go
+++ b/granular_flow.go
@@ -126,7 +126,7 @@ func (c *baseConn) prepare(r *buff.Reader, q query) (idPair, error) {
 	c.writer.EndMessage()
 
 	if e := c.writer.Send(c.conn); e != nil {
-		return idPair{}, wrapError(e)
+		return idPair{}, wrapErrorFromCode(clientConnectionErrorCode, e)
 	}
 
 	var (
@@ -163,7 +163,7 @@ func (c *baseConn) prepare(r *buff.Reader, q query) (idPair, error) {
 	}
 
 	if r.Err != nil {
-		return idPair{}, wrapError(r.Err)
+		return idPair{}, wrapErrorFromCode(clientConnectionErrorCode, r.Err)
 	}
 
 	return ids, err
@@ -181,7 +181,7 @@ func (c *baseConn) describe(r *buff.Reader) (descPair, error) {
 
 	var descs descPair
 	if e := c.writer.Send(c.conn); e != nil {
-		return descPair{}, wrapError(e)
+		return descPair{}, wrapErrorFromCode(clientConnectionErrorCode, e)
 	}
 
 	var err error
@@ -219,7 +219,7 @@ func (c *baseConn) describe(r *buff.Reader) (descPair, error) {
 	}
 
 	if r.Err != nil {
-		return descPair{}, wrapError(r.Err)
+		return descPair{}, wrapErrorFromCode(clientConnectionErrorCode, r.Err)
 	}
 
 	return descs, err
@@ -244,7 +244,7 @@ func (c *baseConn) execute(
 	c.writer.EndMessage()
 
 	if e := c.writer.Send(c.conn); e != nil {
-		return wrapError(e)
+		return wrapErrorFromCode(clientConnectionErrorCode, e)
 	}
 
 	tmp := out
@@ -291,7 +291,7 @@ func (c *baseConn) execute(
 	}
 
 	if r.Err != nil {
-		return wrapError(r.Err)
+		return wrapErrorFromCode(clientConnectionErrorCode, r.Err)
 	}
 
 	if !q.flat() {
@@ -324,7 +324,7 @@ func (c *baseConn) optimistic(
 	c.writer.EndMessage()
 
 	if e := c.writer.Send(c.conn); e != nil {
-		return wrapError(e)
+		return wrapErrorFromCode(clientConnectionErrorCode, e)
 	}
 
 	tmp := out
@@ -371,7 +371,7 @@ func (c *baseConn) optimistic(
 	}
 
 	if r.Err != nil {
-		return wrapError(r.Err)
+		return wrapErrorFromCode(clientConnectionErrorCode, r.Err)
 	}
 
 	if !q.flat() {

--- a/granular_flow.go
+++ b/granular_flow.go
@@ -246,7 +246,7 @@ func (c *baseConn) execute(
 	}
 
 	tmp := out
-	err := ErrZeroResults
+	err := errZeroResults
 	done := buff.NewSignal()
 
 	for r.Next(done.Chan) {
@@ -262,7 +262,7 @@ func (c *baseConn) execute(
 				cdcs.out.Decode(r, unsafe.Pointer(out.UnsafeAddr()))
 			}
 
-			if err == ErrZeroResults {
+			if err == errZeroResults {
 				err = nil
 			}
 		case message.CommandComplete:
@@ -274,7 +274,7 @@ func (c *baseConn) execute(
 			r.Discard(3)
 			done.Signal()
 		case message.ErrorResponse:
-			if err == ErrZeroResults {
+			if err == errZeroResults {
 				err = nil
 			}
 
@@ -326,7 +326,7 @@ func (c *baseConn) optimistic(
 	}
 
 	tmp := out
-	err := ErrZeroResults
+	err := errZeroResults
 	done := buff.NewSignal()
 
 	for r.Next(done.Chan) {
@@ -342,7 +342,7 @@ func (c *baseConn) optimistic(
 				cdcs.out.Decode(r, unsafe.Pointer(out.UnsafeAddr()))
 			}
 
-			if err == ErrZeroResults {
+			if err == errZeroResults {
 				err = nil
 			}
 		case message.CommandComplete:
@@ -354,7 +354,7 @@ func (c *baseConn) optimistic(
 			r.Discard(3)
 			done.Signal()
 		case message.ErrorResponse:
-			if err == ErrZeroResults {
+			if err == errZeroResults {
 				err = nil
 			}
 

--- a/internal/cmd/generr/main.go
+++ b/internal/cmd/generr/main.go
@@ -33,7 +33,7 @@ func printError(name, parent string, ancestors []string) {
 // %[1]v is an error.
 type %[1]v interface {
 	%[3]v
-	is%[1]v()
+	isEdgeDB%[1]v()
 }
 
 type %[2]v struct {
@@ -52,14 +52,14 @@ func (e *%[2]v) Error() string {
 
 func (e *%[2]v) Unwrap() error { return e.err }
 
-func (e *%[2]v) is%[1]v() {}
+func (e *%[2]v) isEdgeDB%[1]v() {}
 
-func (e *%[2]v) is%[3]v() {}
+func (e *%[2]v) isEdgeDB%[3]v() {}
 `, name, private(name), parent)
 
 	for _, ancestor := range ancestors {
 		fmt.Printf(`
-func (e *%v) is%v() {}
+func (e *%v) isEdgeDB%v() {}
 `, private(name), ancestor)
 	}
 }

--- a/internal/cmd/generr/main.go
+++ b/internal/cmd/generr/main.go
@@ -1,0 +1,154 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+type typeList [][]interface{}
+
+func printTypes(types typeList) {
+	for i, t := range types {
+		name := t[0].(string)
+
+		fmt.Printf("// %v is an error.\n", name)
+		fmt.Printf("type %[1]v struct {\n", name)
+		fmt.Printf("\t*baseError\n")
+		fmt.Printf("}\n")
+
+		if i < len(types)-1 {
+			fmt.Println()
+		}
+	}
+}
+
+func codeFromName(name string) string {
+	name = strings.ToLower(name[0:1]) + name[1:]
+	return name + "Code"
+}
+
+func printCodes(types typeList) {
+	fmt.Println("const (")
+
+	for _, t := range types {
+		name := t[0].(string)
+		code := codeFromName(name)
+
+		fmt.Printf("\t%v uint32 = 0x%02x_%02x_%02x_%02x\n",
+			code,
+			int(t[2].(float64)),
+			int(t[3].(float64)),
+			int(t[4].(float64)),
+			int(t[5].(float64)),
+		)
+	}
+
+	fmt.Println(")")
+}
+
+func printTree(types typeList) {
+	fmt.Println("// newErrorFromCode returns a new edgedb error.")
+	fmt.Println("func newErrorFromCode(code uint32, msg string) error {")
+	fmt.Println("\tswitch code {")
+
+	for _, t := range types {
+		name := t[0].(string)
+		code := codeFromName(name)
+
+		switch parent := t[1].(type) {
+		case string:
+			pCode := codeFromName(parent)
+			fmt.Printf("\tcase %v:\n", code)
+			fmt.Printf(
+				"\t\tbase := &baseError{err: newErrorFromCode(%v, msg)}\n",
+				pCode,
+			)
+			fmt.Printf("\t\treturn &%v{base}\n", name)
+		case nil:
+			fmt.Printf("\tcase %v:\n", code)
+			fmt.Printf("\t\ttail := &baseError{msg: \"edgedb: \" + msg}\n")
+			fmt.Printf("\t\tbase := &baseError{err: &Error{tail}}\n")
+			fmt.Printf("\t\treturn &%v{base}\n", name)
+		default:
+			panic("unexpected type")
+		}
+	}
+
+	fmt.Print("\tdefault:\n")
+	fmt.Printf("\t\tpanic(fmt.Sprintf(\"unknown error code: %%v\", code))\n")
+	fmt.Print("\t}\n")
+	fmt.Print("}\n")
+}
+
+// log messages and warnings don't make sense as error types
+func filterNonError(types typeList) typeList {
+	newTypes := typeList{}
+
+	for _, t := range types {
+		name := t[0].(string)
+		if !strings.HasSuffix(name, "Error") {
+			continue
+		}
+		newTypes = append(newTypes, t)
+	}
+
+	return newTypes
+}
+
+func main() {
+	var types typeList
+	if e := json.NewDecoder(os.Stdin).Decode(&types); e != nil {
+		log.Fatal(e)
+	}
+
+	types = filterNonError(types)
+
+	fmt.Print(`// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is auto generated. Do not edit!
+`)
+
+	fmt.Println()
+	fmt.Println("package edgedb")
+	fmt.Println()
+	fmt.Println(`import "fmt"`)
+	fmt.Println()
+	printCodes(types)
+	fmt.Println()
+	printTree(types)
+	fmt.Println()
+	printTypes(types)
+}

--- a/internal/cmd/generr/main.go
+++ b/internal/cmd/generr/main.go
@@ -66,8 +66,12 @@ func printCodes(types typeList) {
 }
 
 func printTree(types typeList) {
-	fmt.Println("// newErrorFromCode returns a new edgedb error.")
-	fmt.Println("func newErrorFromCode(code uint32, msg string) error {")
+	fmt.Println("// wrapErrorFromCode wraps an error in an edgedb error type.")
+	fmt.Println("func wrapErrorFromCode(code uint32, err error) error {")
+	fmt.Println("\tif err == nil {")
+	fmt.Println("\t\treturn nil")
+	fmt.Println("\t}")
+	fmt.Println()
 	fmt.Println("\tswitch code {")
 
 	for _, t := range types {
@@ -78,16 +82,12 @@ func printTree(types typeList) {
 		case string:
 			pCode := codeFromName(parent)
 			fmt.Printf("\tcase %v:\n", code)
-			fmt.Printf(
-				"\t\tbase := &baseError{err: newErrorFromCode(%v, msg)}\n",
-				pCode,
-			)
-			fmt.Printf("\t\treturn &%v{base}\n", name)
+			fmt.Printf("\t\tnext := wrapErrorFromCode(%v, err)\n", pCode)
+			fmt.Printf("\t\treturn &%v{&baseError{err: next}}\n", name)
 		case nil:
 			fmt.Printf("\tcase %v:\n", code)
-			fmt.Printf("\t\ttail := &baseError{msg: \"edgedb: \" + msg}\n")
-			fmt.Printf("\t\tbase := &baseError{err: &Error{tail}}\n")
-			fmt.Printf("\t\treturn &%v{base}\n", name)
+			fmt.Printf(
+				"\t\treturn &%v{&baseError{err: wrapError(err)}}\n", name)
 		default:
 			panic("unexpected type")
 		}

--- a/internal/cmd/generr/main.go
+++ b/internal/cmd/generr/main.go
@@ -146,6 +146,7 @@ func main() {
 // limitations under the License.
 
 // This file is auto generated. Do not edit!
+// run 'make errors' to regenerate
 `)
 
 	fmt.Println()

--- a/internal/cmd/generr/main.go
+++ b/internal/cmd/generr/main.go
@@ -66,8 +66,8 @@ func printCodes(types typeList) {
 }
 
 func printTree(types typeList) {
-	fmt.Println("// wrapErrorFromCode wraps an error in an edgedb error type.")
-	fmt.Println("func wrapErrorFromCode(code uint32, err error) error {")
+	fmt.Println("// wrapErrorWithType wraps an error in an edgedb error type.")
+	fmt.Println("func wrapErrorWithType(code uint32, err error) error {")
 	fmt.Println("\tif err == nil {")
 	fmt.Println("\t\treturn nil")
 	fmt.Println("\t}")
@@ -82,7 +82,7 @@ func printTree(types typeList) {
 		case string:
 			pCode := codeFromName(parent)
 			fmt.Printf("\tcase %v:\n", code)
-			fmt.Printf("\t\tnext := wrapErrorFromCode(%v, err)\n", pCode)
+			fmt.Printf("\t\tnext := wrapErrorWithType(%v, err)\n", pCode)
 			fmt.Printf("\t\treturn &%v{&baseError{err: next}}\n", name)
 		case nil:
 			fmt.Printf("\tcase %v:\n", code)

--- a/internal/codecs/array.go
+++ b/internal/codecs/array.go
@@ -99,8 +99,12 @@ func (c *Array) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode an array.
-func (c *Array) Encode(w *buff.Writer, val interface{}) {
-	in := val.([]interface{})
+func (c *Array) Encode(w *buff.Writer, val interface{}) error {
+	in, ok := val.([]interface{})
+	if !ok {
+		return fmt.Errorf("expected []interface{} got: %T", val)
+	}
+
 	elmCount := len(in)
 
 	w.BeginBytes()
@@ -110,9 +114,14 @@ func (c *Array) Encode(w *buff.Writer, val interface{}) {
 	w.PushUint32(uint32(elmCount)) // dimension.upper
 	w.PushUint32(1)                // dimension.lower
 
+	var err error
 	for i := 0; i < elmCount; i++ {
-		c.child.Encode(w, in[i])
+		err = c.child.Encode(w, in[i])
+		if err != nil {
+			return err
+		}
 	}
 
 	w.EndBytes()
+	return nil
 }

--- a/internal/codecs/array_test.go
+++ b/internal/codecs/array_test.go
@@ -74,7 +74,8 @@ func TestEncodeArray(t *testing.T) {
 	w.BeginMessage(0xff)
 
 	codec := &Array{child: &Int64{}}
-	codec.Encode(w, []interface{}{int64(3), int64(5), int64(8)})
+	err := codec.Encode(w, []interface{}{int64(3), int64(5), int64(8)})
+	require.Nil(t, err)
 	w.EndMessage()
 
 	expected := []byte{

--- a/internal/codecs/base_scalar.go
+++ b/internal/codecs/base_scalar.go
@@ -145,9 +145,14 @@ func (c *UUID) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a UUID.
-func (c *UUID) Encode(w *buff.Writer, val interface{}) {
-	tmp := val.(types.UUID)
+func (c *UUID) Encode(w *buff.Writer, val interface{}) error {
+	tmp, ok := val.(types.UUID)
+	if !ok {
+		return fmt.Errorf("expected types.UUID got %T", val)
+	}
+
 	w.PushBytes(tmp[:])
+	return nil
 }
 
 // Str is an EdgeDB string type codec.
@@ -180,8 +185,14 @@ func (c *Str) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a string.
-func (c *Str) Encode(w *buff.Writer, val interface{}) {
-	w.PushString(val.(string))
+func (c *Str) Encode(w *buff.Writer, val interface{}) error {
+	in, ok := val.(string)
+	if !ok {
+		return fmt.Errorf("expected types.UUID got %T", val)
+	}
+
+	w.PushString(in)
+	return nil
 }
 
 // Bytes is an EdgeDB bytes type codec.
@@ -224,8 +235,14 @@ func (c *Bytes) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode []byte.
-func (c *Bytes) Encode(w *buff.Writer, val interface{}) {
-	w.PushBytes(val.([]byte))
+func (c *Bytes) Encode(w *buff.Writer, val interface{}) error {
+	in, ok := val.([]byte)
+	if !ok {
+		return fmt.Errorf("expected []byte got %T", val)
+	}
+
+	w.PushBytes(in)
+	return nil
 }
 
 // Int16 is an EdgeDB int64 type codec.
@@ -259,9 +276,15 @@ func (c *Int16) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode an int16.
-func (c *Int16) Encode(w *buff.Writer, val interface{}) {
+func (c *Int16) Encode(w *buff.Writer, val interface{}) error {
+	in, ok := val.(int16)
+	if !ok {
+		return fmt.Errorf("expected int16 got %T", val)
+	}
+
 	w.PushUint32(2) // data length
-	w.PushUint16(uint16(val.(int16)))
+	w.PushUint16(uint16(in))
+	return nil
 }
 
 // Int32 is an EdgeDB int32 type codec.
@@ -295,9 +318,15 @@ func (c *Int32) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode an int32.
-func (c *Int32) Encode(w *buff.Writer, val interface{}) {
+func (c *Int32) Encode(w *buff.Writer, val interface{}) error {
+	in, ok := val.(int32)
+	if !ok {
+		return fmt.Errorf("expected int32 got %T", val)
+	}
+
 	w.PushUint32(4) // data length
-	w.PushUint32(uint32(val.(int32)))
+	w.PushUint32(uint32(in))
+	return nil
 }
 
 // Int64 is an EdgeDB int64 typep codec.
@@ -331,9 +360,15 @@ func (c *Int64) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode an int64.
-func (c *Int64) Encode(w *buff.Writer, val interface{}) {
+func (c *Int64) Encode(w *buff.Writer, val interface{}) error {
+	in, ok := val.(int64)
+	if !ok {
+		return fmt.Errorf("expected int64 got %T", val)
+	}
+
 	w.PushUint32(8) // data length
-	w.PushUint64(uint64(val.(int64)))
+	w.PushUint64(uint64(in))
+	return nil
 }
 
 // Float32 is an EdgeDB float32 type codec.
@@ -367,9 +402,15 @@ func (c *Float32) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a float32.
-func (c *Float32) Encode(w *buff.Writer, val interface{}) {
+func (c *Float32) Encode(w *buff.Writer, val interface{}) error {
+	in, ok := val.(float32)
+	if !ok {
+		return fmt.Errorf("expected float32 got %T", val)
+	}
+
 	w.PushUint32(4)
-	w.PushUint32(math.Float32bits(val.(float32)))
+	w.PushUint32(math.Float32bits(in))
+	return nil
 }
 
 // Float64 is an EdgeDB float64 type codec.
@@ -403,9 +444,15 @@ func (c *Float64) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a float64.
-func (c *Float64) Encode(w *buff.Writer, val interface{}) {
+func (c *Float64) Encode(w *buff.Writer, val interface{}) error {
+	in, ok := val.(float64)
+	if !ok {
+		return fmt.Errorf("expected float64 got %T", val)
+	}
+
 	w.PushUint32(8)
-	w.PushUint64(math.Float64bits(val.(float64)))
+	w.PushUint64(math.Float64bits(in))
+	return nil
 }
 
 // Bool is an EdgeDB bool type codec.
@@ -439,16 +486,22 @@ func (c *Bool) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a bool.
-func (c *Bool) Encode(w *buff.Writer, val interface{}) {
+func (c *Bool) Encode(w *buff.Writer, val interface{}) error {
+	in, ok := val.(bool)
+	if !ok {
+		return fmt.Errorf("expected bool got %T", val)
+	}
+
 	w.PushUint32(1) // data length
 
 	// convert bool to uint8
 	var out uint8 = 0
-	if val.(bool) {
+	if in {
 		out = 1
 	}
 
 	w.PushUint8(out)
+	return nil
 }
 
 // DateTime is an EdgeDB datetime type codec.
@@ -488,13 +541,18 @@ func (c *DateTime) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a datetime.
-func (c *DateTime) Encode(w *buff.Writer, val interface{}) {
-	date := val.(time.Time)
+func (c *DateTime) Encode(w *buff.Writer, val interface{}) error {
+	date, ok := val.(time.Time)
+	if !ok {
+		return fmt.Errorf("expected time.Time got %T", val)
+	}
+
 	seconds := date.Unix() - 946_684_800
 	nanoseconds := int64(date.Sub(time.Unix(date.Unix(), 0)))
 	microseconds := seconds*1_000_000 + nanoseconds/1_000
 	w.PushUint32(8) // data length
 	w.PushUint64(uint64(microseconds))
+	return nil
 }
 
 // Duration is an EdgeDB duration codec.
@@ -530,12 +588,17 @@ func (c *Duration) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a duration.
-func (c *Duration) Encode(w *buff.Writer, val interface{}) {
-	duration := val.(time.Duration)
+func (c *Duration) Encode(w *buff.Writer, val interface{}) error {
+	duration, ok := val.(time.Duration)
+	if !ok {
+		return fmt.Errorf("expected time.Duration got %T", val)
+	}
+
 	w.PushUint32(16) // data length
 	w.PushUint64(uint64(duration / 1_000))
 	w.PushUint32(0) // reserved
 	w.PushUint32(0) // reserved
+	return nil
 }
 
 // todo what type should JSON be decoded to :thinking:
@@ -552,7 +615,7 @@ func (c *JSON) ID() types.UUID {
 	return c.id
 }
 
-func (c *JSON) setType(typ reflect.Type) error {
+func (c *JSON) setType(typ reflect.Type) error { // nolint:unused
 	if typ != c.typ {
 		return fmt.Errorf("expected %v got %v", c.typ, typ)
 	}
@@ -575,6 +638,7 @@ func (c *JSON) Decode(r *buff.Reader, out unsafe.Pointer) {
 func (c *JSON) Encode(w *buff.Writer, val interface{}) {
 	bts, err := json.Marshal(val)
 	if err != nil {
+		// todo err: Encode should return error?
 		panic(err)
 	}
 

--- a/internal/codecs/base_scalar_test.go
+++ b/internal/codecs/base_scalar_test.go
@@ -60,9 +60,10 @@ func BenchmarkDecodeUUID(b *testing.B) {
 
 func TestEncodeUUID(t *testing.T) {
 	w := buff.NewWriter()
-	(&UUID{}).Encode(w, types.UUID{
+	err := (&UUID{}).Encode(w, types.UUID{
 		0, 1, 2, 3, 3, 2, 1, 0, 8, 7, 6, 5, 5, 6, 7, 8,
 	})
+	require.Nil(t, err)
 
 	conn := &writeFixture{}
 	require.Nil(t, w.Send(conn))
@@ -82,7 +83,7 @@ func BenchmarkEncodeUUID(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		codec.Encode(w, id)
+		_ = codec.Encode(w, id)
 	}
 }
 
@@ -123,7 +124,8 @@ func BenchmarkDecodeString(b *testing.B) {
 
 func TestEncodeString(t *testing.T) {
 	w := buff.NewWriter()
-	(&Str{}).Encode(w, "hello")
+	err := (&Str{}).Encode(w, "hello")
+	require.Nil(t, err)
 
 	conn := &writeFixture{}
 	require.Nil(t, w.Send(conn))
@@ -174,7 +176,8 @@ func BenchmarkDecodeBytes(b *testing.B) {
 
 func TestEncodeBytes(t *testing.T) {
 	w := buff.NewWriter()
-	(&Bytes{}).Encode(w, []byte{104, 101, 108, 108, 111})
+	err := (&Bytes{}).Encode(w, []byte{104, 101, 108, 108, 111})
+	require.Nil(t, err)
 
 	conn := &writeFixture{}
 	require.Nil(t, w.Send(conn))
@@ -219,7 +222,8 @@ func BenchmarkDecodeInt16(b *testing.B) {
 
 func TestEncodeInt16(t *testing.T) {
 	w := buff.NewWriter()
-	(&Int16{}).Encode(w, int16(7))
+	err := (&Int16{}).Encode(w, int16(7))
+	require.Nil(t, err)
 
 	conn := &writeFixture{}
 	require.Nil(t, w.Send(conn))
@@ -264,7 +268,8 @@ func BenchmarkDecodeInt32(b *testing.B) {
 
 func TestEncodeInt32(t *testing.T) {
 	w := buff.NewWriter()
-	(&Int32{}).Encode(w, int32(7))
+	err := (&Int32{}).Encode(w, int32(7))
+	require.Nil(t, err)
 
 	conn := &writeFixture{}
 	require.Nil(t, w.Send(conn))
@@ -309,7 +314,8 @@ func BenchmarkDecodeInt64(b *testing.B) {
 
 func TestEncodeInt64(t *testing.T) {
 	w := buff.NewWriter()
-	(&Int64{}).Encode(w, int64(27))
+	err := (&Int64{}).Encode(w, int64(27))
+	require.Nil(t, err)
 
 	conn := &writeFixture{}
 	require.Nil(t, w.Send(conn))
@@ -354,7 +360,8 @@ func BenchmarkDecodeFloat32(b *testing.B) {
 
 func TestEncodeFloat32(t *testing.T) {
 	w := buff.NewWriter()
-	(&Float32{}).Encode(w, float32(-32))
+	err := (&Float32{}).Encode(w, float32(-32))
+	require.Nil(t, err)
 
 	conn := &writeFixture{}
 	require.Nil(t, w.Send(conn))
@@ -399,7 +406,8 @@ func BenchmarkDecodeFloat64(b *testing.B) {
 
 func TestEncodeFloat64(t *testing.T) {
 	w := buff.NewWriter()
-	(&Float64{}).Encode(w, float64(-64))
+	err := (&Float64{}).Encode(w, float64(-64))
+	require.Nil(t, err)
 
 	conn := &writeFixture{}
 	require.Nil(t, w.Send(conn))
@@ -444,7 +452,8 @@ func BenchmarkDecodeBool(b *testing.B) {
 
 func TestEncodeBool(t *testing.T) {
 	w := buff.NewWriter()
-	(&Bool{}).Encode(w, true)
+	err := (&Bool{}).Encode(w, true)
+	require.Nil(t, err)
 
 	conn := &writeFixture{}
 	require.Nil(t, w.Send(conn))
@@ -472,7 +481,8 @@ func TestDecodeDateTime(t *testing.T) {
 
 func TestEncodeDateTime(t *testing.T) {
 	w := buff.NewWriter()
-	(&DateTime{}).Encode(w, time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))
+	err := (&DateTime{}).Encode(w, time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))
+	require.Nil(t, err)
 
 	conn := &writeFixture{}
 	require.Nil(t, w.Send(conn))
@@ -501,7 +511,8 @@ func TestDecodeDuration(t *testing.T) {
 
 func TestEncodeDuration(t *testing.T) {
 	w := buff.NewWriter()
-	(&Duration{}).Encode(w, time.Duration(1_000_000_000))
+	err := (&Duration{}).Encode(w, time.Duration(1_000_000_000))
+	require.Nil(t, err)
 
 	conn := &writeFixture{}
 	require.Nil(t, w.Send(conn))

--- a/internal/codecs/codecs.go
+++ b/internal/codecs/codecs.go
@@ -41,9 +41,8 @@ const (
 
 // Codec interface
 type Codec interface {
-	// todo update name
 	Decode(*buff.Reader, unsafe.Pointer)
-	Encode(*buff.Writer, interface{})
+	Encode(*buff.Writer, interface{}) error
 	ID() types.UUID
 	Type() reflect.Type
 	setType(reflect.Type) error
@@ -70,7 +69,6 @@ func BuildCodec(r *buff.Reader) (Codec, error) {
 				return nil, err
 			}
 		case scalarType:
-			// todo implement scalar type descriptor
 			return nil, errors.New("scalar type descriptor not implemented")
 		case tupleType:
 			codec = popTupleCodec(r, id, codecs)
@@ -79,7 +77,6 @@ func BuildCodec(r *buff.Reader) (Codec, error) {
 		case arrayType:
 			codec = popArrayCodec(r, id, codecs)
 		case enumType:
-			// todo implement enum type descriptor
 			return nil, errors.New("enum type descriptor not implemented")
 		default:
 			if 0x80 <= dType && dType <= 0xff {
@@ -106,20 +103,17 @@ func BuildTypedCodec(r *buff.Reader, t reflect.Type) (Codec, error) {
 
 	if err := codec.setType(t); err != nil {
 		return nil, fmt.Errorf(
-			"the \"out\" argument does not match query schema: %w",
-			err,
+			"the \"out\" argument does not match query schema: %v", err,
 		)
 	}
 
 	return codec, nil
 }
 
-// todo test
 func pAdd(p unsafe.Pointer, i uintptr) unsafe.Pointer {
 	return unsafe.Pointer(uintptr(p) + i)
 }
 
-// todo test
 func calcStep(tp reflect.Type) int {
 	step := int(tp.Size())
 	a := tp.Align()
@@ -131,8 +125,7 @@ func calcStep(tp reflect.Type) int {
 	return step
 }
 
-// the following structs represent the memory layout of builtin types.
-
+// sliceHeader represent the memory layout for a slice.
 type sliceHeader struct {
 	Data unsafe.Pointer
 	Len  int

--- a/internal/codecs/named_tuple.go
+++ b/internal/codecs/named_tuple.go
@@ -107,27 +107,36 @@ func (c *NamedTuple) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a named tuple.
-func (c *NamedTuple) Encode(w *buff.Writer, val interface{}) {
+func (c *NamedTuple) Encode(w *buff.Writer, val interface{}) error {
+	args, ok := val.([]interface{})
+	if !ok {
+		return fmt.Errorf("expected []interface{} got %T", val)
+	}
+
 	elmCount := len(c.fields)
 
 	w.BeginBytes()
 	w.PushUint32(uint32(elmCount))
 
-	args := val.([]interface{})
 	if len(args) != 1 {
 		panic(fmt.Sprintf(
 			"wrong number of arguments, expected 1 got: %v",
-			args,
+			len(args),
 		))
 	}
 
 	in := args[0].(map[string]interface{})
 
+	var err error
 	for i := 0; i < elmCount; i++ {
 		w.PushUint32(0) // reserved
 		field := c.fields[i]
-		field.codec.Encode(w, in[field.name])
+		err = field.codec.Encode(w, in[field.name])
+		if err != nil {
+			return err
+		}
 	}
 
 	w.EndBytes()
+	return nil
 }

--- a/internal/codecs/named_tuple_test.go
+++ b/internal/codecs/named_tuple_test.go
@@ -137,10 +137,11 @@ func TestEncodeNamedTuple(t *testing.T) {
 
 	w := buff.NewWriter()
 	w.BeginMessage(message.Sync)
-	codec.Encode(w, []interface{}{map[string]interface{}{
+	err := codec.Encode(w, []interface{}{map[string]interface{}{
 		"a": int32(5),
 		"b": int32(6),
 	}})
+	require.Nil(t, err)
 	w.EndMessage()
 
 	conn := &writeFixture{}

--- a/internal/codecs/object.go
+++ b/internal/codecs/object.go
@@ -129,6 +129,6 @@ func (c *Object) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode an object
-func (c *Object) Encode(buf *buff.Writer, val interface{}) {
+func (c *Object) Encode(buf *buff.Writer, val interface{}) error {
 	panic("objects can't be query parameters")
 }

--- a/internal/codecs/set.go
+++ b/internal/codecs/set.go
@@ -31,7 +31,6 @@ func popSetCodec(
 	codecs []Codec,
 ) Codec {
 	n := r.PopUint16()
-	// todo type value
 	return &Set{id: id, child: codecs[n]}
 }
 
@@ -95,6 +94,6 @@ func (c *Set) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a set
-func (c *Set) Encode(buf *buff.Writer, val interface{}) {
+func (c *Set) Encode(buf *buff.Writer, val interface{}) error {
 	panic("not implemented")
 }

--- a/internal/codecs/tuple.go
+++ b/internal/codecs/tuple.go
@@ -104,17 +104,26 @@ func (c *Tuple) Decode(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a tuple.
-func (c *Tuple) Encode(w *buff.Writer, val interface{}) {
+func (c *Tuple) Encode(w *buff.Writer, val interface{}) error {
+	in, ok := val.([]interface{})
+	if !ok {
+		return fmt.Errorf("expected []interface{} got %T", val)
+	}
+
 	w.BeginBytes()
 
 	elmCount := len(c.fields)
 	w.PushUint32(uint32(elmCount))
 
-	in := val.([]interface{})
+	var err error
 	for i := 0; i < elmCount; i++ {
 		w.PushUint32(0) // reserved
-		c.fields[i].Encode(w, in[i])
+		err = c.fields[i].Encode(w, in[i])
+		if err != nil {
+			return err
+		}
 	}
 
 	w.EndBytes()
+	return nil
 }

--- a/internal/codecs/tuple_test.go
+++ b/internal/codecs/tuple_test.go
@@ -74,7 +74,8 @@ func TestDecodeTuple(t *testing.T) {
 func TestEncodeNullTuple(t *testing.T) {
 	w := buff.NewWriter()
 	w.BeginMessage(0xff)
-	(&Tuple{}).Encode(w, []interface{}{})
+	err := (&Tuple{}).Encode(w, []interface{}{})
+	require.Nil(t, err)
 	w.EndMessage()
 
 	conn := &writeFixture{}
@@ -95,7 +96,8 @@ func TestEncodeTuple(t *testing.T) {
 	w.BeginMessage(0xff)
 
 	codec := &Tuple{fields: []Codec{&Int64{}, &Int64{}}}
-	codec.Encode(w, []interface{}{int64(2), int64(3)})
+	err := codec.Encode(w, []interface{}{int64(2), int64(3)})
+	require.Nil(t, err)
 	w.EndMessage()
 
 	conn := &writeFixture{}
@@ -128,6 +130,6 @@ func BenchmarkEncodeTuple(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		codec.Encode(w, ids)
+		_ = codec.Encode(w, ids)
 	}
 }

--- a/internal/marshal/marshal.go
+++ b/internal/marshal/marshal.go
@@ -59,7 +59,7 @@ func ValueOf(i interface{}) (reflect.Value, error) {
 	e := v.Elem()
 	if !e.IsValid() {
 		return reflect.Value{}, fmt.Errorf(
-			"the \"out\" argument must point to a valid value, got %v",
+			"the \"out\" argument must point to a valid value, got %+v",
 			i,
 		)
 	}
@@ -77,7 +77,7 @@ func ValueOfSlice(i interface{}) (reflect.Value, error) {
 
 	if v.Kind() != reflect.Slice {
 		return reflect.Value{}, fmt.Errorf(
-			"the \"out\" argument must be a pointer to a slice, got %v",
+			"the \"out\" argument must be a pointer to a slice, got %+v",
 			reflect.ValueOf(i).Type(),
 		)
 	}

--- a/internal/soc/mempool.go
+++ b/internal/soc/mempool.go
@@ -52,7 +52,8 @@ func (p *MemPool) Acquire() []byte {
 // Release returns ownership of a slab to the pool.
 func (p *MemPool) Release(buf []byte) {
 	if len(buf) != p.slabSize {
-		panic("something is not right :/")
+		panic("unexpected buffer len. " +
+			"The buffer probably doesn't belong in this pool")
 	}
 
 	select {

--- a/internal/soc/soc.go
+++ b/internal/soc/soc.go
@@ -49,7 +49,7 @@ func IsPermanentNetErr(err error) bool {
 
 	var netErr net.Error
 	if errors.As(err, &netErr) {
-		return netErr.Temporary()
+		return !netErr.Temporary()
 	}
 
 	return false

--- a/main_test.go
+++ b/main_test.go
@@ -187,7 +187,7 @@ func TestMain(m *testing.M) {
 
 	var name string
 	err = conn.QueryOne(ctx, query, &name)
-	if errors.Is(err, ErrZeroResults) {
+	if errors.Is(err, errZeroResults) {
 		fmt.Println("running migration")
 		executeOrPanic(`
 			START MIGRATION TO {

--- a/pool.go
+++ b/pool.go
@@ -142,8 +142,7 @@ func (p *Pool) acquire(ctx context.Context) (*baseConn, error) {
 	// force do nothing if context is expired
 	select {
 	case <-ctx.Done():
-		err := ctx.Err()
-		return nil, &baseError{msg: "edgedb: " + err.Error(), err: err}
+		return nil, fmt.Errorf("edgedb: %w", ctx.Err())
 	default:
 	}
 
@@ -165,8 +164,7 @@ func (p *Pool) acquire(ctx context.Context) (*baseConn, error) {
 		}
 		return conn, nil
 	case <-ctx.Done():
-		err := ctx.Err()
-		return nil, &baseError{msg: "edgedb: " + err.Error(), err: err}
+		return nil, fmt.Errorf("edgedb: %w", ctx.Err())
 	}
 }
 

--- a/pool.go
+++ b/pool.go
@@ -136,7 +136,7 @@ func (p *Pool) acquire(ctx context.Context) (*baseConn, error) {
 	defer p.mu.RUnlock()
 
 	if p.isClosed {
-		return nil, ErrPoolClosed
+		return nil, newErrorFromCode(interfaceErrorCode, "pool closed")
 	}
 
 	// force do nothing if context is expired
@@ -218,7 +218,7 @@ func (p *Pool) Close() error {
 	defer p.mu.Unlock()
 
 	if p.isClosed {
-		return ErrPoolClosed
+		return newErrorFromCode(interfaceErrorCode, "pool closed")
 	}
 	p.isClosed = true
 

--- a/pool.go
+++ b/pool.go
@@ -142,7 +142,8 @@ func (p *Pool) acquire(ctx context.Context) (*baseConn, error) {
 	// force do nothing if context is expired
 	select {
 	case <-ctx.Done():
-		return nil, fmt.Errorf("edgedb: %w", ctx.Err())
+		err := ctx.Err()
+		return nil, &baseError{msg: "edgedb: " + err.Error(), err: err}
 	default:
 	}
 
@@ -164,7 +165,8 @@ func (p *Pool) acquire(ctx context.Context) (*baseConn, error) {
 		}
 		return conn, nil
 	case <-ctx.Done():
-		return nil, fmt.Errorf("edgedb: %w", ctx.Err())
+		err := ctx.Err()
+		return nil, &baseError{msg: "edgedb: " + err.Error(), err: err}
 	}
 }
 

--- a/pool.go
+++ b/pool.go
@@ -58,17 +58,17 @@ func Connect(ctx context.Context, opts Options) (*Pool, error) { // nolint:gocri
 // ConnectDSN a pool of connections to a server.
 func ConnectDSN(ctx context.Context, dsn string, opts Options) (*Pool, error) { // nolint:gocritic,lll
 	if opts.MinConns < 1 {
-		return nil, newErrorFromCode(configurationErrorCode, fmt.Sprintf(
+		return nil, &configurationError{msg: fmt.Sprintf(
 			"MinConns may not be less than 1, got: %v",
 			opts.MinConns,
-		))
+		)}
 	}
 
 	if opts.MaxConns < opts.MinConns {
-		return nil, newErrorFromCode(configurationErrorCode, fmt.Sprintf(
+		return nil, &configurationError{msg: fmt.Sprintf(
 			"MaxConns (%v) may not be less than MinConns (%v)",
 			opts.MaxConns, opts.MinConns,
-		))
+		)}
 	}
 
 	cfg, err := parseConnectDSNAndArgs(dsn, &opts)
@@ -136,7 +136,7 @@ func (p *Pool) acquire(ctx context.Context) (*baseConn, error) {
 	defer p.mu.RUnlock()
 
 	if p.isClosed {
-		return nil, newErrorFromCode(interfaceErrorCode, "pool closed")
+		return nil, &interfaceError{msg: "pool closed"}
 	}
 
 	// force do nothing if context is expired
@@ -220,7 +220,7 @@ func (p *Pool) Close() error {
 	defer p.mu.Unlock()
 
 	if p.isClosed {
-		return newErrorFromCode(interfaceErrorCode, "pool closed")
+		return &interfaceError{msg: "pool closed"}
 	}
 	p.isClosed = true
 

--- a/pool.go
+++ b/pool.go
@@ -142,7 +142,7 @@ func (p *Pool) acquire(ctx context.Context) (*baseConn, error) {
 	// force do nothing if context is expired
 	select {
 	case <-ctx.Done():
-		return nil, ErrContextExpired
+		return nil, fmt.Errorf("edgedb: %w", ctx.Err())
 	default:
 	}
 
@@ -164,7 +164,7 @@ func (p *Pool) acquire(ctx context.Context) (*baseConn, error) {
 		}
 		return conn, nil
 	case <-ctx.Done():
-		return nil, ErrContextExpired
+		return nil, fmt.Errorf("edgedb: %w", ctx.Err())
 	}
 }
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -60,7 +60,7 @@ func TestClosePoolConcurently(t *testing.T) {
 	go func() { errs <- pool.Close() }()
 
 	assert.Nil(t, <-errs)
-	var closedErr *InterfaceError
+	var closedErr InterfaceError
 	assert.True(t, errors.As(<-errs, &closedErr))
 }
 
@@ -73,10 +73,10 @@ func TestConnectPoolMinConnGteZero(t *testing.T) {
 	assert.EqualError(
 		t,
 		err,
-		"edgedb: MinConns may not be less than 1, got: 0",
+		"edgedb.ConfigurationError: MinConns may not be less than 1, got: 0",
 	)
 
-	var expected *ConfigurationError
+	var expected ConfigurationError
 	assert.True(t, errors.As(err, &expected))
 }
 
@@ -89,10 +89,11 @@ func TestConnectPoolMinConnLteMaxConn(t *testing.T) {
 	assert.EqualError(
 		t,
 		err,
-		"edgedb: MaxConns (1) may not be less than MinConns (5)",
+		"edgedb.ConfigurationError: "+
+			"MaxConns (1) may not be less than MinConns (5)",
 	)
 
-	var expected *ConfigurationError
+	var expected ConfigurationError
 	assert.True(t, errors.As(err, &expected))
 }
 
@@ -104,7 +105,7 @@ func TestAcquireFromClosedPool(t *testing.T) {
 	}
 
 	conn, err := pool.Acquire(context.TODO())
-	var closedErr *InterfaceError
+	var closedErr InterfaceError
 	require.True(t, errors.As(err, &closedErr))
 	assert.Nil(t, conn)
 }
@@ -203,6 +204,6 @@ func TestClosePool(t *testing.T) {
 	assert.Nil(t, err)
 
 	err = pool.Close()
-	var closedErr *InterfaceError
+	var closedErr InterfaceError
 	assert.True(t, errors.As(err, &closedErr))
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -69,8 +69,14 @@ func TestConnectPoolMinConnGteZero(t *testing.T) {
 
 	o := Options{MinConns: 0, MaxConns: 10}
 	_, err := Connect(ctx, o)
-	assert.EqualError(t, err, "MinConns may not be less than 1, got: 0")
-	assert.True(t, errors.Is(err, ErrBadConfig))
+	assert.EqualError(
+		t,
+		err,
+		"edgedb: MinConns may not be less than 1, got: 0",
+	)
+
+	var expected *ConfigurationError
+	assert.True(t, errors.As(err, &expected))
 }
 
 func TestConnectPoolMinConnLteMaxConn(t *testing.T) {
@@ -79,8 +85,14 @@ func TestConnectPoolMinConnLteMaxConn(t *testing.T) {
 
 	o := Options{MinConns: 5, MaxConns: 1}
 	_, err := Connect(ctx, o)
-	assert.EqualError(t, err, "MaxConns may not be less than MinConns")
-	assert.True(t, errors.Is(err, ErrBadConfig))
+	assert.EqualError(
+		t,
+		err,
+		"edgedb: MaxConns (1) may not be less than MinConns (5)",
+	)
+
+	var expected *ConfigurationError
+	assert.True(t, errors.As(err, &expected))
 }
 
 func TestAcquireFromClosedPool(t *testing.T) {

--- a/pool_test.go
+++ b/pool_test.go
@@ -174,7 +174,7 @@ func TestPoolAcquireExpiredContext(t *testing.T) {
 	cancel()
 
 	conn, err := pool.Acquire(ctx)
-	assert.Equal(t, err, ErrContextExpired)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded))
 	assert.Nil(t, conn)
 }
 
@@ -184,7 +184,7 @@ func TestPoolAcquireThenContextExpires(t *testing.T) {
 	deadline := time.Now().Add(10 * time.Millisecond)
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	conn, err := pool.Acquire(ctx)
-	assert.Equal(t, err, ErrContextExpired)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded))
 	assert.Nil(t, conn)
 	cancel()
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -60,7 +60,8 @@ func TestClosePoolConcurently(t *testing.T) {
 	go func() { errs <- pool.Close() }()
 
 	assert.Nil(t, <-errs)
-	assert.Equal(t, ErrPoolClosed, <-errs)
+	var closedErr *InterfaceError
+	assert.True(t, errors.As(<-errs, &closedErr))
 }
 
 func TestConnectPoolMinConnGteZero(t *testing.T) {
@@ -103,7 +104,8 @@ func TestAcquireFromClosedPool(t *testing.T) {
 	}
 
 	conn, err := pool.Acquire(context.TODO())
-	require.Equal(t, err, ErrPoolClosed)
+	var closedErr *InterfaceError
+	require.True(t, errors.As(err, &closedErr))
 	assert.Nil(t, conn)
 }
 
@@ -201,5 +203,6 @@ func TestClosePool(t *testing.T) {
 	assert.Nil(t, err)
 
 	err = pool.Close()
-	assert.Equal(t, err, ErrPoolClosed)
+	var closedErr *InterfaceError
+	assert.True(t, errors.As(err, &closedErr))
 }

--- a/poolconn.go
+++ b/poolconn.go
@@ -18,7 +18,8 @@ package edgedb
 
 import (
 	"context"
-	"net"
+
+	"github.com/edgedb/edgedb-go/internal/soc"
 )
 
 // PoolConn is a pooled connection.
@@ -44,9 +45,8 @@ func (c *PoolConn) Release() error {
 }
 
 func (c *PoolConn) checkErr(err error) {
-	e, ok := err.(*net.OpError)
-	if ok && !e.Temporary() {
-		c.err = e
+	if soc.IsPermanentNetErr(err) {
+		c.err = err
 	}
 }
 

--- a/poolconn.go
+++ b/poolconn.go
@@ -33,7 +33,8 @@ type PoolConn struct {
 // PoolConn is not useable after Release has been called.
 func (c *PoolConn) Release() error {
 	if c.pool == nil {
-		return ErrReleasedTwice
+		msg := "connection released more than once"
+		return newErrorFromCode(interfaceErrorCode, msg)
 	}
 
 	err := c.pool.release(c.baseConn, c.err)

--- a/poolconn.go
+++ b/poolconn.go
@@ -34,7 +34,7 @@ type PoolConn struct {
 func (c *PoolConn) Release() error {
 	if c.pool == nil {
 		msg := "connection released more than once"
-		return newErrorFromCode(interfaceErrorCode, msg)
+		return &interfaceError{msg: msg}
 	}
 
 	err := c.pool.release(c.baseConn, c.err)

--- a/poolconn_test.go
+++ b/poolconn_test.go
@@ -36,6 +36,6 @@ func TestReleasePoolConn(t *testing.T) {
 	assert.Equal(t, conn, result)
 
 	err = poolConn.Release()
-	assert.EqualError(t, err, "connection released more than once")
+	assert.EqualError(t, err, "edgedb: connection released more than once")
 	assert.True(t, errors.Is(err, ErrReleasedTwice))
 }

--- a/poolconn_test.go
+++ b/poolconn_test.go
@@ -36,8 +36,12 @@ func TestReleasePoolConn(t *testing.T) {
 	assert.Equal(t, conn, result)
 
 	err = poolConn.Release()
-	assert.EqualError(t, err, "edgedb: connection released more than once")
+	assert.EqualError(
+		t,
+		err,
+		"edgedb.InterfaceError: connection released more than once",
+	)
 
-	var errReleasedTwice *InterfaceError
+	var errReleasedTwice InterfaceError
 	assert.True(t, errors.As(err, &errReleasedTwice))
 }

--- a/poolconn_test.go
+++ b/poolconn_test.go
@@ -37,5 +37,7 @@ func TestReleasePoolConn(t *testing.T) {
 
 	err = poolConn.Release()
 	assert.EqualError(t, err, "edgedb: connection released more than once")
-	assert.True(t, errors.Is(err, ErrReleasedTwice))
+
+	var errReleasedTwice *InterfaceError
+	assert.True(t, errors.As(err, &errReleasedTwice))
 }

--- a/query_test.go
+++ b/query_test.go
@@ -129,8 +129,10 @@ func TestQueryOneZeroResults(t *testing.T) {
 func TestError(t *testing.T) {
 	ctx := context.Background()
 	err := conn.Execute(ctx, "malformed query;")
-	assert.EqualError(t, err, "Unexpected 'malformed'")
-	assert.True(t, errors.Is(err, Error))
+	assert.EqualError(t, err, "edgedb: Unexpected 'malformed'")
+
+	var expected *Error
+	assert.True(t, errors.As(err, &expected))
 }
 
 func TestQueryTimesOut(t *testing.T) {
@@ -141,7 +143,7 @@ func TestQueryTimesOut(t *testing.T) {
 	err := conn.QueryOne(ctx, "SELECT 1;", &r)
 	require.True(
 		t,
-		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, ErrContextExpired) ||
 			errors.Is(err, os.ErrDeadlineExceeded),
 		err,
 	)

--- a/query_test.go
+++ b/query_test.go
@@ -129,9 +129,13 @@ func TestQueryOneZeroResults(t *testing.T) {
 func TestError(t *testing.T) {
 	ctx := context.Background()
 	err := conn.Execute(ctx, "malformed query;")
-	assert.EqualError(t, err, "edgedb: Unexpected 'malformed'")
+	assert.EqualError(
+		t,
+		err,
+		"edgedb.EdgeQLSyntaxError: Unexpected 'malformed'",
+	)
 
-	var expected *Error
+	var expected Error
 	assert.True(t, errors.As(err, &expected))
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -143,7 +143,7 @@ func TestQueryTimesOut(t *testing.T) {
 	err := conn.QueryOne(ctx, "SELECT 1;", &r)
 	require.True(
 		t,
-		errors.Is(err, ErrContextExpired) ||
+		errors.Is(err, context.DeadlineExceeded) ||
 			errors.Is(err, os.ErrDeadlineExceeded),
 		err,
 	)

--- a/query_test.go
+++ b/query_test.go
@@ -105,7 +105,7 @@ func TestQueryOneJSONZeroResults(t *testing.T) {
 	var result []byte
 	err := conn.QueryOneJSON(ctx, "SELECT <int64>{}", &result)
 
-	require.Equal(t, err, ErrZeroResults)
+	require.Equal(t, err, errZeroResults)
 	assert.Equal(t, []byte(nil), result)
 }
 
@@ -123,7 +123,7 @@ func TestQueryOneZeroResults(t *testing.T) {
 	var result int64
 	err := conn.QueryOne(ctx, "SELECT <int64>{}", &result)
 
-	assert.Equal(t, ErrZeroResults, err)
+	assert.Equal(t, errZeroResults, err)
 }
 
 func TestError(t *testing.T) {

--- a/script_flow.go
+++ b/script_flow.go
@@ -28,7 +28,7 @@ func (c *baseConn) scriptFlow(r *buff.Reader, query string) error {
 	c.writer.EndMessage()
 
 	if e := c.writer.Send(c.conn); e != nil {
-		return wrapError(e)
+		return wrapErrorFromCode(clientConnectionErrorCode, e)
 	}
 
 	var err error
@@ -56,7 +56,7 @@ func (c *baseConn) scriptFlow(r *buff.Reader, query string) error {
 	}
 
 	if r.Err != nil {
-		return wrapError(r.Err)
+		return wrapErrorFromCode(clientConnectionErrorCode, r.Err)
 	}
 
 	return err

--- a/script_flow.go
+++ b/script_flow.go
@@ -28,7 +28,7 @@ func (c *baseConn) scriptFlow(r *buff.Reader, query string) error {
 	c.writer.EndMessage()
 
 	if e := c.writer.Send(c.conn); e != nil {
-		return wrapErrorFromCode(clientConnectionErrorCode, e)
+		return wrapErrorWithType(clientConnectionErrorCode, e)
 	}
 
 	var err error
@@ -56,7 +56,7 @@ func (c *baseConn) scriptFlow(r *buff.Reader, query string) error {
 	}
 
 	if r.Err != nil {
-		return wrapErrorFromCode(clientConnectionErrorCode, r.Err)
+		return wrapErrorWithType(clientConnectionErrorCode, r.Err)
 	}
 
 	return err

--- a/script_flow.go
+++ b/script_flow.go
@@ -28,7 +28,7 @@ func (c *baseConn) scriptFlow(r *buff.Reader, query string) error {
 	c.writer.EndMessage()
 
 	if e := c.writer.Send(c.conn); e != nil {
-		return wrapErrorWithType(clientConnectionErrorCode, e)
+		return &clientConnectionError{err: e}
 	}
 
 	var err error
@@ -56,7 +56,7 @@ func (c *baseConn) scriptFlow(r *buff.Reader, query string) error {
 	}
 
 	if r.Err != nil {
-		return wrapErrorWithType(clientConnectionErrorCode, r.Err)
+		return &clientConnectionError{err: r.Err}
 	}
 
 	return err

--- a/script_flow.go
+++ b/script_flow.go
@@ -28,7 +28,7 @@ func (c *baseConn) scriptFlow(r *buff.Reader, query string) error {
 	c.writer.EndMessage()
 
 	if e := c.writer.Send(c.conn); e != nil {
-		return e
+		return wrapError(e)
 	}
 
 	var err error
@@ -53,6 +53,10 @@ func (c *baseConn) scriptFlow(r *buff.Reader, query string) error {
 				return e
 			}
 		}
+	}
+
+	if r.Err != nil {
+		return wrapError(r.Err)
 	}
 
 	return err


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb-go/issues/24

- all errors returned from edgedb unwrap to `edgedb.Error`
- all error messages returned from edgedb start with `edgedb: `
- the only errors from other libraries that are wrapped are errors from the stdlib net package.
- errors from the edgedb server can be unwrapped using `errors.As()`. Any error type in the returned error's hierarchy will match.
- error values like `edgedb.ErrZeroResults` can be checked with `errors.Is()` or simple equality. 