### PR TITLE
fix stale write buffer bug

### DIFF
--- a/edgedb.go
+++ b/edgedb.go
@@ -30,8 +30,10 @@ import (
 )
 
 type baseConn struct {
-	conn   net.Conn
-	writer *buff.Writer
+	conn net.Conn
+
+	// writeMemory is preallocated memory for payloads to be sent to the server
+	writeMemory [1024]byte
 
 	acquireReaderSignal chan struct{}
 	readerChan          chan *buff.Reader
@@ -78,8 +80,6 @@ func connectOne(ctx context.Context, cfg *connConfig, conn *baseConn) error {
 		d   net.Dialer
 		err error
 	)
-
-	conn.writer = buff.NewWriter()
 
 	for _, addr := range cfg.addrs { // nolint:gocritic
 		conn.conn, err = d.DialContext(ctx, addr.network, addr.address)

--- a/internal/buff/testutils.go
+++ b/internal/buff/testutils.go
@@ -32,9 +32,7 @@ func newBenchmarkMessage(n int) []byte {
 }
 
 func newBenchmarkWriter(size int) *Writer {
-	w := NewWriter()
-	w.buf = make([]byte, size)[:0]
-	return w
+	return NewWriter(make([]byte, size))
 }
 
 type writerFixture struct {

--- a/internal/buff/write.go
+++ b/internal/buff/write.go
@@ -25,18 +25,14 @@ import (
 
 // Writer is a write buffer.
 type Writer struct {
-	alocatedMemory [1024]byte
-	buf            []byte
-
+	buf     []byte
 	msgPos  int
 	bytePos []int
 }
 
 // NewWriter returns a new Writer.
-func NewWriter() *Writer {
-	w := &Writer{}
-	w.buf = w.alocatedMemory[:0]
-	return w
+func NewWriter(alocatedMemory []byte) *Writer {
+	return &Writer{buf: alocatedMemory[:0]}
 }
 
 // Send writes buffered data to conn.
@@ -58,7 +54,6 @@ func (w *Writer) Send(conn io.Writer) (err error) {
 		w.buf = w.buf[n:]
 	}
 
-	w.buf = w.alocatedMemory[:0]
 	return nil
 }
 

--- a/internal/buff/write_test.go
+++ b/internal/buff/write_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestPushUint8(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	w.PushUint8(0xff)
 	assert.Equal(t, []byte{0xff}, w.buf)
 }
@@ -40,7 +40,7 @@ func BenchmarkPushUint8(b *testing.B) {
 }
 
 func TestPushUint16(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	w.PushUint16(0xffff)
 	assert.Equal(t, []byte{0xff, 0xff}, w.buf)
 }
@@ -55,7 +55,7 @@ func BenchmarkPushUint16(b *testing.B) {
 }
 
 func TestPushUint32(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	w.PushUint32(0xffffffff)
 	assert.Equal(t, []byte{0xff, 0xff, 0xff, 0xff}, w.buf)
 }
@@ -70,7 +70,7 @@ func BenchmarkPushUint32(b *testing.B) {
 }
 
 func TestPushUint64(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	w.PushUint64(0xffffffffffffffff)
 
 	expected := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
@@ -87,7 +87,7 @@ func BenchmarkPushUint64(b *testing.B) {
 }
 
 func TestPushUUID(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	w.PushUUID(types.UUID{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1})
 
 	expected := []byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}
@@ -95,7 +95,7 @@ func TestPushUUID(t *testing.T) {
 }
 
 func BenchmarkPushUUID(b *testing.B) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	id := types.UUID{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}
 	b.ResetTimer()
 
@@ -106,14 +106,14 @@ func BenchmarkPushUUID(b *testing.B) {
 }
 
 func TestPushBytes(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	w.PushBytes([]byte{7, 5})
 
 	assert.Equal(t, []byte{0, 0, 0, 2, 7, 5}, w.buf)
 }
 
 func BenchmarkPushBytes(b *testing.B) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	bytes := []byte{1, 2, 3, 4}
 	b.ResetTimer()
 
@@ -124,7 +124,7 @@ func BenchmarkPushBytes(b *testing.B) {
 }
 
 func TestPushString(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	w.PushString("hello")
 
 	expected := []byte{0, 0, 0, 5, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
@@ -141,7 +141,7 @@ func BenchmarkPushString(b *testing.B) {
 }
 
 func TestBeginBytes(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 
 	msg := "cannot begin bytes: no current message"
 	assert.PanicsWithValue(t, msg, func() { w.BeginBytes() })
@@ -164,7 +164,7 @@ func BenchmarkBeginBytes(b *testing.B) {
 }
 
 func TestEndBytes(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	noBytesMsg := "cannot end bytes: no bytes in progress"
 	assert.PanicsWithValue(t, noBytesMsg, func() { w.EndBytes() })
 
@@ -192,7 +192,7 @@ func BenchmarkBeginAndEndBytes(b *testing.B) {
 }
 
 func TestBeginMessage(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	w.BeginMessage(message.Sync)
 
 	msg := "cannot begin message: the previous message is not finished"
@@ -211,7 +211,7 @@ func BenchmarkBeginAndEndMessage(b *testing.B) {
 }
 
 func TestEndMessage(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	noMsgMsg := "cannot end message: no current message"
 	assert.PanicsWithValue(t, noMsgMsg, func() { w.EndMessage() })
 
@@ -230,7 +230,7 @@ func TestEndMessage(t *testing.T) {
 }
 
 func TestOnlySendsWhatWasPushed(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	w.PushString("hello")
 
 	f := &writerFixture{}
@@ -241,7 +241,7 @@ func TestOnlySendsWhatWasPushed(t *testing.T) {
 }
 
 func TestSendsAllChuncks(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	w.PushUint32(1)
 	w.PushUint32(2)
 	w.PushUint32(3)
@@ -259,7 +259,7 @@ func TestSendsAllChuncks(t *testing.T) {
 }
 
 func TestSendWithoutEndingMessage(t *testing.T) {
-	w := NewWriter()
+	w := NewWriter([]byte{})
 	w.BeginMessage(message.Sync)
 	assert.Panics(t, func() { _ = w.Send(&writerFixture{}) })
 }

--- a/internal/codecs/array_test.go
+++ b/internal/codecs/array_test.go
@@ -76,7 +76,7 @@ func TestEncodeArray(t *testing.T) {
 	}
 
 	for _, a := range arrays {
-		w := buff.NewWriter()
+		w := buff.NewWriter([]byte{})
 		w.BeginMessage(0xff)
 
 		codec := &Array{child: &Int64{}}
@@ -111,7 +111,7 @@ func TestEncodeArray(t *testing.T) {
 }
 
 func TestEncodeArrayWrongType(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	w.BeginMessage(0xff)
 
 	codec := &Array{child: &Int64{typ: reflect.TypeOf(int64(1))}}

--- a/internal/codecs/base_scalar_test.go
+++ b/internal/codecs/base_scalar_test.go
@@ -59,7 +59,7 @@ func BenchmarkDecodeUUID(b *testing.B) {
 }
 
 func TestEncodeUUID(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	err := (&UUID{}).Encode(w, types.UUID{
 		0, 1, 2, 3, 3, 2, 1, 0, 8, 7, 6, 5, 5, 6, 7, 8,
 	})
@@ -77,7 +77,7 @@ func TestEncodeUUID(t *testing.T) {
 }
 
 func BenchmarkEncodeUUID(b *testing.B) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	id := types.UUID{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}
 	codec := &UUID{}
 
@@ -123,7 +123,7 @@ func BenchmarkDecodeString(b *testing.B) {
 }
 
 func TestEncodeString(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	err := (&Str{}).Encode(w, "hello")
 	require.Nil(t, err)
 
@@ -175,7 +175,7 @@ func BenchmarkDecodeBytes(b *testing.B) {
 }
 
 func TestEncodeBytes(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	err := (&Bytes{}).Encode(w, []byte{104, 101, 108, 108, 111})
 	require.Nil(t, err)
 
@@ -221,7 +221,7 @@ func BenchmarkDecodeInt16(b *testing.B) {
 }
 
 func TestEncodeInt16(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	err := (&Int16{}).Encode(w, int16(7))
 	require.Nil(t, err)
 
@@ -267,7 +267,7 @@ func BenchmarkDecodeInt32(b *testing.B) {
 }
 
 func TestEncodeInt32(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	err := (&Int32{}).Encode(w, int32(7))
 	require.Nil(t, err)
 
@@ -313,7 +313,7 @@ func BenchmarkDecodeInt64(b *testing.B) {
 }
 
 func TestEncodeInt64(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	err := (&Int64{}).Encode(w, int64(27))
 	require.Nil(t, err)
 
@@ -359,7 +359,7 @@ func BenchmarkDecodeFloat32(b *testing.B) {
 }
 
 func TestEncodeFloat32(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	err := (&Float32{}).Encode(w, float32(-32))
 	require.Nil(t, err)
 
@@ -405,7 +405,7 @@ func BenchmarkDecodeFloat64(b *testing.B) {
 }
 
 func TestEncodeFloat64(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	err := (&Float64{}).Encode(w, float64(-64))
 	require.Nil(t, err)
 
@@ -451,7 +451,7 @@ func BenchmarkDecodeBool(b *testing.B) {
 }
 
 func TestEncodeBool(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	err := (&Bool{}).Encode(w, true)
 	require.Nil(t, err)
 
@@ -480,7 +480,7 @@ func TestDecodeDateTime(t *testing.T) {
 }
 
 func TestEncodeDateTime(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	err := (&DateTime{}).Encode(w, time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))
 	require.Nil(t, err)
 
@@ -510,7 +510,7 @@ func TestDecodeDuration(t *testing.T) {
 }
 
 func TestEncodeDuration(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	err := (&Duration{}).Encode(w, time.Duration(1_000_000_000))
 	require.Nil(t, err)
 
@@ -548,7 +548,7 @@ func TestDecodeJSON(t *testing.T) {
 }
 
 func TestEncodeJSON(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	(&JSON{}).Encode(w, map[string]string{"hello": "world"})
 
 	conn := &writeFixture{}

--- a/internal/codecs/named_tuple_test.go
+++ b/internal/codecs/named_tuple_test.go
@@ -134,7 +134,7 @@ func TestEncodeNamedTuple(t *testing.T) {
 		{name: "b", codec: &Int32{}},
 	}}
 
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	w.BeginMessage(message.Sync)
 	err := codec.Encode(w, []interface{}{map[string]interface{}{
 		"a": int32(5),

--- a/internal/codecs/tuple_test.go
+++ b/internal/codecs/tuple_test.go
@@ -72,7 +72,7 @@ func TestDecodeTuple(t *testing.T) {
 }
 
 func TestEncodeNullTuple(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	w.BeginMessage(0xff)
 	err := (&Tuple{}).Encode(w, []interface{}{})
 	require.Nil(t, err)
@@ -92,7 +92,7 @@ func TestEncodeNullTuple(t *testing.T) {
 }
 
 func TestEncodeTuple(t *testing.T) {
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	w.BeginMessage(0xff)
 
 	codec := &Tuple{fields: []Codec{&Int64{}, &Int64{}}}
@@ -125,7 +125,7 @@ func BenchmarkEncodeTuple(b *testing.B) {
 	codec := Tuple{fields: []Codec{&UUID{}}}
 	id := types.UUID{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}
 	ids := []interface{}{id}
-	w := buff.NewWriter()
+	w := buff.NewWriter([]byte{})
 	w.BeginMessage(0xff)
 
 	b.ResetTimer()

--- a/query_test.go
+++ b/query_test.go
@@ -27,6 +27,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestArgumentTypeMissmatch(t *testing.T) {
+	var res []interface{}
+	ctx := context.Background()
+	err := conn.QueryOne(ctx, "SELECT (<int16>$0 + <int16>$1,)", &res, 1, 1111)
+
+	require.NotNil(t, err)
+	assert.Equal(
+		t,
+		"edgedb.InvalidArgumentError: expected int16 got int",
+		err.Error(),
+	)
+}
+
 func TestNamedQueryArguments(t *testing.T) {
 	ctx := context.Background()
 	var result [][]int64

--- a/script_flow.go
+++ b/script_flow.go
@@ -22,12 +22,13 @@ import (
 )
 
 func (c *baseConn) scriptFlow(r *buff.Reader, query string) error {
-	c.writer.BeginMessage(message.ExecuteScript)
-	c.writer.PushUint16(0) // no headers
-	c.writer.PushString(query)
-	c.writer.EndMessage()
+	w := buff.NewWriter(c.writeMemory[:0])
+	w.BeginMessage(message.ExecuteScript)
+	w.PushUint16(0) // no headers
+	w.PushString(query)
+	w.EndMessage()
 
-	if e := c.writer.Send(c.conn); e != nil {
+	if e := w.Send(c.conn); e != nil {
 		return &clientConnectionError{err: e}
 	}
 


### PR DESCRIPTION
I added a test to start fixing https://github.com/edgedb/edgedb-go/issues/33 and discovered that it was already fixed, but the new test unearthed a bug caused by reusing the write buffer. This change creates a new write buffer for every payload sent to the server.