### PR TITLE
support decoding non-scalar tuple elements

### DIFF
--- a/internal/codecs/array.go
+++ b/internal/codecs/array.go
@@ -42,10 +42,15 @@ func popArrayCodec(
 
 // Array is an EdgeDB array type codec.
 type Array struct {
-	id         types.UUID
-	child      Codec
-	typ        reflect.Type
-	step       int
+	id    types.UUID
+	child Codec
+	typ   reflect.Type
+
+	// step is the element width in bytes for a go array of type `Array.typ`.
+	step int
+
+	// useReflect indicates weather reflection or a known memory layout
+	// should be used to deserialize data.
 	useReflect bool
 }
 

--- a/internal/codecs/array.go
+++ b/internal/codecs/array.go
@@ -42,20 +42,31 @@ func popArrayCodec(
 
 // Array is an EdgeDB array type codec.
 type Array struct {
-	id    types.UUID
-	child Codec
-	typ   reflect.Type
-	step  int
+	id         types.UUID
+	child      Codec
+	typ        reflect.Type
+	step       int
+	useReflect bool
 }
 
-func (c *Array) setType(typ reflect.Type) error {
+func (c *Array) setDefaultType() {
+	c.child.setDefaultType()
+	c.typ = reflect.SliceOf(c.child.Type())
+	c.step = calcStep(c.typ.Elem())
+	c.useReflect = true
+}
+
+func (c *Array) setType(typ reflect.Type) (bool, error) {
 	if typ.Kind() != reflect.Slice {
-		return fmt.Errorf("expected Slice got %v", typ.Kind())
+		return false, fmt.Errorf("expected Slice got %v", typ.Kind())
 	}
 
 	c.typ = typ
 	c.step = calcStep(typ.Elem())
-	return c.child.setType(typ.Elem())
+
+	var err error
+	c.useReflect, err = c.child.setType(typ.Elem())
+	return c.useReflect, err
 }
 
 // ID returns the descriptor id.
@@ -65,11 +76,60 @@ func (c *Array) ID() types.UUID {
 
 // Type returns the reflect.Type that this codec decodes to.
 func (c *Array) Type() reflect.Type {
-	return c.child.Type()
+	typ := c.child.Type()
+
+	if typ == nil {
+		return nil
+	}
+
+	return reflect.SliceOf(typ)
 }
 
 // Decode an array.
-func (c *Array) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *Array) Decode(r *buff.Reader, out reflect.Value) {
+	if c.useReflect {
+		c.DecodeReflect(r, out)
+		return
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodeReflect decodes an array into a reflect.Value.
+func (c *Array) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.Type() {
+		panic(fmt.Sprintf("expected %v got: %v", c.Type(), out.Type()))
+	}
+
+	r.Discard(4) // data length
+
+	// number of dimensions is 1 or 0
+	if r.PopUint32() == 0 {
+		r.Discard(8) // reserved
+		return
+	}
+
+	r.Discard(8) // reserved
+
+	upper := int32(r.PopUint32())
+	lower := int32(r.PopUint32())
+	n := int(upper - lower + 1)
+
+	if out.Cap() < n {
+		out.Set(reflect.MakeSlice(c.Type(), n, n))
+	}
+
+	if out.Len() > n {
+		out.Set(out.Slice(0, n))
+	}
+
+	for i := 0; i < n; i++ {
+		c.child.DecodeReflect(r, out.Index(i))
+	}
+}
+
+// DecodePtr decodes an array into an unsafe.Pointer.
+func (c *Array) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	r.Discard(4) // data length
 
 	// number of dimensions is 1 or 0
@@ -94,7 +154,7 @@ func (c *Array) Decode(r *buff.Reader, out unsafe.Pointer) {
 	}
 
 	for i := 0; i < n; i++ {
-		c.child.Decode(r, pAdd(slice.Data, uintptr(i*c.step)))
+		c.child.DecodePtr(r, pAdd(slice.Data, uintptr(i*c.step)))
 	}
 }
 

--- a/internal/codecs/base_scalar.go
+++ b/internal/codecs/base_scalar.go
@@ -124,12 +124,14 @@ func (c *UUID) ID() types.UUID {
 	return c.id
 }
 
-func (c *UUID) setType(typ reflect.Type) error {
+func (c *UUID) setDefaultType() {}
+
+func (c *UUID) setType(typ reflect.Type) (bool, error) {
 	if typ != c.typ {
-		return fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
 	}
 
-	return nil
+	return false, nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -138,7 +140,21 @@ func (c *UUID) Type() reflect.Type {
 }
 
 // Decode a UUID.
-func (c *UUID) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *UUID) Decode(r *buff.Reader, out reflect.Value) {
+	c.DecodeReflect(r, out)
+}
+
+// DecodeReflect decodes a UUID.using reflection
+func (c *UUID) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.typ {
+		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodePtr decodes a UUID into an unsafe.Pointer.
+func (c *UUID) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	p := (*types.UUID)(out)
 	copy((*p)[:], r.Buf[4:20])
 	r.Discard(20)
@@ -165,13 +181,14 @@ type Str struct {
 func (c *Str) ID() types.UUID {
 	return c.id
 }
+func (c *Str) setDefaultType() {}
 
-func (c *Str) setType(typ reflect.Type) error {
+func (c *Str) setType(typ reflect.Type) (bool, error) {
 	if typ != c.typ {
-		return fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
 	}
 
-	return nil
+	return false, nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -180,7 +197,21 @@ func (c *Str) Type() reflect.Type {
 }
 
 // Decode a string.
-func (c *Str) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *Str) Decode(r *buff.Reader, out reflect.Value) {
+	c.DecodeReflect(r, out)
+}
+
+// DecodeReflect decodes a str into a reflect.Value.
+func (c *Str) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.typ {
+		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodePtr decodes a str into an unsafe.Pointer.
+func (c *Str) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	*(*string)(out) = r.PopString()
 }
 
@@ -205,13 +236,14 @@ type Bytes struct {
 func (c *Bytes) ID() types.UUID {
 	return c.id
 }
+func (c *Bytes) setDefaultType() {}
 
-func (c *Bytes) setType(typ reflect.Type) error {
+func (c *Bytes) setType(typ reflect.Type) (bool, error) {
 	if typ != c.typ {
-		return fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
 	}
 
-	return nil
+	return false, nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -220,7 +252,21 @@ func (c *Bytes) Type() reflect.Type {
 }
 
 // Decode []byte.
-func (c *Bytes) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *Bytes) Decode(r *buff.Reader, out reflect.Value) {
+	c.DecodeReflect(r, out)
+}
+
+// DecodeReflect decodes bytes into a reflect.Value.
+func (c *Bytes) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.typ {
+		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodePtr decodes bytes into an unsafe.Pointer.
+func (c *Bytes) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	n := int(r.PopUint32())
 
 	p := (*[]byte)(out)
@@ -255,13 +301,14 @@ type Int16 struct {
 func (c *Int16) ID() types.UUID {
 	return c.id
 }
+func (c *Int16) setDefaultType() {}
 
-func (c *Int16) setType(typ reflect.Type) error {
+func (c *Int16) setType(typ reflect.Type) (bool, error) {
 	if typ != c.typ {
-		return fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
 	}
 
-	return nil
+	return false, nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -270,7 +317,21 @@ func (c *Int16) Type() reflect.Type {
 }
 
 // Decode an int16.
-func (c *Int16) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *Int16) Decode(r *buff.Reader, out reflect.Value) {
+	c.DecodeReflect(r, out)
+}
+
+// DecodeReflect decodes an int16 into a reflect.Value.
+func (c *Int16) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.typ {
+		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodePtr decodes an int16 into an unsafe.Pointer.
+func (c *Int16) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	r.Discard(4) // data length
 	*(*uint16)(out) = r.PopUint16()
 }
@@ -297,13 +358,14 @@ type Int32 struct {
 func (c *Int32) ID() types.UUID {
 	return c.id
 }
+func (c *Int32) setDefaultType() {}
 
-func (c *Int32) setType(typ reflect.Type) error {
+func (c *Int32) setType(typ reflect.Type) (bool, error) {
 	if typ != c.typ {
-		return fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
 	}
 
-	return nil
+	return false, nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -312,7 +374,21 @@ func (c *Int32) Type() reflect.Type {
 }
 
 // Decode an int32.
-func (c *Int32) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *Int32) Decode(r *buff.Reader, out reflect.Value) {
+	c.DecodeReflect(r, out)
+}
+
+// DecodeReflect decodes an int32 into a reflect.Value.
+func (c *Int32) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.typ {
+		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodePtr decodes an int32 into an unsafe.Pointer.
+func (c *Int32) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	*(*uint32)(out) = binary.BigEndian.Uint32(r.Buf[4:8])
 	r.Buf = r.Buf[8:]
 }
@@ -339,13 +415,14 @@ type Int64 struct {
 func (c *Int64) ID() types.UUID {
 	return c.id
 }
+func (c *Int64) setDefaultType() {}
 
-func (c *Int64) setType(typ reflect.Type) error {
+func (c *Int64) setType(typ reflect.Type) (bool, error) {
 	if typ != c.typ {
-		return fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
 	}
 
-	return nil
+	return false, nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -354,7 +431,21 @@ func (c *Int64) Type() reflect.Type {
 }
 
 // Decode an int64.
-func (c *Int64) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *Int64) Decode(r *buff.Reader, out reflect.Value) {
+	c.DecodeReflect(r, out)
+}
+
+// DecodeReflect decodes an int64 into a reflect.Value.
+func (c *Int64) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.typ {
+		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodePtr decodes an int64 into an unsafe.Pointer.
+func (c *Int64) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	*(*uint64)(out) = binary.BigEndian.Uint64(r.Buf[4:12])
 	r.Buf = r.Buf[12:]
 }
@@ -381,13 +472,14 @@ type Float32 struct {
 func (c *Float32) ID() types.UUID {
 	return c.id
 }
+func (c *Float32) setDefaultType() {}
 
-func (c *Float32) setType(typ reflect.Type) error {
+func (c *Float32) setType(typ reflect.Type) (bool, error) {
 	if typ != c.typ {
-		return fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
 	}
 
-	return nil
+	return false, nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -396,7 +488,21 @@ func (c *Float32) Type() reflect.Type {
 }
 
 // Decode a float32.
-func (c *Float32) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *Float32) Decode(r *buff.Reader, out reflect.Value) {
+	c.DecodeReflect(r, out)
+}
+
+// DecodeReflect decodes a float32 into a reflect.Value.
+func (c *Float32) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.typ {
+		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodePtr decodes a float32 into an unsafe.Pointer.
+func (c *Float32) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	*(*uint32)(out) = binary.BigEndian.Uint32(r.Buf[4:8])
 	r.Buf = r.Buf[8:]
 }
@@ -423,13 +529,14 @@ type Float64 struct {
 func (c *Float64) ID() types.UUID {
 	return c.id
 }
+func (c *Float64) setDefaultType() {}
 
-func (c *Float64) setType(typ reflect.Type) error {
+func (c *Float64) setType(typ reflect.Type) (bool, error) {
 	if typ != c.typ {
-		return fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
 	}
 
-	return nil
+	return false, nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -438,7 +545,21 @@ func (c *Float64) Type() reflect.Type {
 }
 
 // Decode a float64.
-func (c *Float64) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *Float64) Decode(r *buff.Reader, out reflect.Value) {
+	c.DecodeReflect(r, out)
+}
+
+// DecodeReflect decodes a float64 into a reflect.Value.
+func (c *Float64) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.typ {
+		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodePtr decodes a float64 into an unsafe.Pointer.
+func (c *Float64) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	*(*uint64)(out) = binary.BigEndian.Uint64(r.Buf[4:12])
 	r.Buf = r.Buf[12:]
 }
@@ -465,13 +586,14 @@ type Bool struct {
 func (c *Bool) ID() types.UUID {
 	return c.id
 }
+func (c *Bool) setDefaultType() {}
 
-func (c *Bool) setType(typ reflect.Type) error {
+func (c *Bool) setType(typ reflect.Type) (bool, error) {
 	if typ != c.typ {
-		return fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
 	}
 
-	return nil
+	return false, nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -480,7 +602,21 @@ func (c *Bool) Type() reflect.Type {
 }
 
 // Decode a bool.
-func (c *Bool) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *Bool) Decode(r *buff.Reader, out reflect.Value) {
+	c.DecodeReflect(r, out)
+}
+
+// DecodeReflect decodes a bool into a reflect.Value.
+func (c *Bool) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.typ {
+		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodePtr decodes a bool into an unsafe.Pointer.
+func (c *Bool) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	r.Discard(4) // data length
 	*(*uint8)(out) = r.PopUint8()
 }
@@ -514,13 +650,14 @@ type DateTime struct {
 func (c *DateTime) ID() types.UUID {
 	return c.id
 }
+func (c *DateTime) setDefaultType() {}
 
-func (c *DateTime) setType(typ reflect.Type) error {
+func (c *DateTime) setType(typ reflect.Type) (bool, error) {
 	if typ != c.typ {
-		return fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
 	}
 
-	return nil
+	return false, nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -529,7 +666,21 @@ func (c *DateTime) Type() reflect.Type {
 }
 
 // Decode a datetime.
-func (c *DateTime) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *DateTime) Decode(r *buff.Reader, out reflect.Value) {
+	c.DecodeReflect(r, out)
+}
+
+// DecodeReflect decodes a datetime into a reflect.Value.
+func (c *DateTime) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.typ {
+		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodePtr decodes a datetime into an unsafe.Pointer.
+func (c *DateTime) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	r.Discard(4) // data length
 	val := int64(r.PopUint64())
 	seconds := val / 1_000_000
@@ -566,12 +717,13 @@ func (c *Duration) ID() types.UUID {
 	return c.id
 }
 
-func (c *Duration) setType(typ reflect.Type) error {
+func (c *Duration) setDefaultType() {}
+func (c *Duration) setType(typ reflect.Type) (bool, error) {
 	if typ != c.typ {
-		return fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
 	}
 
-	return nil
+	return false, nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -580,7 +732,21 @@ func (c *Duration) Type() reflect.Type {
 }
 
 // Decode a duration.
-func (c *Duration) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *Duration) Decode(r *buff.Reader, out reflect.Value) {
+	c.DecodeReflect(r, out)
+}
+
+// DecodeReflect decodes a duration into a reflect.Value.
+func (c *Duration) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.typ {
+		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodePtr decodes a duration into an unsafe.Pointer.
+func (c *Duration) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	r.Discard(4) // data length
 	microseconds := int64(r.PopUint64())
 	r.Discard(8) // reserved
@@ -612,12 +778,14 @@ func (c *JSON) ID() types.UUID {
 	return c.id
 }
 
-func (c *JSON) setType(typ reflect.Type) error { // nolint:unused
+func (c *JSON) setDefaultType() {} // nolint:unused
+
+func (c *JSON) setType(typ reflect.Type) (bool, error) { // nolint:unused
 	if typ != c.typ {
-		return fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
 	}
 
-	return nil
+	return false, nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -626,7 +794,21 @@ func (c *JSON) Type() reflect.Type {
 }
 
 // Decode json.
-func (c *JSON) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *JSON) Decode(r *buff.Reader, out reflect.Value) {
+	c.DecodeReflect(r, out)
+}
+
+// DecodeReflect decodes JSON into a reflect.Value.
+func (c *JSON) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.typ {
+		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodePtr decodes JSON into an unsafe.Pointer.
+func (c *JSON) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	r.PopBytes()
 }
 

--- a/internal/codecs/base_scalar_test.go
+++ b/internal/codecs/base_scalar_test.go
@@ -34,7 +34,7 @@ func TestDecodeUUID(t *testing.T) {
 	})
 
 	var result types.UUID
-	(&UUID{}).Decode(r, unsafe.Pointer(&result))
+	(&UUID{}).DecodePtr(r, unsafe.Pointer(&result))
 
 	expected := types.UUID{0, 1, 2, 3, 3, 2, 1, 0, 8, 7, 6, 5, 5, 6, 7, 8}
 	assert.Equal(t, expected, result)
@@ -54,7 +54,7 @@ func BenchmarkDecodeUUID(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.Buf = data
-		codec.Decode(r, ptr)
+		codec.DecodePtr(r, ptr)
 	}
 }
 
@@ -95,7 +95,7 @@ func TestDecodeString(t *testing.T) {
 	r := buff.SimpleReader(data)
 
 	var result string
-	(&Str{}).Decode(r, unsafe.Pointer(&result))
+	(&Str{}).DecodePtr(r, unsafe.Pointer(&result))
 
 	assert.Equal(t, "hello", result)
 
@@ -118,7 +118,7 @@ func BenchmarkDecodeString(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.Buf = data
-		codec.Decode(r, ptr)
+		codec.DecodePtr(r, ptr)
 	}
 }
 
@@ -146,7 +146,7 @@ func TestDecodeBytes(t *testing.T) {
 	r := buff.SimpleReader(data)
 
 	var result []byte
-	(&Bytes{}).Decode(r, unsafe.Pointer(&result))
+	(&Bytes{}).DecodePtr(r, unsafe.Pointer(&result))
 
 	expected := []byte{104, 101, 108, 108, 111}
 	assert.Equal(t, expected, result)
@@ -170,7 +170,7 @@ func BenchmarkDecodeBytes(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.Buf = data
-		codec.Decode(r, ptr)
+		codec.DecodePtr(r, ptr)
 	}
 }
 
@@ -197,7 +197,7 @@ func TestDecodeInt16(t *testing.T) {
 	})
 
 	var result int16
-	(&Int16{}).Decode(r, unsafe.Pointer(&result))
+	(&Int16{}).DecodePtr(r, unsafe.Pointer(&result))
 
 	assert.Equal(t, int16(7), result)
 }
@@ -216,7 +216,7 @@ func BenchmarkDecodeInt16(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.Buf = data
-		codec.Decode(r, ptr)
+		codec.DecodePtr(r, ptr)
 	}
 }
 
@@ -243,7 +243,7 @@ func TestDecodeInt32(t *testing.T) {
 	})
 
 	var result int32
-	(&Int32{}).Decode(r, unsafe.Pointer(&result))
+	(&Int32{}).DecodePtr(r, unsafe.Pointer(&result))
 
 	assert.Equal(t, int32(7), result)
 }
@@ -262,7 +262,7 @@ func BenchmarkDecodeInt32(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.Buf = data
-		codec.Decode(r, ptr)
+		codec.DecodePtr(r, ptr)
 	}
 }
 
@@ -289,7 +289,7 @@ func TestDecodeInt64(t *testing.T) {
 	})
 
 	var result int64
-	(&Int64{}).Decode(r, unsafe.Pointer(&result))
+	(&Int64{}).DecodePtr(r, unsafe.Pointer(&result))
 
 	assert.Equal(t, int64(72623859790382856), result)
 }
@@ -308,7 +308,7 @@ func BenchmarkDecodeInt64(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.Buf = data
-		codec.Decode(r, ptr)
+		codec.DecodePtr(r, ptr)
 	}
 }
 
@@ -335,7 +335,7 @@ func TestDecodeFloat32(t *testing.T) {
 	})
 
 	var result float32
-	(&Float32{}).Decode(r, unsafe.Pointer(&result))
+	(&Float32{}).DecodePtr(r, unsafe.Pointer(&result))
 
 	assert.Equal(t, float32(-32), result)
 }
@@ -354,7 +354,7 @@ func BenchmarkDecodeFloat32(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.Buf = data
-		codec.Decode(r, ptr)
+		codec.DecodePtr(r, ptr)
 	}
 }
 
@@ -381,7 +381,7 @@ func TestDecodeFloat64(t *testing.T) {
 	})
 
 	var result float64
-	(&Float64{}).Decode(r, unsafe.Pointer(&result))
+	(&Float64{}).DecodePtr(r, unsafe.Pointer(&result))
 
 	assert.Equal(t, float64(-64), result)
 }
@@ -400,7 +400,7 @@ func BenchmarkDecodeFloat64(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.Buf = data
-		codec.Decode(r, ptr)
+		codec.DecodePtr(r, ptr)
 	}
 }
 
@@ -427,7 +427,7 @@ func TestDecodeBool(t *testing.T) {
 	})
 
 	var result bool
-	(&Bool{}).Decode(r, unsafe.Pointer(&result))
+	(&Bool{}).DecodePtr(r, unsafe.Pointer(&result))
 
 	assert.Equal(t, true, result)
 }
@@ -446,7 +446,7 @@ func BenchmarkDecodeBool(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.Buf = data
-		codec.Decode(r, ptr)
+		codec.DecodePtr(r, ptr)
 	}
 }
 
@@ -473,7 +473,7 @@ func TestDecodeDateTime(t *testing.T) {
 	})
 
 	var result time.Time
-	(&DateTime{}).Decode(r, unsafe.Pointer(&result))
+	(&DateTime{}).DecodePtr(r, unsafe.Pointer(&result))
 
 	expected := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	assert.Equal(t, expected, result)
@@ -504,7 +504,7 @@ func TestDecodeDuration(t *testing.T) {
 	})
 
 	var result time.Duration
-	(&Duration{}).Decode(r, unsafe.Pointer(&result))
+	(&Duration{}).DecodePtr(r, unsafe.Pointer(&result))
 
 	assert.Equal(t, time.Duration(1_000_000_000), result)
 }
@@ -541,7 +541,7 @@ func TestDecodeJSON(t *testing.T) {
 	})
 
 	var result interface{}
-	(&JSON{}).Decode(r, unsafe.Pointer(&result))
+	(&JSON{}).DecodePtr(r, unsafe.Pointer(&result))
 	expected := map[string]interface{}{"hello": "world"}
 
 	assert.Equal(t, expected, result)

--- a/internal/codecs/codecs.go
+++ b/internal/codecs/codecs.go
@@ -118,6 +118,7 @@ func pAdd(p unsafe.Pointer, i uintptr) unsafe.Pointer {
 	return unsafe.Pointer(uintptr(p) + i)
 }
 
+// calcStep returns the element width in bytes for a go array of `typ`.
 func calcStep(typ reflect.Type) int {
 	step := int(typ.Size())
 	a := typ.Align()

--- a/internal/codecs/codecs.go
+++ b/internal/codecs/codecs.go
@@ -39,11 +39,17 @@ const (
 
 // Codec interface
 type Codec interface {
-	Decode(*buff.Reader, unsafe.Pointer)
+	Decode(*buff.Reader, reflect.Value)
+	DecodeReflect(*buff.Reader, reflect.Value)
+	DecodePtr(*buff.Reader, unsafe.Pointer)
 	Encode(*buff.Writer, interface{}) error
 	ID() types.UUID
 	Type() reflect.Type
-	setType(reflect.Type) error
+	setDefaultType()
+
+	// setType returns true if the memory layout for reflect.Type
+	// is not fully known.
+	setType(reflect.Type) (bool, error)
 }
 
 // BuildCodec a decoder
@@ -99,7 +105,7 @@ func BuildTypedCodec(r *buff.Reader, t reflect.Type) (Codec, error) {
 		return nil, err
 	}
 
-	if err := codec.setType(t); err != nil {
+	if _, err = codec.setType(t); err != nil {
 		return nil, fmt.Errorf(
 			"the \"out\" argument does not match query schema: %v", err,
 		)
@@ -112,9 +118,9 @@ func pAdd(p unsafe.Pointer, i uintptr) unsafe.Pointer {
 	return unsafe.Pointer(uintptr(p) + i)
 }
 
-func calcStep(tp reflect.Type) int {
-	step := int(tp.Size())
-	a := tp.Align()
+func calcStep(typ reflect.Type) int {
+	step := int(typ.Size())
+	a := typ.Align()
 
 	if step%a > 0 {
 		step = step/a + a

--- a/internal/codecs/named_tuple.go
+++ b/internal/codecs/named_tuple.go
@@ -55,9 +55,12 @@ func popNamedTupleCodec(
 
 // NamedTuple is an EdgeDB namedtuple type codec.
 type NamedTuple struct {
-	id         types.UUID
-	fields     []*objectField
-	typ        reflect.Type
+	id     types.UUID
+	fields []*objectField
+	typ    reflect.Type
+
+	// useReflect indicates weather reflection or a known memory layout
+	// should be used to deserialize data.
 	useReflect bool
 }
 

--- a/internal/codecs/object.go
+++ b/internal/codecs/object.go
@@ -64,9 +64,12 @@ type objectField struct {
 
 // Object is an EdgeDB object type codec.
 type Object struct {
-	id         types.UUID
-	fields     []*objectField
-	typ        reflect.Type
+	id     types.UUID
+	fields []*objectField
+	typ    reflect.Type
+
+	// useReflect indicates weather reflection or a known memory layout
+	// should be used to deserialize data.
 	useReflect bool
 }
 

--- a/internal/codecs/object.go
+++ b/internal/codecs/object.go
@@ -64,9 +64,10 @@ type objectField struct {
 
 // Object is an EdgeDB object type codec.
 type Object struct {
-	id     types.UUID
-	fields []*objectField
-	typ    reflect.Type
+	id         types.UUID
+	fields     []*objectField
+	typ        reflect.Type
+	useReflect bool
 }
 
 // ID returns the descriptor id.
@@ -74,9 +75,18 @@ func (c *Object) ID() types.UUID {
 	return c.id
 }
 
-func (c *Object) setType(typ reflect.Type) error {
+func (c *Object) setDefaultType() {
+	for _, field := range c.fields {
+		field.codec.setDefaultType()
+	}
+
+	c.typ = reflect.TypeOf(map[string]interface{}{})
+	c.useReflect = true
+}
+
+func (c *Object) setType(typ reflect.Type) (bool, error) {
 	if typ.Kind() != reflect.Struct {
-		return fmt.Errorf("expected Struct got %v", typ.Kind())
+		return false, fmt.Errorf("expected Struct got %v", typ.Kind())
 	}
 
 	for _, field := range c.fields {
@@ -84,18 +94,25 @@ func (c *Object) setType(typ reflect.Type) error {
 			continue
 		}
 
-		if f, ok := marshal.StructField(typ, field.name); ok {
-			field.offset = f.Offset
-			if err := field.codec.setType(f.Type); err != nil {
-				return err
-			}
-		} else {
-			return fmt.Errorf("%v struct is missing field %q", typ, field.name)
+		f, ok := marshal.StructField(typ, field.name)
+		if !ok {
+			return false, fmt.Errorf(
+				"%v struct is missing field %q",
+				typ, field.name,
+			)
 		}
+
+		useReflect, err := field.codec.setType(f.Type)
+		if err != nil {
+			return false, err
+		}
+
+		field.offset = f.Offset
+		c.useReflect = c.useReflect || useReflect
 	}
 
 	c.typ = typ
-	return nil
+	return c.useReflect, nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -104,7 +121,83 @@ func (c *Object) Type() reflect.Type {
 }
 
 // Decode an object
-func (c *Object) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *Object) Decode(r *buff.Reader, out reflect.Value) {
+	if c.useReflect {
+		c.DecodeReflect(r, out)
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodeReflect decodes an object into a reflect.Value.
+func (c *Object) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	if out.Type() != c.typ {
+		panic(fmt.Sprintf(
+			"object codec unexpected type: expected %v, but got %v",
+			c.typ,
+			out.Type(),
+		))
+	}
+
+	switch out.Kind() {
+	case reflect.Struct:
+		c.decodeReflectStruct(r, out)
+	case reflect.Map:
+		c.decodeReflectMap(r, out)
+	default:
+		panic(fmt.Sprintf("object codec can not decode into %v", out.Kind()))
+	}
+}
+
+func (c *Object) decodeReflectStruct(r *buff.Reader, out reflect.Value) {
+	r.Discard(8) // data length & element count
+
+	for _, field := range c.fields {
+		r.Discard(4) // reserved
+
+		switch int32(r.PeekUint32()) {
+		case -1:
+			// element length -1 means missing field
+			// https://www.edgedb.com/docs/internals/protocol/dataformats
+			r.Discard(4)
+		default:
+			if field.name == "__tid__" {
+				r.Discard(20)
+				break
+			}
+
+			field.codec.DecodeReflect(r, out.FieldByName(field.name))
+		}
+	}
+}
+
+func (c *Object) decodeReflectMap(r *buff.Reader, out reflect.Value) {
+	r.Discard(8) // data length & element count
+	out.Set(reflect.MakeMapWithSize(c.typ, len(c.fields)))
+
+	for _, field := range c.fields {
+		r.Discard(4) // reserved
+
+		switch int32(r.PeekUint32()) {
+		case -1:
+			// element length -1 means missing field
+			// https://www.edgedb.com/docs/internals/protocol/dataformats
+			r.Discard(4)
+		default:
+			if field.name == "__tid__" {
+				r.Discard(20)
+				break
+			}
+
+			val := reflect.New(field.codec.Type()).Elem()
+			field.codec.DecodeReflect(r, val)
+			out.SetMapIndex(reflect.ValueOf(field.name), val)
+		}
+	}
+}
+
+// DecodePtr decodes an object into an unsafe.Pointer.
+func (c *Object) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	r.Discard(8) // data length & element count
 
 	for _, field := range c.fields {
@@ -122,7 +215,7 @@ func (c *Object) Decode(r *buff.Reader, out unsafe.Pointer) {
 			}
 
 			p := pAdd(out, field.offset)
-			field.codec.Decode(r, p)
+			field.codec.DecodePtr(r, p)
 		}
 	}
 }

--- a/internal/codecs/set.go
+++ b/internal/codecs/set.go
@@ -36,10 +36,11 @@ func popSetCodec(
 
 // Set is an EdgeDB set type codec.
 type Set struct {
-	id    types.UUID
-	child Codec
-	typ   reflect.Type
-	step  int
+	id         types.UUID
+	child      Codec
+	typ        reflect.Type
+	step       int
+	useReflect bool
 }
 
 // ID returns the descriptor id.
@@ -47,14 +48,23 @@ func (c *Set) ID() types.UUID {
 	return c.id
 }
 
-func (c *Set) setType(typ reflect.Type) error {
+func (c *Set) setDefaultType() {
+	c.child.setDefaultType()
+	c.typ = reflect.SliceOf(c.child.Type())
+	c.step = calcStep(c.typ.Elem())
+	c.useReflect = true
+}
+func (c *Set) setType(typ reflect.Type) (bool, error) {
 	if typ.Kind() != reflect.Slice {
-		return fmt.Errorf("expected Slice got %v", typ.Kind())
+		return false, fmt.Errorf("expected Slice got %v", typ.Kind())
 	}
 
 	c.typ = typ
 	c.step = calcStep(typ.Elem())
-	return c.child.setType(typ.Elem())
+
+	var err error
+	c.useReflect, err = c.child.setType(typ.Elem())
+	return c.useReflect, err
 }
 
 // Type returns the reflect.Type that this codec decodes to.
@@ -63,7 +73,43 @@ func (c *Set) Type() reflect.Type {
 }
 
 // Decode a set
-func (c *Set) Decode(r *buff.Reader, out unsafe.Pointer) {
+func (c *Set) Decode(r *buff.Reader, out reflect.Value) {
+	if c.useReflect {
+		c.DecodeReflect(r, out)
+	}
+
+	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
+}
+
+// DecodeReflect decodes a set into a reflect.Value.
+func (c *Set) DecodeReflect(r *buff.Reader, out reflect.Value) {
+	r.Discard(4) // data length
+
+	// number of dimensions, either 0 or 1
+	if r.PopUint32() == 0 {
+		r.Discard(8) // skip 2 reserved fields
+		return
+	}
+
+	r.Discard(8) // reserved
+
+	upper := int32(r.PopUint32())
+	lower := int32(r.PopUint32())
+	n := int(upper - lower + 1)
+
+	if out.Cap() < n {
+		out.Set(reflect.MakeSlice(c.typ, n, n))
+	} else {
+		out.SetLen(n)
+	}
+
+	for i := 0; i < n; i++ {
+		c.child.DecodeReflect(r, out.Index(i))
+	}
+}
+
+// DecodePtr decodes a set into an unsafe.Pointer.
+func (c *Set) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 	r.Discard(4) // data length
 
 	// number of dimensions, either 0 or 1
@@ -89,7 +135,7 @@ func (c *Set) Decode(r *buff.Reader, out unsafe.Pointer) {
 	}
 
 	for i := 0; i < n; i++ {
-		c.child.Decode(r, pAdd(slice.Data, uintptr(i*c.step)))
+		c.child.DecodePtr(r, pAdd(slice.Data, uintptr(i*c.step)))
 	}
 }
 

--- a/internal/codecs/set.go
+++ b/internal/codecs/set.go
@@ -36,10 +36,15 @@ func popSetCodec(
 
 // Set is an EdgeDB set type codec.
 type Set struct {
-	id         types.UUID
-	child      Codec
-	typ        reflect.Type
-	step       int
+	id    types.UUID
+	child Codec
+	typ   reflect.Type
+
+	// step is the element width in bytes for a go array of type `Array.typ`.
+	step int
+
+	// useReflect indicates weather reflection or a known memory layout
+	// should be used to deserialize data.
 	useReflect bool
 }
 

--- a/internal/codecs/tuple.go
+++ b/internal/codecs/tuple.go
@@ -43,10 +43,12 @@ func popTupleCodec(
 
 // Tuple is an EdgeDB tuple type codec.
 type Tuple struct {
-	id         types.UUID
-	fields     []Codec
-	typ        reflect.Type
-	step       int
+	id     types.UUID
+	fields []Codec
+	typ    reflect.Type
+
+	// useReflect indicates weather reflection or a known memory layout
+	// should be used to deserialize data.
 	useReflect bool
 }
 
@@ -61,7 +63,6 @@ func (c *Tuple) setDefaultType() {
 	}
 
 	c.typ = reflect.TypeOf([]interface{}{})
-	c.step = 16
 	c.useReflect = true
 }
 
@@ -78,7 +79,6 @@ func (c *Tuple) setType(typ reflect.Type) (bool, error) {
 	}
 
 	c.typ = reflect.TypeOf([]interface{}{})
-	c.step = 16
 
 	for _, field := range c.fields {
 		// scalar codecs have a preset type

--- a/internal/codecs/tuple_test.go
+++ b/internal/codecs/tuple_test.go
@@ -36,8 +36,6 @@ func TestTupleSetType(t *testing.T) {
 	useReflect, err := codec.setType(reflect.TypeOf([]interface{}{}))
 	require.Nil(t, err)
 	require.False(t, useReflect)
-
-	assert.Equal(t, 16, codec.step)
 }
 
 func TestTupleDecodePtr(t *testing.T) {

--- a/internal/codecs/tuple_test.go
+++ b/internal/codecs/tuple_test.go
@@ -33,13 +33,14 @@ func TestTupleSetType(t *testing.T) {
 		&Int64{typ: int64Type},
 		&Int32{typ: int32Type},
 	}}
-	err := codec.setType(reflect.TypeOf([]interface{}{}))
+	useReflect, err := codec.setType(reflect.TypeOf([]interface{}{}))
 	require.Nil(t, err)
+	require.False(t, useReflect)
 
 	assert.Equal(t, 16, codec.step)
 }
 
-func TestDecodeTuple(t *testing.T) {
+func TestTupleDecodePtr(t *testing.T) {
 	r := buff.SimpleReader([]byte{
 		0, 0, 0, 32, // data length
 		0, 0, 0, 2, // number of elements
@@ -59,9 +60,43 @@ func TestDecodeTuple(t *testing.T) {
 		&Int64{typ: int64Type},
 		&Int32{typ: int32Type},
 	}}
-	err := codec.setType(reflect.TypeOf(result))
+	useReflect, err := codec.setType(reflect.TypeOf(result))
 	require.Nil(t, err)
-	codec.Decode(r, unsafe.Pointer(&result))
+	require.False(t, useReflect)
+	codec.DecodePtr(r, unsafe.Pointer(&result))
+
+	// force garbage collection to be sure that
+	// references are durable.
+	debug.FreeOSMemory()
+
+	expected := []interface{}{int64(2), int32(3)}
+	assert.Equal(t, expected, result)
+}
+
+func TestTupleDecodeReflect(t *testing.T) {
+	r := buff.SimpleReader([]byte{
+		0, 0, 0, 32, // data length
+		0, 0, 0, 2, // number of elements
+		// element 0
+		0, 0, 0, 0, // reserved
+		0, 0, 0, 8, // data length
+		0, 0, 0, 0, 0, 0, 0, 2,
+		// element 1
+		0, 0, 0, 0, // reserved
+		0, 0, 0, 4, // data length
+		0, 0, 0, 3,
+	})
+
+	var result []interface{}
+
+	codec := &Tuple{fields: []Codec{
+		&Int64{typ: int64Type},
+		&Int32{typ: int32Type},
+	}}
+	useReflect, err := codec.setType(reflect.TypeOf(result))
+	require.Nil(t, err)
+	require.False(t, useReflect)
+	codec.DecodeReflect(r, reflect.ValueOf(&result).Elem())
 
 	// force garbage collection to be sure that
 	// references are durable.

--- a/internal/marshal/marshal_test.go
+++ b/internal/marshal/marshal_test.go
@@ -32,22 +32,22 @@ type SomeStruct struct {
 }
 
 func TestStructFieldTagPrefered(t *testing.T) {
-	tp := reflect.TypeOf(SomeStruct{})
-	field, ok := StructField(tp, "First")
+	typ := reflect.TypeOf(SomeStruct{})
+	field, ok := StructField(typ, "First")
 	require.True(t, ok)
 	assert.Equal(t, "Third", field.Name)
 }
 
 func TestStructFieldByName(t *testing.T) {
-	tp := reflect.TypeOf(SomeStruct{})
-	field, ok := StructField(tp, "Second")
+	typ := reflect.TypeOf(SomeStruct{})
+	field, ok := StructField(typ, "Second")
 	require.True(t, ok)
 	assert.Equal(t, "Second", field.Name)
 }
 
 func TestStructFieldMissingField(t *testing.T) {
-	tp := reflect.TypeOf(SomeStruct{})
-	_, ok := StructField(tp, "Fourth")
+	typ := reflect.TypeOf(SomeStruct{})
+	_, ok := StructField(typ, "Fourth")
 	require.False(t, ok)
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -19,6 +19,7 @@ package edgedb
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -38,6 +39,27 @@ func TestArgumentTypeMissmatch(t *testing.T) {
 		"edgedb.InvalidArgumentError: expected int16 got int",
 		err.Error(),
 	)
+}
+
+func TestDeeplyNestedTuple(t *testing.T) {
+	var result []interface{}
+	ctx := context.Background()
+	query := "SELECT ([(1, 2), (3, 4)], (5, (6, 7)))"
+	err := conn.QueryOne(ctx, query, &result)
+	require.Nil(t, err, fmt.Sprintf("%v", err))
+
+	expected := []interface{}{
+		[][]interface{}{
+			{int64(1), int64(2)},
+			{int64(3), int64(4)},
+		},
+		[]interface{}{
+			int64(5),
+			[]interface{}{int64(6), int64(7)},
+		},
+	}
+
+	assert.Equal(t, expected, result)
 }
 
 func TestNamedQueryArguments(t *testing.T) {


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb-go/issues/54

This change enables decoding tuple elements to default types.
- Object and named tuples decode to map[string]interface{}
- tuples to []interface{}
- scalars to their respective types
- array & set to slice of whatever the element type decodes to