### PR TITLE
add try transaction and retry

### DIFF
--- a/borrow.go
+++ b/borrow.go
@@ -16,6 +16,8 @@
 
 package edgedb
 
+import "fmt"
+
 type borrowable struct {
 	reason string
 }
@@ -27,8 +29,10 @@ func (b *borrowable) assertUnborrowed() error {
 			msg: "Connection is borrowed for a transaction. " +
 				"Use the methods on transaction object instead.",
 		}
-	default:
+	case "":
 		return nil
+	default:
+		panic(fmt.Sprintf("unexpected reason: %q", b.reason))
 	}
 }
 
@@ -38,10 +42,18 @@ func (b *borrowable) borrow(reason string) error {
 		return &interfaceError{msg: msg}
 	}
 
+	if reason != "transaction" {
+		panic(fmt.Sprintf("unexpected reason: %q", reason))
+	}
+
 	b.reason = reason
 	return nil
 }
 
 func (b *borrowable) unborrow() {
+	if b.reason == "" {
+		panic("not currently borrowed, can not unborrow")
+	}
+
 	b.reason = ""
 }

--- a/conn.go
+++ b/conn.go
@@ -25,7 +25,7 @@ import (
 // Conn is a single connection to a server.
 // Conn implementations are not safe for concurrent use.
 type Conn interface {
-	Querier
+	Executor
 	Trier
 
 	// Close closes the connection.

--- a/conn.go
+++ b/conn.go
@@ -22,13 +22,107 @@ import (
 	"github.com/edgedb/edgedb-go/internal/cache"
 )
 
-// Conn is a conn created outside of a pool.
-type Conn struct {
-	baseConn
+// Conn is a single connection to a server.
+// Conn implementations are not safe for concurrent use.
+type Conn interface {
+	Querier
+	Trier
+
+	// Close closes the connection.
+	// Connections are not usable after they are closed.
+	Close() error
+}
+
+// connection is the standalone connection implementation.
+type connection struct {
+	*baseConn
+	borrowable
+}
+
+func (c *connection) Close() error {
+	return c.baseConn.close()
+}
+
+func (c *connection) Execute(ctx context.Context, cmd string) error {
+	if e := c.assertUnborrowed(); e != nil {
+		return e
+	}
+
+	return c.baseConn.Execute(ctx, cmd)
+}
+
+func (c *connection) Query(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
+	if e := c.assertUnborrowed(); e != nil {
+		return e
+	}
+
+	return c.baseConn.Query(ctx, cmd, out, args...)
+}
+
+func (c *connection) QueryOne(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
+	if e := c.assertUnborrowed(); e != nil {
+		return e
+	}
+
+	return c.baseConn.QueryOne(ctx, cmd, out, args...)
+}
+
+func (c *connection) QueryJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
+	if e := c.assertUnborrowed(); e != nil {
+		return e
+	}
+
+	return c.baseConn.QueryJSON(ctx, cmd, out, args...)
+}
+
+func (c *connection) QueryOneJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
+	if e := c.assertUnborrowed(); e != nil {
+		return e
+	}
+
+	return c.baseConn.QueryOneJSON(ctx, cmd, out, args...)
+}
+
+func (c *connection) TryTx(ctx context.Context, action Action) error {
+	if e := c.borrow("transaction"); e != nil {
+		return e
+	}
+	defer c.unborrow()
+
+	return c.baseConn.TryTx(ctx, action)
+}
+
+func (c *connection) Retry(ctx context.Context, action Action) error {
+	if e := c.borrow("transaction"); e != nil {
+		return e
+	}
+	defer c.unborrow()
+
+	return c.baseConn.Retry(ctx, action)
 }
 
 // ConnectOne establishes a connection to an EdgeDB server.
-func ConnectOne(ctx context.Context, opts Options) (*Conn, error) { // nolint:gocritic,lll
+func ConnectOne(ctx context.Context, opts Options) (Conn, error) { // nolint:gocritic,lll
 	return ConnectOneDSN(ctx, "", opts)
 }
 
@@ -37,7 +131,7 @@ func ConnectOneDSN(
 	ctx context.Context,
 	dsn string,
 	opts Options, // nolint:gocritic
-) (*Conn, error) {
+) (Conn, error) {
 	config, err := parseConnectDSNAndArgs(dsn, &opts)
 	if err != nil {
 		return nil, err
@@ -54,10 +148,5 @@ func ConnectOneDSN(
 		return nil, err
 	}
 
-	return &Conn{*conn}, nil
-}
-
-// Close closes the connection.
-func (c *Conn) Close() error {
-	return c.baseConn.close()
+	return &connection{baseConn: conn}, nil
 }

--- a/edgedb.go
+++ b/edgedb.go
@@ -59,8 +59,8 @@ type Trier interface {
 	Retry(context.Context, Action) error
 }
 
-// Querier allows querying the database.
-type Querier interface {
+// Executor allows querying the database.
+type Executor interface {
 	// Execute an EdgeQL command (or commands).
 	Execute(context.Context, string) error
 

--- a/edgedb.go
+++ b/edgedb.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"net"
 	"syscall"
@@ -33,7 +34,52 @@ import (
 	"github.com/edgedb/edgedb-go/internal/soc"
 )
 
+const defaultMaxTxRetries = 3
+
 var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func defaultBackoff(attempt int) time.Duration {
+	backoff := math.Pow(2.0, float64(attempt)) * 100.0
+	jitter := rnd.Float64() * 100.0
+	return time.Duration(backoff+jitter) * time.Millisecond
+}
+
+// Action is work to be done in a transaction.
+type Action func(context.Context, Tx) error
+
+// Trier allows trying actions in a transaction.
+type Trier interface {
+	// TryTx runs an action in a transaction.
+	// If the action returns an error the transaction is rolled back,
+	// otherwise it is committed.
+	TryTx(context.Context, Action) error
+
+	// Retry does the same as TryTx
+	// but retries the action if it might succeed on a subsequent attempt.
+	Retry(context.Context, Action) error
+}
+
+// Querier allows querying the database.
+type Querier interface {
+	// Execute an EdgeQL command (or commands).
+	Execute(context.Context, string) error
+
+	// Query runs a query and returns the results.
+	Query(context.Context, string, interface{}, ...interface{}) error
+
+	// QueryOne runs a singleton-returning query and returns its element.
+	// If the query executes successfully but doesn't return a result
+	// a NoDataError is returned.
+	QueryOne(context.Context, string, interface{}, ...interface{}) error
+
+	// QueryJSON runs a query and return the results as JSON.
+	QueryJSON(context.Context, string, *[]byte, ...interface{}) error
+
+	// QueryOneJSON runs a singleton-returning query.
+	// If the query executes successfully but doesn't have a result
+	// a NoDataError is returned.
+	QueryOneJSON(context.Context, string, *[]byte, ...interface{}) error
+}
 
 type baseConn struct {
 	conn net.Conn
@@ -139,7 +185,7 @@ handleError:
 	}
 }
 
-// recconnect establishes a new connection with the server
+// reconnect establishes a new connection with the server
 // retrying the connection on failure.
 // An error is returned if the `baseConn` was closed.
 func (c *baseConn) reconnect(ctx context.Context) (err error) {
@@ -260,7 +306,6 @@ func (c *baseConn) ensureConnection(ctx context.Context) error {
 	return c.reconnect(ctx)
 }
 
-// Execute an EdgeQL command (or commands).
 func (c *baseConn) Execute(ctx context.Context, cmd string) error {
 	if e := c.ensureConnection(ctx); e != nil {
 		return e
@@ -278,44 +323,6 @@ func (c *baseConn) Execute(ctx context.Context, cmd string) error {
 	return c.releaseReader(r, c.scriptFlow(r, cmd))
 }
 
-// QueryOne runs a singleton-returning query and returns its element.
-// If the query executes successfully but doesn't return a result
-// ErrorZeroResults is returned.
-func (c *baseConn) QueryOne(
-	ctx context.Context,
-	cmd string,
-	out interface{},
-	args ...interface{},
-) (err error) {
-	if e := c.ensureConnection(ctx); e != nil {
-		return e
-	}
-
-	val, err := marshal.ValueOf(out)
-	if err != nil {
-		return &invalidArgumentError{msg: err.Error()}
-	}
-
-	q := query{
-		cmd:     cmd,
-		fmt:     format.Binary,
-		expCard: cardinality.One,
-		args:    args,
-	}
-
-	r, err := c.acquireReader(ctx)
-	if err != nil {
-		return err
-	}
-
-	if e := c.setDeadline(ctx); e != nil {
-		return e
-	}
-
-	return c.releaseReader(r, c.granularFlow(r, val, q))
-}
-
-// Query runs a query and returns the results.
 func (c *baseConn) Query(
 	ctx context.Context,
 	cmd string,
@@ -350,7 +357,40 @@ func (c *baseConn) Query(
 	return c.releaseReader(r, c.granularFlow(r, val, q))
 }
 
-// QueryJSON runs a query and return the results as JSON.
+func (c *baseConn) QueryOne(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) (err error) {
+	if e := c.ensureConnection(ctx); e != nil {
+		return e
+	}
+
+	val, err := marshal.ValueOf(out)
+	if err != nil {
+		return &invalidArgumentError{msg: err.Error()}
+	}
+
+	q := query{
+		cmd:     cmd,
+		fmt:     format.Binary,
+		expCard: cardinality.One,
+		args:    args,
+	}
+
+	r, err := c.acquireReader(ctx)
+	if err != nil {
+		return err
+	}
+
+	if e := c.setDeadline(ctx); e != nil {
+		return e
+	}
+
+	return c.releaseReader(r, c.granularFlow(r, val, q))
+}
+
 func (c *baseConn) QueryJSON(
 	ctx context.Context,
 	cmd string,
@@ -385,10 +425,6 @@ func (c *baseConn) QueryJSON(
 	return c.releaseReader(r, c.granularFlow(r, val, q))
 }
 
-// QueryOneJSON runs a singleton-returning query
-// and return its element in JSON.
-// If the query executes successfully but doesn't return a result
-// []byte{}, ErrorZeroResults is returned.
 func (c *baseConn) QueryOneJSON(
 	ctx context.Context,
 	cmd string,
@@ -421,4 +457,50 @@ func (c *baseConn) QueryOneJSON(
 	}
 
 	return c.releaseReader(r, c.granularFlow(r, val, q))
+}
+
+func (c *baseConn) TryTx(ctx context.Context, action Action) error {
+	tx := &transaction{conn: c, isolation: repeatableRead}
+	if e := tx.start(ctx); e != nil {
+		return e
+	}
+
+	if e := action(ctx, tx); e != nil {
+		return firstError(e, tx.rollback(ctx))
+	}
+
+	return tx.commit(ctx)
+}
+
+func (c *baseConn) Retry(ctx context.Context, action Action) error {
+	var edbErr Error
+
+	for i := 0; i < defaultMaxTxRetries; i++ {
+		tx := &transaction{conn: c, isolation: repeatableRead}
+
+		if e := tx.start(ctx); e != nil {
+			return e
+		}
+
+		err := action(ctx, tx)
+
+		if err == nil {
+			return tx.commit(ctx)
+		}
+
+		if e := tx.rollback(ctx); e != nil && !errors.As(e, &edbErr) {
+			return e
+		}
+
+		if errors.As(err, &edbErr) &&
+			edbErr.HasTag(ShouldRetry) &&
+			(i+1 < defaultMaxTxRetries) {
+			time.Sleep(defaultBackoff(i))
+			continue
+		}
+
+		return err
+	}
+
+	panic("unreachable")
 }

--- a/granular_flow.go
+++ b/granular_flow.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/edgedb/edgedb-go/internal/aspect"
 	"github.com/edgedb/edgedb-go/internal/buff"
+	"github.com/edgedb/edgedb-go/internal/cardinality"
 	"github.com/edgedb/edgedb-go/internal/codecs"
 	"github.com/edgedb/edgedb-go/internal/format"
 	"github.com/edgedb/edgedb-go/internal/message"
@@ -245,7 +246,10 @@ func (c *baseConn) execute(
 	}
 
 	tmp := out
-	err := errZeroResults
+	err := error(nil)
+	if q.expCard == cardinality.One {
+		err = errZeroResults
+	}
 	done := buff.NewSignal()
 
 	for r.Next(done.Chan) {
@@ -326,7 +330,10 @@ func (c *baseConn) optimistic(
 	}
 
 	tmp := out
-	err := errZeroResults
+	err := error(nil)
+	if q.expCard == cardinality.One {
+		err = errZeroResults
+	}
 	done := buff.NewSignal()
 
 	for r.Next(done.Chan) {

--- a/internal/cmd/generr/errortype.go
+++ b/internal/cmd/generr/errortype.go
@@ -68,8 +68,13 @@ func parseTypes(data [][]interface{}) []*errorType {
 	}
 
 	types := make([]*errorType, 0, len(data))
-	for _, typ := range data {
-		types = append(types, parseType(typ, lookup))
+	for _, d := range data {
+		typ := parseType(d, lookup)
+		if !strings.HasSuffix(typ.name, "Error") {
+			continue
+		}
+
+		types = append(types, parseType(d, lookup))
 	}
 
 	return types

--- a/main_test.go
+++ b/main_test.go
@@ -35,7 +35,7 @@ import (
 // initialized by TestMain
 var (
 	opts Options
-	conn *Conn
+	conn Conn
 )
 
 func executeOrPanic(command string) {

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -44,30 +43,6 @@ func executeOrPanic(command string) {
 	if err != nil {
 		panic(err)
 	}
-}
-
-func getLocalServer() error {
-	credFileName, ok := os.LookupEnv("EDGEDB_CREDENTIALS_FILE")
-	if !ok {
-		log.Print("EDGEDB_CREDENTIALS_FILE environment variable not set")
-		return errors.New("credentials not found")
-	}
-
-	creds, err := readCredentials(credFileName)
-	if err != nil {
-		log.Printf("failed to read credentials file: %q", credFileName)
-		return errors.New("credentials not found")
-	}
-
-	opts = Options{
-		Ports:    []int{creds.port},
-		User:     creds.user,
-		Password: creds.password,
-		Database: creds.database,
-	}
-
-	log.Print("using existing server")
-	return nil
 }
 
 func startServer() (err error) {
@@ -154,12 +129,9 @@ func TestMain(m *testing.M) {
 		os.Exit(code)
 	}()
 
-	err = getLocalServer()
+	err = startServer()
 	if err != nil {
-		err = startServer()
-		if err != nil {
-			panic(err)
-		}
+		panic(err)
 	}
 
 	ctx := context.Background()
@@ -170,43 +142,30 @@ func TestMain(m *testing.M) {
 	}
 	log.Println("connected")
 
-	defer func() {
-		e := conn.Close()
-		if e != nil {
-			log.Println("while closing: ", e)
-		}
-	}()
+	defer conn.Close() // nolint:errcheck
 
-	query := `
-		SELECT (
-			SELECT schema::Type
-			FILTER .name = 'default::User'
-		).name
-		LIMIT 1;
-	`
-
-	var name string
-	err = conn.QueryOne(ctx, query, &name)
-	if errors.Is(err, errZeroResults) {
-		fmt.Println("running migration")
-		executeOrPanic(`
+	log.Println("running migration")
+	executeOrPanic(`
 			START MIGRATION TO {
 				module default {
 					type User {
 						property name -> str;
+					}
+					type TxTest {
+						required property name -> str;
 					}
 				}
 			};
 			POPULATE MIGRATION;
 			COMMIT MIGRATION;
 		`)
-		_ = conn.Execute(ctx, `
+	executeOrPanic(`
 			CREATE SUPERUSER ROLE user_with_password {
 				SET password := 'secret';
 			};
 		`)
-		executeOrPanic("CONFIGURE SYSTEM RESET Auth;")
-		executeOrPanic(`
+	executeOrPanic("CONFIGURE SYSTEM RESET Auth;")
+	executeOrPanic(`
 			CONFIGURE SYSTEM INSERT Auth {
 				comment := "no password",
 				priority := 1,
@@ -214,7 +173,7 @@ func TestMain(m *testing.M) {
 				user := {'*'},
 			};
 		`)
-		executeOrPanic(`
+	executeOrPanic(`
 			CONFIGURE SYSTEM INSERT Auth {
 				comment := "password required",
 				priority := 0,
@@ -222,10 +181,6 @@ func TestMain(m *testing.M) {
 				user := {'user_with_password'}
 			}
 		`)
-		err = nil
-	} else if err != nil {
-		return
-	}
 
 	rand.Seed(time.Now().Unix())
 	log.Println("starting tests")

--- a/pool.go
+++ b/pool.go
@@ -27,7 +27,7 @@ import (
 
 // Pool is a pool of connections.
 type Pool interface {
-	Querier
+	Executor
 	Trier
 
 	// Acquire returns a connection from the pool

--- a/pool.go
+++ b/pool.go
@@ -26,7 +26,22 @@ import (
 )
 
 // Pool is a pool of connections.
-type Pool struct {
+type Pool interface {
+	Querier
+	Trier
+
+	// Acquire returns a connection from the pool
+	// blocking until a connection is available.
+	// Acquired connections must be released to the pool when no longer needed.
+	Acquire(context.Context) (PoolConn, error)
+
+	// Close closes all connections in the pool.
+	// Calling close blocks until all acquired connections have been released,
+	// and returns an error if called more than once.
+	Close() error
+}
+
+type pool struct {
 	isClosed bool
 	mu       sync.RWMutex // locks isClosed
 
@@ -47,12 +62,12 @@ type Pool struct {
 }
 
 // Connect a pool of connections to a server.
-func Connect(ctx context.Context, opts Options) (*Pool, error) { // nolint:gocritic,lll
+func Connect(ctx context.Context, opts Options) (Pool, error) { // nolint:gocritic,lll
 	return ConnectDSN(ctx, "", opts)
 }
 
 // ConnectDSN a pool of connections to a server.
-func ConnectDSN(ctx context.Context, dsn string, opts Options) (*Pool, error) { // nolint:gocritic,lll
+func ConnectDSN(ctx context.Context, dsn string, opts Options) (Pool, error) { // nolint:gocritic,lll
 	if opts.MinConns < 1 {
 		return nil, &configurationError{msg: fmt.Sprintf(
 			"MinConns may not be less than 1, got: %v",
@@ -72,7 +87,7 @@ func ConnectDSN(ctx context.Context, dsn string, opts Options) (*Pool, error) { 
 		return nil, err
 	}
 
-	pool := &Pool{
+	p := &pool{
 		maxConns: opts.MaxConns,
 		minConns: opts.MinConns,
 		cfg:      cfg,
@@ -86,7 +101,7 @@ func ConnectDSN(ctx context.Context, dsn string, opts Options) (*Pool, error) { 
 	}
 
 	for i := 0; i < opts.MaxConns-opts.MinConns; i++ {
-		pool.potentialConns <- struct{}{}
+		p.potentialConns <- struct{}{}
 	}
 
 	wg := sync.WaitGroup{}
@@ -94,26 +109,26 @@ func ConnectDSN(ctx context.Context, dsn string, opts Options) (*Pool, error) { 
 	for i := 0; i < opts.MinConns; i++ {
 		wg.Add(1)
 		go func(i int) {
-			conn, err := pool.newConn(ctx)
+			conn, err := p.newConn(ctx)
 			if err == nil {
-				pool.freeConns <- conn
+				p.freeConns <- conn
 				return
 			}
 			errs[i] = err
-			pool.potentialConns <- struct{}{}
+			p.potentialConns <- struct{}{}
 		}(i)
 	}
 
 	wg.Done()
 	if err := wrapAll(errs...); err != nil {
-		_ = pool.Close()
+		_ = p.Close()
 		return nil, err
 	}
 
-	return pool, nil
+	return p, nil
 }
 
-func (p *Pool) newConn(ctx context.Context) (*baseConn, error) {
+func (p *pool) newConn(ctx context.Context) (*baseConn, error) {
 	conn := &baseConn{
 		cfg:           p.cfg,
 		typeIDCache:   p.typeIDCache,
@@ -128,7 +143,7 @@ func (p *Pool) newConn(ctx context.Context) (*baseConn, error) {
 	return conn, nil
 }
 
-func (p *Pool) acquire(ctx context.Context) (*baseConn, error) {
+func (p *pool) acquire(ctx context.Context) (*baseConn, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
@@ -165,16 +180,13 @@ func (p *Pool) acquire(ctx context.Context) (*baseConn, error) {
 	}
 }
 
-// Acquire gets a connection out of the pool
-// blocking until a connection is available.
-// Acquired connections must be released to the pool when no longer needed.
-func (p *Pool) Acquire(ctx context.Context) (*PoolConn, error) {
+func (p *pool) Acquire(ctx context.Context) (PoolConn, error) {
 	conn, err := p.acquire(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return &PoolConn{pool: p, baseConn: conn}, nil
+	return &poolConn{pool: p, baseConn: conn}, nil
 }
 
 func unrecoverable(err error) bool {
@@ -190,7 +202,7 @@ func unrecoverable(err error) bool {
 	return true
 }
 
-func (p *Pool) release(conn *baseConn, err error) error {
+func (p *pool) release(conn *baseConn, err error) error {
 	if unrecoverable(err) {
 		p.potentialConns <- struct{}{}
 		return conn.close()
@@ -207,10 +219,7 @@ func (p *Pool) release(conn *baseConn, err error) error {
 	return nil
 }
 
-// Close closes all connections in the pool.
-// Calling close blocks until all acquired connections have been released,
-// and returns an error if called more than once.
-func (p *Pool) Close() error {
+func (p *pool) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -238,7 +247,7 @@ func (p *Pool) Close() error {
 }
 
 // Execute an EdgeQL command (or commands).
-func (p *Pool) Execute(ctx context.Context, cmd string) error {
+func (p *pool) Execute(ctx context.Context, cmd string) error {
 	conn, err := p.acquire(ctx)
 	if err != nil {
 		return err
@@ -248,8 +257,7 @@ func (p *Pool) Execute(ctx context.Context, cmd string) error {
 	return firstError(err, p.release(conn, err))
 }
 
-// Query runs a query and returns the results.
-func (p *Pool) Query(
+func (p *pool) Query(
 	ctx context.Context,
 	cmd string,
 	out interface{},
@@ -264,10 +272,7 @@ func (p *Pool) Query(
 	return firstError(err, p.release(conn, err))
 }
 
-// QueryOne runs a singleton-returning query and returns its element.
-// If the query executes successfully but doesn't return a result
-// ErrorZeroResults is returned.
-func (p *Pool) QueryOne(
+func (p *pool) QueryOne(
 	ctx context.Context,
 	cmd string,
 	out interface{},
@@ -282,8 +287,7 @@ func (p *Pool) QueryOne(
 	return firstError(err, p.release(conn, err))
 }
 
-// QueryJSON runs a query and return the results as JSON.
-func (p *Pool) QueryJSON(
+func (p *pool) QueryJSON(
 	ctx context.Context,
 	cmd string,
 	out *[]byte,
@@ -298,11 +302,7 @@ func (p *Pool) QueryJSON(
 	return firstError(err, p.release(conn, err))
 }
 
-// QueryOneJSON runs a singleton-returning query
-// and return its element in JSON.
-// If the query executes successfully but doesn't return a result
-// []byte{}, ErrorZeroResults is returned.
-func (p *Pool) QueryOneJSON(
+func (p *pool) QueryOneJSON(
 	ctx context.Context,
 	cmd string,
 	out *[]byte,
@@ -315,4 +315,28 @@ func (p *Pool) QueryOneJSON(
 
 	err = conn.QueryOneJSON(ctx, cmd, out, args...)
 	return firstError(err, p.release(conn, err))
+}
+
+func (p *pool) TryTx(ctx context.Context, action Action) error {
+	conn, err := p.acquire(ctx)
+	if err != nil {
+		return err
+	}
+
+	return firstError(
+		conn.TryTx(ctx, action),
+		p.release(conn, err),
+	)
+}
+
+func (p *pool) Retry(ctx context.Context, action Action) error {
+	conn, err := p.acquire(ctx)
+	if err != nil {
+		return err
+	}
+
+	return firstError(
+		conn.Retry(ctx, action),
+		p.release(conn, err),
+	)
 }

--- a/poolconn.go
+++ b/poolconn.go
@@ -24,7 +24,7 @@ import (
 
 // PoolConn is a pooled connection.
 type PoolConn interface {
-	Querier
+	Executor
 	Trier
 
 	// Release the connection back to its pool.

--- a/poolconn.go
+++ b/poolconn.go
@@ -23,15 +23,24 @@ import (
 )
 
 // PoolConn is a pooled connection.
-type PoolConn struct {
-	pool *Pool
-	err  error
-	*baseConn
+type PoolConn interface {
+	Querier
+	Trier
+
+	// Release the connection back to its pool.
+	// Release returns an error if called more than once.
+	// A PoolConn is not usable after Release has been called.
+	Release() error
 }
 
-// Release the connection back to its pool. Panics if called more than once.
-// PoolConn is not useable after Release has been called.
-func (c *PoolConn) Release() error {
+type poolConn struct {
+	pool *pool
+	err  error
+	*baseConn
+	borrowable
+}
+
+func (c *poolConn) Release() error {
 	if c.pool == nil {
 		msg := "connection released more than once"
 		return &interfaceError{msg: msg}
@@ -45,68 +54,96 @@ func (c *PoolConn) Release() error {
 	return err
 }
 
-func (c *PoolConn) checkErr(err error) {
+func (c *poolConn) checkErr(err error) {
 	if soc.IsPermanentNetErr(err) {
 		c.err = err
 	}
 }
 
-// Execute an EdgeQL command (or commands).
-func (c *PoolConn) Execute(ctx context.Context, cmd string) error {
+func (c *poolConn) Execute(ctx context.Context, cmd string) error {
+	if e := c.assertUnborrowed(); e != nil {
+		return e
+	}
+
 	err := c.baseConn.Execute(ctx, cmd)
 	c.checkErr(err)
 	return err
 }
 
-// Query runs a query and returns the results.
-func (c *PoolConn) Query(
+func (c *poolConn) Query(
 	ctx context.Context,
 	cmd string,
 	out interface{},
 	args ...interface{},
 ) error {
-	err := c.baseConn.Query(ctx, cmd, out, args)
+	if e := c.assertUnborrowed(); e != nil {
+		return e
+	}
+
+	err := c.baseConn.Query(ctx, cmd, out, args...)
 	c.checkErr(err)
 	return err
 }
 
-// QueryOne runs a singleton-returning query and returns its element.
-// If the query executes successfully but doesn't return a result
-// ErrorZeroResults is returned.
-func (c *PoolConn) QueryOne(
+func (c *poolConn) QueryOne(
 	ctx context.Context,
 	cmd string,
 	out interface{},
 	args ...interface{},
 ) error {
-	err := c.baseConn.QueryOne(ctx, cmd, out, args)
+	if e := c.assertUnborrowed(); e != nil {
+		return e
+	}
+
+	err := c.baseConn.QueryOne(ctx, cmd, out, args...)
 	c.checkErr(err)
 	return err
 }
 
-// QueryJSON runs a query and return the results as JSON.
-func (c *PoolConn) QueryJSON(
+func (c *poolConn) QueryJSON(
 	ctx context.Context,
 	cmd string,
 	out *[]byte,
 	args ...interface{},
 ) error {
-	err := c.baseConn.QueryJSON(ctx, cmd, out, args)
+	if e := c.assertUnborrowed(); e != nil {
+		return e
+	}
+
+	err := c.baseConn.QueryJSON(ctx, cmd, out, args...)
 	c.checkErr(err)
 	return err
 }
 
-// QueryOneJSON runs a singleton-returning query
-// and return its element in JSON.
-// If the query executes successfully but doesn't return a result
-// []byte{}, ErrorZeroResults is returned.
-func (c *PoolConn) QueryOneJSON(
+func (c *poolConn) QueryOneJSON(
 	ctx context.Context,
 	cmd string,
 	out *[]byte,
 	args ...interface{},
 ) error {
-	err := c.baseConn.QueryOneJSON(ctx, cmd, out, args)
+	if e := c.assertUnborrowed(); e != nil {
+		return e
+	}
+
+	err := c.baseConn.QueryOneJSON(ctx, cmd, out, args...)
 	c.checkErr(err)
 	return err
+}
+
+func (c *poolConn) TryTx(ctx context.Context, action Action) error {
+	if e := c.borrow("transaction"); e != nil {
+		return e
+	}
+	defer c.unborrow()
+
+	return c.baseConn.TryTx(ctx, action)
+}
+
+func (c *poolConn) Retry(ctx context.Context, action Action) error {
+	if e := c.borrow("transaction"); e != nil {
+		return e
+	}
+	defer c.unborrow()
+
+	return c.baseConn.Retry(ctx, action)
 }

--- a/transaction.go
+++ b/transaction.go
@@ -40,7 +40,7 @@ const (
 
 // Tx is a transaction.
 type Tx interface {
-	Querier
+	Executor
 }
 
 type transaction struct {

--- a/transaction.go
+++ b/transaction.go
@@ -1,0 +1,220 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedb
+
+import (
+	"context"
+	"fmt"
+)
+
+type transactionState int
+
+const (
+	newTx transactionState = iota
+	startedTx
+	committedTx
+	rolledBackTx
+	failedTx
+)
+
+type isolationLevel string
+
+const (
+	serializable   isolationLevel = "serializable"
+	repeatableRead isolationLevel = "repeatable_read"
+)
+
+// Tx is a transaction.
+type Tx interface {
+	Querier
+}
+
+type transaction struct {
+	conn       *baseConn
+	state      transactionState
+	isolation  isolationLevel
+	readOnly   bool
+	deferrable bool
+}
+
+func (t *transaction) execute(
+	ctx context.Context,
+	query string,
+	sucessState transactionState,
+) error {
+	err := t.conn.Execute(ctx, query)
+
+	switch err {
+	case nil:
+		t.state = sucessState
+	default:
+		t.state = failedTx
+	}
+
+	return err
+}
+
+// assertNotDone returns an error if the transaction is in a done state.
+func (t *transaction) assertNotDone(opName string) error {
+	switch t.state {
+	case committedTx:
+		return &interfaceError{msg: fmt.Sprintf(
+			"cannot %v; the transaction is already committed", opName,
+		)}
+	case rolledBackTx:
+		return &interfaceError{msg: fmt.Sprintf(
+			"cannot %v; the transaction is already rolled back", opName,
+		)}
+	case failedTx:
+		return &interfaceError{msg: fmt.Sprintf(
+			"cannot %v; the transaction is in error state", opName,
+		)}
+	default:
+		return nil
+	}
+}
+
+// assertStarted returns an error if the transaction is not in Started state.
+func (t *transaction) assertStarted(opName string) error {
+	switch t.state {
+	case startedTx:
+		return nil
+	case newTx:
+		return &interfaceError{msg: fmt.Sprintf(
+			"cannot %v; the transaction is not yet started", opName,
+		)}
+	default:
+		return t.assertNotDone(opName)
+	}
+}
+
+func (t *transaction) start(ctx context.Context) error {
+	if e := t.assertNotDone("start"); e != nil {
+		return e
+	}
+
+	if t.state == startedTx {
+		return &interfaceError{
+			msg: "cannot start; the transaction is already started",
+		}
+	}
+
+	query := "START TRANSACTION"
+
+	switch t.isolation {
+	case repeatableRead:
+		query += " ISOLATION REPEATABLE READ"
+	case serializable:
+		query += " ISOLATION SERIALIZABLE"
+	default:
+		return &configurationError{
+			msg: fmt.Sprintf("unknown isolation level: %q", t.isolation),
+		}
+	}
+
+	if t.readOnly {
+		query += ", READ ONLY"
+	} else {
+		query += ", READ WRITE"
+	}
+
+	if t.deferrable {
+		query += ", DEFERRABLE"
+	} else {
+		query += ", NOT DEFERRABLE"
+	}
+
+	query += ";"
+
+	return t.execute(ctx, query, startedTx)
+}
+
+func (t *transaction) commit(ctx context.Context) error {
+	if e := t.assertStarted("commit"); e != nil {
+		return e
+	}
+
+	return t.execute(ctx, "COMMIT;", committedTx)
+}
+
+func (t *transaction) rollback(ctx context.Context) error {
+	if e := t.assertStarted("rollback"); e != nil {
+		return e
+	}
+
+	return t.execute(ctx, "ROLLBACK;", rolledBackTx)
+}
+
+func (t *transaction) Execute(ctx context.Context, cmd string) error {
+	if e := t.assertStarted("Execute"); e != nil {
+		return e
+	}
+
+	return t.conn.Execute(ctx, cmd)
+}
+
+func (t *transaction) Query(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
+	if e := t.assertStarted("Query"); e != nil {
+		return e
+	}
+
+	return t.conn.Query(ctx, cmd, out, args...)
+}
+
+func (t *transaction) QueryOne(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
+	if e := t.assertStarted("QueryOne"); e != nil {
+		return e
+	}
+
+	return t.conn.QueryOne(ctx, cmd, out, args...)
+}
+
+func (t *transaction) QueryJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
+	if e := t.assertStarted("QueryJSON"); e != nil {
+		return e
+	}
+
+	return t.conn.QueryJSON(ctx, cmd, out, args...)
+}
+
+func (t *transaction) QueryOneJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
+	if e := t.assertStarted("QueryJSON"); e != nil {
+		return e
+	}
+
+	return t.conn.QueryOneJSON(ctx, cmd, out, args...)
+}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -1,0 +1,130 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedb
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func ensureTxTestType(t *testing.T) {
+	query := `
+		SELECT (
+			SELECT schema::Type
+			FILTER .name = 'default::TxTest'
+		).name
+		LIMIT 1;
+	`
+
+	var result string
+	ctx := context.Background()
+	err := conn.QueryOne(ctx, query, &result)
+
+	var errNoData NoDataError
+	if errors.As(err, &errNoData) {
+		e := conn.Execute(ctx, `CREATE TYPE TxTest {
+			CREATE REQUIRED PROPERTY name -> std::str;
+		}`)
+		require.Nil(t, e, e)
+	} else {
+		require.Nil(t, err, err)
+	}
+}
+
+func TestTxRollesBack(t *testing.T) {
+	ensureTxTestType(t)
+
+	ctx := context.Background()
+	err := conn.TryTx(ctx, func(ctx context.Context, tx Tx) error {
+		query := "INSERT TxTest {name := 'Test Roll Back'};"
+		if e := tx.Execute(ctx, query); e != nil {
+			return e
+		}
+
+		return tx.Execute(ctx, "SELECT 1 / 0;")
+	})
+
+	var errZeroDivision DivisionByZeroError
+	require.True(t,
+		errors.As(err, &errZeroDivision),
+		"wrong error type: %v", err,
+	)
+
+	query := `
+		SELECT (
+			SELECT TxTest {name}
+			FILTER .name = 'Test Roll Back'
+		).name
+		LIMIT 1
+	`
+
+	var testNames []string
+	err = conn.Query(ctx, query, &testNames)
+
+	require.Nil(t, err, "unexpected error: %v", err)
+	require.Equal(t, 0, len(testNames), "The transaction wasn't rolled back")
+}
+
+func TestTxCommits(t *testing.T) {
+	ensureTxTestType(t)
+
+	ctx := context.Background()
+	err := conn.TryTx(ctx, func(ctx context.Context, tx Tx) error {
+		return tx.Execute(ctx, "INSERT TxTest {name := 'Test Commit'};")
+	})
+	require.Nil(t, err, err)
+
+	query := `
+		SELECT (
+			SELECT TxTest {name}
+			FILTER .name = 'Test Commit'
+		).name
+		LIMIT 1
+	`
+
+	var testNames []string
+	err = conn.Query(ctx, query, &testNames)
+
+	require.Nil(t, err, "unexpected error: %v", err)
+	require.Equal(
+		t,
+		[]string{"Test Commit"},
+		testNames,
+		"The transaction wasn't commited",
+	)
+}
+
+func TestTxCanNotUseConn(t *testing.T) {
+	ensureTxTestType(t)
+
+	ctx := context.Background()
+	err := conn.TryTx(ctx, func(ctx context.Context, tx Tx) error {
+		var num []int64
+		return conn.Query(ctx, "SELECT 7*9;", &num)
+	})
+
+	var errBorrowed InterfaceError
+	require.True(t, errors.As(err, &errBorrowed), "wrong error type: %v", err)
+
+	expected := "edgedb.InterfaceError: " +
+		"Connection is borrowed for a transaction. " +
+		"Use the methods on transaction object instead."
+	require.EqualError(t, err, expected)
+}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -24,33 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ensureTxTestType(t *testing.T) {
-	query := `
-		SELECT (
-			SELECT schema::Type
-			FILTER .name = 'default::TxTest'
-		).name
-		LIMIT 1;
-	`
-
-	var result string
-	ctx := context.Background()
-	err := conn.QueryOne(ctx, query, &result)
-
-	var errNoData NoDataError
-	if errors.As(err, &errNoData) {
-		e := conn.Execute(ctx, `CREATE TYPE TxTest {
-			CREATE REQUIRED PROPERTY name -> std::str;
-		}`)
-		require.Nil(t, e, e)
-	} else {
-		require.Nil(t, err, err)
-	}
-}
-
 func TestTxRollesBack(t *testing.T) {
-	ensureTxTestType(t)
-
 	ctx := context.Background()
 	err := conn.TryTx(ctx, func(ctx context.Context, tx Tx) error {
 		query := "INSERT TxTest {name := 'Test Roll Back'};"
@@ -83,8 +57,6 @@ func TestTxRollesBack(t *testing.T) {
 }
 
 func TestTxRollesBackOnUserError(t *testing.T) {
-	ensureTxTestType(t)
-
 	ctx := context.Background()
 	err := conn.TryTx(ctx, func(ctx context.Context, tx Tx) error {
 		query := "INSERT TxTest {name := 'Test Roll Back'};"
@@ -113,8 +85,6 @@ func TestTxRollesBackOnUserError(t *testing.T) {
 }
 
 func TestTxCommits(t *testing.T) {
-	ensureTxTestType(t)
-
 	ctx := context.Background()
 	err := conn.TryTx(ctx, func(ctx context.Context, tx Tx) error {
 		return tx.Execute(ctx, "INSERT TxTest {name := 'Test Commit'};")
@@ -142,8 +112,6 @@ func TestTxCommits(t *testing.T) {
 }
 
 func TestTxCanNotUseConn(t *testing.T) {
-	ensureTxTestType(t)
-
 	ctx := context.Background()
 	err := conn.TryTx(ctx, func(ctx context.Context, tx Tx) error {
 		var num []int64


### PR DESCRIPTION
this is part of https://github.com/edgedb/edgedb-go/issues/32

- Interfaces are introduced to allow the most flexibility for future changes.
- Only the minimum transaction API is introduced to fulfill RFC1004 requirements. A fuller API if required is left for future work.
- Transaction is shortened to Tx because both [database/sql](https://golang.org/pkg/database/sql/#Tx) and [pgx](https://pkg.go.dev/github.com/jackc/pgx/v4#Tx) use this name and it seems to fit the Go naming paradigm of including the maximum information with the fewest characters.
- Interface names end in -er because that is the [go recommendation](https://golang.org/doc/effective_go.html#interface-names).
