### PR TITLE
add default min and max pool connections

### DIFF
--- a/options.go
+++ b/options.go
@@ -85,10 +85,12 @@ type Options struct {
 	WaitUntilAvailable time.Duration
 
 	// MinConns determines the minimum number of connections.
-	MinConns int
+	// If MinConns is zero, 1 will be used.
+	MinConns uint
 
 	// MaxConns determines the maximum number of connections.
-	MaxConns int
+	// If MaxConns is zero, max(4, runtime.NumCPU()) will be used.
+	MaxConns uint
 
 	ServerSettings map[string]string
 }


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb-go/issues/66

This change uses a pool MinConns of 1 when MinConns is 0, and a MaxConns
of `max(4, runtime.NumCPU())` (arbitrarily borrowed from pgx) when
MaxConns is 0. Previously users were required to set MinConns and
MaxConns.