### PR TITLE
improve type miss-match error messages

### DIFF
--- a/granular_flow.go
+++ b/granular_flow.go
@@ -237,7 +237,7 @@ func (c *baseConn) execute(
 	w.BeginMessage(message.Execute)
 	w.PushUint16(0)       // no headers
 	w.PushBytes([]byte{}) // no statement name
-	if e := cdcs.in.Encode(w, q.args); e != nil {
+	if e := cdcs.in.Encode(w, q.args, codecs.Path("args")); e != nil {
 		return &invalidArgumentError{msg: e.Error()}
 	}
 	w.EndMessage()
@@ -327,7 +327,7 @@ func (c *baseConn) optimistic(
 	w.PushString(q.cmd)
 	w.PushUUID(cdcs.in.ID())
 	w.PushUUID(cdcs.out.ID())
-	if e := cdcs.in.Encode(w, q.args); e != nil {
+	if e := cdcs.in.Encode(w, q.args, codecs.Path("args")); e != nil {
 		return &invalidArgumentError{msg: e.Error()}
 	}
 	w.EndMessage()

--- a/internal/codecs/array_test.go
+++ b/internal/codecs/array_test.go
@@ -29,7 +29,8 @@ import (
 
 func TestArraySetType(t *testing.T) {
 	codec := &Array{child: &Int64{typ: int64Type}}
-	useReflect, err := codec.setType(reflect.TypeOf([]int64{}))
+	typ := reflect.TypeOf([]int64{})
+	useReflect, err := codec.setType(typ, Path(""))
 	require.Nil(t, err)
 	require.False(t, useReflect)
 
@@ -57,7 +58,8 @@ func TestArrayDecodePtr(t *testing.T) {
 	var result []int64
 
 	codec := &Array{child: &Int64{typ: int64Type}}
-	useReflect, err := codec.setType(reflect.TypeOf(result))
+	typ := reflect.TypeOf(result)
+	useReflect, err := codec.setType(typ, Path(""))
 	require.Nil(t, err)
 	require.False(t, useReflect)
 	codec.DecodePtr(r, unsafe.Pointer(&result))
@@ -91,10 +93,11 @@ func TestArrayDecodeReflect(t *testing.T) {
 	var result []int64
 
 	codec := &Array{child: &Int64{typ: int64Type}}
-	useReflect, err := codec.setType(reflect.TypeOf(result))
+	typ := reflect.TypeOf(result)
+	useReflect, err := codec.setType(typ, Path(""))
 	require.Nil(t, err)
 	require.False(t, useReflect)
-	codec.DecodeReflect(r, reflect.ValueOf(&result).Elem())
+	codec.DecodeReflect(r, reflect.ValueOf(&result).Elem(), Path(""))
 
 	// force garbage collection to be sure that
 	// references are durable.
@@ -115,7 +118,7 @@ func TestEncodeArray(t *testing.T) {
 		w.BeginMessage(0xff)
 
 		codec := &Array{child: &Int64{}}
-		err := codec.Encode(w, a)
+		err := codec.Encode(w, a, Path(""))
 		require.Nil(t, err)
 		w.EndMessage()
 
@@ -150,6 +153,6 @@ func TestEncodeArrayWrongType(t *testing.T) {
 	w.BeginMessage(0xff)
 
 	codec := &Array{child: &Int64{typ: reflect.TypeOf(int64(1))}}
-	err := codec.Encode(w, "hello")
-	assert.EqualError(t, err, "expected []int64 got: string")
+	err := codec.Encode(w, "hello", Path("args[1]"))
+	assert.EqualError(t, err, "expected args[1] to be []int64 got: string")
 }

--- a/internal/codecs/base_scalar.go
+++ b/internal/codecs/base_scalar.go
@@ -125,22 +125,22 @@ func (c *UUID) ID() types.UUID {
 
 func (c *UUID) setDefaultType() {}
 
-func (c *UUID) setType(typ reflect.Type) (bool, error) {
-	return false, c.checkType(typ)
+func (c *UUID) setType(typ reflect.Type, path Path) (bool, error) {
+	return false, c.checkType(typ, path)
 }
 
-func (c *UUID) checkType(typ reflect.Type) error {
+func (c *UUID) checkType(typ reflect.Type, path Path) error {
 	switch {
 	case typ.Kind() != c.typ.Kind():
-		return fmt.Errorf("expected edgedb.UUID got %v", typ)
+		return fmt.Errorf("expected %v to be edgedb.UUID got %v", path, typ)
 	case typ.Elem() != c.typ.Elem():
-		return fmt.Errorf("expected edgedb.UUID got %v", typ)
+		return fmt.Errorf("expected %v to be edgedb.UUID got %v", path, typ)
 	case typ.Len() != c.typ.Len():
-		return fmt.Errorf("expected edgedb.UUID got %v", typ)
+		return fmt.Errorf("expected %v to be edgedb.UUID got %v", path, typ)
 	case typ.PkgPath() != "github.com/edgedb/edgedb-go":
-		return fmt.Errorf("expected edgedb.UUID got %v", typ)
+		return fmt.Errorf("expected %v to be edgedb.UUID got %v", path, typ)
 	case typ.Name() != "UUID":
-		return fmt.Errorf("expected edgedb.UUID got %v", typ)
+		return fmt.Errorf("expected %v to be edgedb.UUID got %v", path, typ)
 	}
 
 	return nil
@@ -153,12 +153,12 @@ func (c *UUID) Type() reflect.Type {
 
 // Decode a UUID.
 func (c *UUID) Decode(r *buff.Reader, out reflect.Value) {
-	c.DecodeReflect(r, out)
+	c.DecodeReflect(r, out, Path(out.Type().String()))
 }
 
 // DecodeReflect decodes a UUID.using reflection
-func (c *UUID) DecodeReflect(r *buff.Reader, out reflect.Value) {
-	if e := c.checkType(out.Type()); e != nil {
+func (c *UUID) DecodeReflect(r *buff.Reader, out reflect.Value, path Path) {
+	if e := c.checkType(out.Type(), path); e != nil {
 		panic(e)
 	}
 
@@ -173,10 +173,10 @@ func (c *UUID) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a UUID.
-func (c *UUID) Encode(w *buff.Writer, val interface{}) error {
+func (c *UUID) Encode(w *buff.Writer, val interface{}, path Path) error {
 	tmp, ok := val.(types.UUID)
 	if !ok {
-		return fmt.Errorf("expected types.UUID got %T", val)
+		return fmt.Errorf("expected %v to be types.UUID got %T", path, val)
 	}
 
 	w.PushBytes(tmp[:])
@@ -195,9 +195,11 @@ func (c *Str) ID() types.UUID {
 }
 func (c *Str) setDefaultType() {}
 
-func (c *Str) setType(typ reflect.Type) (bool, error) {
+func (c *Str) setType(typ reflect.Type, path Path) (bool, error) {
 	if typ != c.typ {
-		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, typ,
+		)
 	}
 
 	return false, nil
@@ -210,13 +212,15 @@ func (c *Str) Type() reflect.Type {
 
 // Decode a string.
 func (c *Str) Decode(r *buff.Reader, out reflect.Value) {
-	c.DecodeReflect(r, out)
+	c.DecodeReflect(r, out, Path(out.Type().String()))
 }
 
 // DecodeReflect decodes a str into a reflect.Value.
-func (c *Str) DecodeReflect(r *buff.Reader, out reflect.Value) {
+func (c *Str) DecodeReflect(r *buff.Reader, out reflect.Value, path Path) {
 	if out.Type() != c.typ {
-		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+		panic(fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, out.Type(),
+		))
 	}
 
 	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
@@ -229,10 +233,10 @@ func (c *Str) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a string.
-func (c *Str) Encode(w *buff.Writer, val interface{}) error {
+func (c *Str) Encode(w *buff.Writer, val interface{}, path Path) error {
 	in, ok := val.(string)
 	if !ok {
-		return fmt.Errorf("expected types.UUID got %T", val)
+		return fmt.Errorf("expected %v to be types.UUID got %T", path, val)
 	}
 
 	w.PushString(in)
@@ -251,9 +255,11 @@ func (c *Bytes) ID() types.UUID {
 }
 func (c *Bytes) setDefaultType() {}
 
-func (c *Bytes) setType(typ reflect.Type) (bool, error) {
+func (c *Bytes) setType(typ reflect.Type, path Path) (bool, error) {
 	if typ != c.typ {
-		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, typ,
+		)
 	}
 
 	return false, nil
@@ -266,13 +272,15 @@ func (c *Bytes) Type() reflect.Type {
 
 // Decode []byte.
 func (c *Bytes) Decode(r *buff.Reader, out reflect.Value) {
-	c.DecodeReflect(r, out)
+	c.DecodeReflect(r, out, Path(out.Type().String()))
 }
 
 // DecodeReflect decodes bytes into a reflect.Value.
-func (c *Bytes) DecodeReflect(r *buff.Reader, out reflect.Value) {
+func (c *Bytes) DecodeReflect(r *buff.Reader, out reflect.Value, path Path) {
 	if out.Type() != c.typ {
-		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+		panic(fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, out.Type(),
+		))
 	}
 
 	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
@@ -294,10 +302,10 @@ func (c *Bytes) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode []byte.
-func (c *Bytes) Encode(w *buff.Writer, val interface{}) error {
+func (c *Bytes) Encode(w *buff.Writer, val interface{}, path Path) error {
 	in, ok := val.([]byte)
 	if !ok {
-		return fmt.Errorf("expected []byte got %T", val)
+		return fmt.Errorf("expected %v to be []byte got %T", path, val)
 	}
 
 	w.PushBytes(in)
@@ -316,9 +324,11 @@ func (c *Int16) ID() types.UUID {
 }
 func (c *Int16) setDefaultType() {}
 
-func (c *Int16) setType(typ reflect.Type) (bool, error) {
+func (c *Int16) setType(typ reflect.Type, path Path) (bool, error) {
 	if typ != c.typ {
-		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, typ,
+		)
 	}
 
 	return false, nil
@@ -331,13 +341,15 @@ func (c *Int16) Type() reflect.Type {
 
 // Decode an int16.
 func (c *Int16) Decode(r *buff.Reader, out reflect.Value) {
-	c.DecodeReflect(r, out)
+	c.DecodeReflect(r, out, Path(out.Type().String()))
 }
 
 // DecodeReflect decodes an int16 into a reflect.Value.
-func (c *Int16) DecodeReflect(r *buff.Reader, out reflect.Value) {
+func (c *Int16) DecodeReflect(r *buff.Reader, out reflect.Value, path Path) {
 	if out.Type() != c.typ {
-		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+		panic(fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, out.Type(),
+		))
 	}
 
 	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
@@ -349,10 +361,10 @@ func (c *Int16) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode an int16.
-func (c *Int16) Encode(w *buff.Writer, val interface{}) error {
+func (c *Int16) Encode(w *buff.Writer, val interface{}, path Path) error {
 	in, ok := val.(int16)
 	if !ok {
-		return fmt.Errorf("expected int16 got %T", val)
+		return fmt.Errorf("expected %v to be int16 got %T", path, val)
 	}
 
 	w.PushUint32(2) // data length
@@ -372,9 +384,11 @@ func (c *Int32) ID() types.UUID {
 }
 func (c *Int32) setDefaultType() {}
 
-func (c *Int32) setType(typ reflect.Type) (bool, error) {
+func (c *Int32) setType(typ reflect.Type, path Path) (bool, error) {
 	if typ != c.typ {
-		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, typ,
+		)
 	}
 
 	return false, nil
@@ -387,13 +401,15 @@ func (c *Int32) Type() reflect.Type {
 
 // Decode an int32.
 func (c *Int32) Decode(r *buff.Reader, out reflect.Value) {
-	c.DecodeReflect(r, out)
+	c.DecodeReflect(r, out, Path(out.Type().String()))
 }
 
 // DecodeReflect decodes an int32 into a reflect.Value.
-func (c *Int32) DecodeReflect(r *buff.Reader, out reflect.Value) {
+func (c *Int32) DecodeReflect(r *buff.Reader, out reflect.Value, path Path) {
 	if out.Type() != c.typ {
-		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+		panic(fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, out.Type(),
+		))
 	}
 
 	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
@@ -405,10 +421,10 @@ func (c *Int32) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode an int32.
-func (c *Int32) Encode(w *buff.Writer, val interface{}) error {
+func (c *Int32) Encode(w *buff.Writer, val interface{}, path Path) error {
 	in, ok := val.(int32)
 	if !ok {
-		return fmt.Errorf("expected int32 got %T", val)
+		return fmt.Errorf("expected %v to be int32 got %T", path, val)
 	}
 
 	w.PushUint32(4) // data length
@@ -428,9 +444,11 @@ func (c *Int64) ID() types.UUID {
 }
 func (c *Int64) setDefaultType() {}
 
-func (c *Int64) setType(typ reflect.Type) (bool, error) {
+func (c *Int64) setType(typ reflect.Type, path Path) (bool, error) {
 	if typ != c.typ {
-		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, typ,
+		)
 	}
 
 	return false, nil
@@ -443,13 +461,15 @@ func (c *Int64) Type() reflect.Type {
 
 // Decode an int64.
 func (c *Int64) Decode(r *buff.Reader, out reflect.Value) {
-	c.DecodeReflect(r, out)
+	c.DecodeReflect(r, out, Path(out.Type().String()))
 }
 
 // DecodeReflect decodes an int64 into a reflect.Value.
-func (c *Int64) DecodeReflect(r *buff.Reader, out reflect.Value) {
+func (c *Int64) DecodeReflect(r *buff.Reader, out reflect.Value, path Path) {
 	if out.Type() != c.typ {
-		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+		panic(fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, out.Type(),
+		))
 	}
 
 	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
@@ -461,10 +481,10 @@ func (c *Int64) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode an int64.
-func (c *Int64) Encode(w *buff.Writer, val interface{}) error {
+func (c *Int64) Encode(w *buff.Writer, val interface{}, path Path) error {
 	in, ok := val.(int64)
 	if !ok {
-		return fmt.Errorf("expected int64 got %T", val)
+		return fmt.Errorf("expected %v to be int64 got %T", path, val)
 	}
 
 	w.PushUint32(8) // data length
@@ -484,9 +504,11 @@ func (c *Float32) ID() types.UUID {
 }
 func (c *Float32) setDefaultType() {}
 
-func (c *Float32) setType(typ reflect.Type) (bool, error) {
+func (c *Float32) setType(typ reflect.Type, path Path) (bool, error) {
 	if typ != c.typ {
-		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, typ,
+		)
 	}
 
 	return false, nil
@@ -499,13 +521,15 @@ func (c *Float32) Type() reflect.Type {
 
 // Decode a float32.
 func (c *Float32) Decode(r *buff.Reader, out reflect.Value) {
-	c.DecodeReflect(r, out)
+	c.DecodeReflect(r, out, Path(out.Type().String()))
 }
 
 // DecodeReflect decodes a float32 into a reflect.Value.
-func (c *Float32) DecodeReflect(r *buff.Reader, out reflect.Value) {
+func (c *Float32) DecodeReflect(r *buff.Reader, out reflect.Value, path Path) {
 	if out.Type() != c.typ {
-		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+		panic(fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, out.Type(),
+		))
 	}
 
 	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
@@ -517,10 +541,10 @@ func (c *Float32) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a float32.
-func (c *Float32) Encode(w *buff.Writer, val interface{}) error {
+func (c *Float32) Encode(w *buff.Writer, val interface{}, path Path) error {
 	in, ok := val.(float32)
 	if !ok {
-		return fmt.Errorf("expected float32 got %T", val)
+		return fmt.Errorf("expected %v to be float32 got %T", path, val)
 	}
 
 	w.PushUint32(4)
@@ -540,9 +564,11 @@ func (c *Float64) ID() types.UUID {
 }
 func (c *Float64) setDefaultType() {}
 
-func (c *Float64) setType(typ reflect.Type) (bool, error) {
+func (c *Float64) setType(typ reflect.Type, path Path) (bool, error) {
 	if typ != c.typ {
-		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, typ,
+		)
 	}
 
 	return false, nil
@@ -555,13 +581,15 @@ func (c *Float64) Type() reflect.Type {
 
 // Decode a float64.
 func (c *Float64) Decode(r *buff.Reader, out reflect.Value) {
-	c.DecodeReflect(r, out)
+	c.DecodeReflect(r, out, Path(out.Type().String()))
 }
 
 // DecodeReflect decodes a float64 into a reflect.Value.
-func (c *Float64) DecodeReflect(r *buff.Reader, out reflect.Value) {
+func (c *Float64) DecodeReflect(r *buff.Reader, out reflect.Value, path Path) {
 	if out.Type() != c.typ {
-		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+		panic(fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, out.Type(),
+		))
 	}
 
 	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
@@ -573,10 +601,10 @@ func (c *Float64) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a float64.
-func (c *Float64) Encode(w *buff.Writer, val interface{}) error {
+func (c *Float64) Encode(w *buff.Writer, val interface{}, path Path) error {
 	in, ok := val.(float64)
 	if !ok {
-		return fmt.Errorf("expected float64 got %T", val)
+		return fmt.Errorf("expected %v to be float64 got %T", path, val)
 	}
 
 	w.PushUint32(8)
@@ -596,9 +624,11 @@ func (c *Bool) ID() types.UUID {
 }
 func (c *Bool) setDefaultType() {}
 
-func (c *Bool) setType(typ reflect.Type) (bool, error) {
+func (c *Bool) setType(typ reflect.Type, path Path) (bool, error) {
 	if typ != c.typ {
-		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, typ,
+		)
 	}
 
 	return false, nil
@@ -611,13 +641,15 @@ func (c *Bool) Type() reflect.Type {
 
 // Decode a bool.
 func (c *Bool) Decode(r *buff.Reader, out reflect.Value) {
-	c.DecodeReflect(r, out)
+	c.DecodeReflect(r, out, Path(out.Type().String()))
 }
 
 // DecodeReflect decodes a bool into a reflect.Value.
-func (c *Bool) DecodeReflect(r *buff.Reader, out reflect.Value) {
+func (c *Bool) DecodeReflect(r *buff.Reader, out reflect.Value, path Path) {
 	if out.Type() != c.typ {
-		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+		panic(fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, out.Type(),
+		))
 	}
 
 	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
@@ -629,10 +661,10 @@ func (c *Bool) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a bool.
-func (c *Bool) Encode(w *buff.Writer, val interface{}) error {
+func (c *Bool) Encode(w *buff.Writer, val interface{}, path Path) error {
 	in, ok := val.(bool)
 	if !ok {
-		return fmt.Errorf("expected bool got %T", val)
+		return fmt.Errorf("expected %v to be bool got %T", path, val)
 	}
 
 	w.PushUint32(1) // data length
@@ -659,9 +691,11 @@ func (c *DateTime) ID() types.UUID {
 }
 func (c *DateTime) setDefaultType() {}
 
-func (c *DateTime) setType(typ reflect.Type) (bool, error) {
+func (c *DateTime) setType(typ reflect.Type, path Path) (bool, error) {
 	if typ != c.typ {
-		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, typ,
+		)
 	}
 
 	return false, nil
@@ -674,13 +708,19 @@ func (c *DateTime) Type() reflect.Type {
 
 // Decode a datetime.
 func (c *DateTime) Decode(r *buff.Reader, out reflect.Value) {
-	c.DecodeReflect(r, out)
+	c.DecodeReflect(r, out, Path(out.Type().String()))
 }
 
 // DecodeReflect decodes a datetime into a reflect.Value.
-func (c *DateTime) DecodeReflect(r *buff.Reader, out reflect.Value) {
+func (c *DateTime) DecodeReflect(
+	r *buff.Reader,
+	out reflect.Value,
+	path Path,
+) {
 	if out.Type() != c.typ {
-		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+		panic(fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, out.Type(),
+		))
 	}
 
 	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
@@ -698,10 +738,10 @@ func (c *DateTime) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a datetime.
-func (c *DateTime) Encode(w *buff.Writer, val interface{}) error {
+func (c *DateTime) Encode(w *buff.Writer, val interface{}, path Path) error {
 	date, ok := val.(time.Time)
 	if !ok {
-		return fmt.Errorf("expected time.Time got %T", val)
+		return fmt.Errorf("expected %v to be time.Time got %T", path, val)
 	}
 
 	seconds := date.Unix() - 946_684_800
@@ -724,9 +764,12 @@ func (c *Duration) ID() types.UUID {
 }
 
 func (c *Duration) setDefaultType() {}
-func (c *Duration) setType(typ reflect.Type) (bool, error) {
+
+func (c *Duration) setType(typ reflect.Type, path Path) (bool, error) {
 	if typ != c.typ {
-		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, typ,
+		)
 	}
 
 	return false, nil
@@ -739,13 +782,19 @@ func (c *Duration) Type() reflect.Type {
 
 // Decode a duration.
 func (c *Duration) Decode(r *buff.Reader, out reflect.Value) {
-	c.DecodeReflect(r, out)
+	c.DecodeReflect(r, out, Path(out.Type().String()))
 }
 
 // DecodeReflect decodes a duration into a reflect.Value.
-func (c *Duration) DecodeReflect(r *buff.Reader, out reflect.Value) {
+func (c *Duration) DecodeReflect(
+	r *buff.Reader,
+	out reflect.Value,
+	path Path,
+) {
 	if out.Type() != c.typ {
-		panic(fmt.Errorf("expected %v got %v", c.typ, out.Type()))
+		panic(fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, out.Type(),
+		))
 	}
 
 	c.DecodePtr(r, unsafe.Pointer(out.UnsafeAddr()))
@@ -759,10 +808,10 @@ func (c *Duration) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode a duration.
-func (c *Duration) Encode(w *buff.Writer, val interface{}) error {
+func (c *Duration) Encode(w *buff.Writer, val interface{}, path Path) error {
 	duration, ok := val.(time.Duration)
 	if !ok {
-		return fmt.Errorf("expected time.Duration got %T", val)
+		return fmt.Errorf("expected %v to be time.Duration got %T", path, val)
 	}
 
 	w.PushUint32(16) // data length
@@ -785,9 +834,14 @@ func (c *JSON) ID() types.UUID {
 
 func (c *JSON) setDefaultType() {} // nolint:unused
 
-func (c *JSON) setType(typ reflect.Type) (bool, error) { // nolint:unused
+func (c *JSON) setType( // nolint:unused
+	typ reflect.Type,
+	path Path,
+) (bool, error) {
 	if typ != c.typ {
-		return false, fmt.Errorf("expected %v got %v", c.typ, typ)
+		return false, fmt.Errorf(
+			"expected %v to be %v got %v", path, c.typ, typ,
+		)
 	}
 
 	return false, nil
@@ -818,7 +872,7 @@ func (c *JSON) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 }
 
 // Encode json.
-func (c *JSON) Encode(w *buff.Writer, val interface{}) {
+func (c *JSON) Encode(w *buff.Writer, val interface{}, path Path) {
 	bts, err := json.Marshal(val)
 	if err != nil {
 		// todo err: Encode should return error?

--- a/internal/codecs/base_scalar_test.go
+++ b/internal/codecs/base_scalar_test.go
@@ -58,9 +58,8 @@ func BenchmarkDecodeUUID(b *testing.B) {
 
 func TestEncodeUUID(t *testing.T) {
 	w := buff.NewWriter([]byte{})
-	err := (&UUID{}).Encode(w, types.UUID{
-		0, 1, 2, 3, 3, 2, 1, 0, 8, 7, 6, 5, 5, 6, 7, 8,
-	})
+	id := types.UUID{0, 1, 2, 3, 3, 2, 1, 0, 8, 7, 6, 5, 5, 6, 7, 8}
+	err := (&UUID{}).Encode(w, id, Path(""))
 	require.Nil(t, err)
 
 	conn := &writeFixture{}
@@ -81,7 +80,7 @@ func BenchmarkEncodeUUID(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = codec.Encode(w, id)
+		_ = codec.Encode(w, id, Path(""))
 	}
 }
 
@@ -116,7 +115,7 @@ func BenchmarkDecodeString(b *testing.B) {
 
 func TestEncodeString(t *testing.T) {
 	w := buff.NewWriter([]byte{})
-	err := (&Str{}).Encode(w, "hello")
+	err := (&Str{}).Encode(w, "hello", Path(""))
 	require.Nil(t, err)
 
 	conn := &writeFixture{}
@@ -162,7 +161,7 @@ func BenchmarkDecodeBytes(b *testing.B) {
 
 func TestEncodeBytes(t *testing.T) {
 	w := buff.NewWriter([]byte{})
-	err := (&Bytes{}).Encode(w, []byte{104, 101, 108, 108, 111})
+	err := (&Bytes{}).Encode(w, []byte{104, 101, 108, 108, 111}, Path(""))
 	require.Nil(t, err)
 
 	conn := &writeFixture{}
@@ -202,7 +201,7 @@ func BenchmarkDecodeInt16(b *testing.B) {
 
 func TestEncodeInt16(t *testing.T) {
 	w := buff.NewWriter([]byte{})
-	err := (&Int16{}).Encode(w, int16(7))
+	err := (&Int16{}).Encode(w, int16(7), Path(""))
 	require.Nil(t, err)
 
 	conn := &writeFixture{}
@@ -242,7 +241,7 @@ func BenchmarkDecodeInt32(b *testing.B) {
 
 func TestEncodeInt32(t *testing.T) {
 	w := buff.NewWriter([]byte{})
-	err := (&Int32{}).Encode(w, int32(7))
+	err := (&Int32{}).Encode(w, int32(7), Path(""))
 	require.Nil(t, err)
 
 	conn := &writeFixture{}
@@ -282,7 +281,7 @@ func BenchmarkDecodeInt64(b *testing.B) {
 
 func TestEncodeInt64(t *testing.T) {
 	w := buff.NewWriter([]byte{})
-	err := (&Int64{}).Encode(w, int64(27))
+	err := (&Int64{}).Encode(w, int64(27), Path(""))
 	require.Nil(t, err)
 
 	conn := &writeFixture{}
@@ -326,7 +325,7 @@ func BenchmarkDecodeFloat32(b *testing.B) {
 
 func TestEncodeFloat32(t *testing.T) {
 	w := buff.NewWriter([]byte{})
-	err := (&Float32{}).Encode(w, float32(-32))
+	err := (&Float32{}).Encode(w, float32(-32), Path(""))
 	require.Nil(t, err)
 
 	conn := &writeFixture{}
@@ -370,7 +369,7 @@ func BenchmarkDecodeFloat64(b *testing.B) {
 
 func TestEncodeFloat64(t *testing.T) {
 	w := buff.NewWriter([]byte{})
-	err := (&Float64{}).Encode(w, float64(-64))
+	err := (&Float64{}).Encode(w, float64(-64), Path(""))
 	require.Nil(t, err)
 
 	conn := &writeFixture{}
@@ -410,7 +409,7 @@ func BenchmarkDecodeBool(b *testing.B) {
 
 func TestEncodeBool(t *testing.T) {
 	w := buff.NewWriter([]byte{})
-	err := (&Bool{}).Encode(w, true)
+	err := (&Bool{}).Encode(w, true, Path(""))
 	require.Nil(t, err)
 
 	conn := &writeFixture{}
@@ -438,7 +437,8 @@ func TestDecodeDateTime(t *testing.T) {
 
 func TestEncodeDateTime(t *testing.T) {
 	w := buff.NewWriter([]byte{})
-	err := (&DateTime{}).Encode(w, time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))
+	dt := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	err := (&DateTime{}).Encode(w, dt, Path(""))
 	require.Nil(t, err)
 
 	conn := &writeFixture{}
@@ -467,7 +467,7 @@ func TestDecodeDuration(t *testing.T) {
 
 func TestEncodeDuration(t *testing.T) {
 	w := buff.NewWriter([]byte{})
-	err := (&Duration{}).Encode(w, time.Duration(1_000_000_000))
+	err := (&Duration{}).Encode(w, time.Duration(1_000_000_000), Path(""))
 	require.Nil(t, err)
 
 	conn := &writeFixture{}
@@ -504,7 +504,7 @@ func TestDecodeJSON(t *testing.T) {
 
 func TestEncodeJSON(t *testing.T) {
 	w := buff.NewWriter([]byte{})
-	(&JSON{}).Encode(w, map[string]string{"hello": "world"})
+	(&JSON{}).Encode(w, map[string]string{"hello": "world"}, Path(""))
 
 	conn := &writeFixture{}
 	require.Nil(t, w.Send(conn))

--- a/internal/codecs/codecs.go
+++ b/internal/codecs/codecs.go
@@ -40,16 +40,16 @@ const (
 // Codec interface
 type Codec interface {
 	Decode(*buff.Reader, reflect.Value)
-	DecodeReflect(*buff.Reader, reflect.Value)
+	DecodeReflect(*buff.Reader, reflect.Value, Path)
 	DecodePtr(*buff.Reader, unsafe.Pointer)
-	Encode(*buff.Writer, interface{}) error
+	Encode(*buff.Writer, interface{}, Path) error
 	ID() types.UUID
 	Type() reflect.Type
 	setDefaultType()
 
 	// setType returns true if the memory layout for reflect.Type
 	// is not fully known.
-	setType(reflect.Type) (bool, error)
+	setType(reflect.Type, Path) (bool, error)
 }
 
 // BuildCodec a decoder
@@ -99,13 +99,14 @@ func BuildCodec(r *buff.Reader) (Codec, error) {
 }
 
 // BuildTypedCodec builds a codec for decoding into a specific type.
-func BuildTypedCodec(r *buff.Reader, t reflect.Type) (Codec, error) {
+func BuildTypedCodec(r *buff.Reader, typ reflect.Type) (Codec, error) {
 	codec, err := BuildCodec(r)
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err = codec.setType(t); err != nil {
+	path := Path(typ.String())
+	if _, err = codec.setType(typ, path); err != nil {
 		return nil, fmt.Errorf(
 			"the \"out\" argument does not match query schema: %v", err,
 		)

--- a/internal/codecs/named_tuple_test.go
+++ b/internal/codecs/named_tuple_test.go
@@ -46,7 +46,8 @@ func TestNamedTupleSetType(t *testing.T) {
 		{name: "large", codec: &Int64{typ: int64Type}},
 		{name: "name", codec: &Str{typ: strType}},
 	}}
-	useReflect, err := codec.setType(reflect.TypeOf(Thing{}))
+	typ := reflect.TypeOf(Thing{})
+	useReflect, err := codec.setType(typ, Path(""))
 	require.Nil(t, err)
 	require.False(t, useReflect)
 
@@ -81,7 +82,8 @@ func TestNamedTupleDecodePtr(t *testing.T) {
 		{name: "A", codec: &Int32{typ: int32Type}},
 		{name: "B", codec: &Int32{typ: int32Type}},
 	}}
-	useReflect, err := codec.setType(reflect.TypeOf(result))
+	typ := reflect.TypeOf(result)
+	useReflect, err := codec.setType(typ, Path(""))
 	require.Nil(t, err)
 	require.False(t, useReflect)
 	codec.DecodePtr(r, unsafe.Pointer(&result))
@@ -150,10 +152,11 @@ func TestNamedTupleDecodeReflect(t *testing.T) {
 		{name: "A", codec: &Int32{typ: int32Type}},
 		{name: "B", codec: &Int32{typ: int32Type}},
 	}}
-	useReflect, err := codec.setType(reflect.TypeOf(result))
+	typ := reflect.TypeOf(result)
+	useReflect, err := codec.setType(typ, Path(""))
 	require.Nil(t, err)
 	require.False(t, useReflect)
-	codec.DecodeReflect(r, reflect.ValueOf(&result).Elem())
+	codec.DecodeReflect(r, reflect.ValueOf(&result).Elem(), Path(""))
 
 	// force garbage collection to be sure that
 	// references are durable.
@@ -183,7 +186,7 @@ func TestNamedTupleDecodeReflectMap(t *testing.T) {
 	codec.setDefaultType()
 
 	var result map[string]interface{}
-	codec.DecodeReflect(r, reflect.ValueOf(&result).Elem())
+	codec.DecodeReflect(r, reflect.ValueOf(&result).Elem(), Path(""))
 
 	// force garbage collection to be sure that
 	// references are durable.
@@ -200,12 +203,14 @@ func TestEncodeNamedTuple(t *testing.T) {
 		{name: "b", codec: &Int32{}},
 	}}
 
-	w := buff.NewWriter([]byte{})
-	w.BeginMessage(message.Sync)
-	err := codec.Encode(w, []interface{}{map[string]interface{}{
+	val := []interface{}{map[string]interface{}{
 		"a": int32(5),
 		"b": int32(6),
-	}})
+	}}
+
+	w := buff.NewWriter([]byte{})
+	w.BeginMessage(message.Sync)
+	err := codec.Encode(w, val, Path(""))
 	require.Nil(t, err)
 	w.EndMessage()
 

--- a/internal/codecs/object_test.go
+++ b/internal/codecs/object_test.go
@@ -46,7 +46,8 @@ func TestSetObjectType(t *testing.T) {
 		{name: "name", codec: &Str{typ: strType}},
 	}}
 
-	useReflect, err := codec.setType(reflect.TypeOf(Thing{}))
+	typ := reflect.TypeOf(Thing{})
+	useReflect, err := codec.setType(typ, Path(""))
 	require.Nil(t, err)
 	require.False(t, useReflect)
 
@@ -86,7 +87,8 @@ func TestObjectDecodePtr(t *testing.T) {
 		{name: "B", codec: &Int32{typ: int32Type}},
 		{name: "C", codec: &Int64{typ: int64Type}},
 	}}
-	useReflect, err := codec.setType(reflect.TypeOf(result))
+	typ := reflect.TypeOf(result)
+	useReflect, err := codec.setType(typ, Path(""))
 	require.Nil(t, err)
 	require.False(t, useReflect)
 	codec.DecodePtr(r, unsafe.Pointer(&result))
@@ -130,7 +132,8 @@ func BenchmarkObjectDecodePtr(b *testing.B) {
 		{name: "B", codec: &Int32{typ: int32Type}},
 		{name: "C", codec: &Int64{typ: int64Type}},
 	}}
-	_, err := codec.setType(reflect.TypeOf(result))
+	typ := reflect.TypeOf(result)
+	_, err := codec.setType(typ, Path(""))
 	require.Nil(b, err)
 
 	b.ResetTimer()
@@ -168,10 +171,11 @@ func TestObjectDecodeReflectStruct(t *testing.T) {
 		{name: "B", codec: &Int32{typ: int32Type}},
 		{name: "C", codec: &Int64{typ: int64Type}},
 	}}
-	useReflect, err := codec.setType(reflect.TypeOf(result))
+	typ := reflect.TypeOf(result)
+	useReflect, err := codec.setType(typ, Path(""))
 	require.Nil(t, err)
 	require.False(t, useReflect)
-	codec.DecodeReflect(r, reflect.ValueOf(&result).Elem())
+	codec.DecodeReflect(r, reflect.ValueOf(&result).Elem(), Path(""))
 
 	// force garbage collection to be sure that
 	// references are durable.
@@ -205,7 +209,7 @@ func TestObjectDecodeReflectMap(t *testing.T) {
 	codec.setDefaultType()
 
 	var result map[string]interface{}
-	codec.DecodeReflect(r, reflect.ValueOf(&result).Elem())
+	codec.DecodeReflect(r, reflect.ValueOf(&result).Elem(), Path(""))
 
 	// force garbage collection to be sure that
 	// references are durable.

--- a/internal/codecs/path.go
+++ b/internal/codecs/path.go
@@ -1,0 +1,33 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codecs
+
+import "fmt"
+
+// Path is used in error messages
+// to show what field in a nested data structure caused the error.
+type Path string
+
+// AddField adds a field name to the path.
+func (p Path) AddField(name string) Path {
+	return Path(fmt.Sprintf("%v.%v", p, name))
+}
+
+// AddIndex adds an index to the path.
+func (p Path) AddIndex(index int) Path {
+	return Path(fmt.Sprintf("%v[%v]", p, index))
+}

--- a/internal/codecs/set_test.go
+++ b/internal/codecs/set_test.go
@@ -29,7 +29,8 @@ import (
 
 func TestSetSetType(t *testing.T) {
 	codec := Set{child: &Int64{typ: int64Type}}
-	useReflect, err := codec.setType(reflect.TypeOf([]int64{}))
+	typ := reflect.TypeOf([]int64{})
+	useReflect, err := codec.setType(typ, Path(""))
 	require.Nil(t, err)
 	require.False(t, useReflect)
 
@@ -57,7 +58,8 @@ func TestSetDecodePtr(t *testing.T) {
 	codec := Set{child: &Int64{typ: int64Type}}
 
 	var result []int64
-	useReflect, err := codec.setType(reflect.TypeOf(result))
+	typ := reflect.TypeOf(result)
+	useReflect, err := codec.setType(typ, Path(""))
 	require.Nil(t, err)
 	require.False(t, useReflect)
 
@@ -93,11 +95,12 @@ func TestSetDecodeReflect(t *testing.T) {
 	codec := Set{child: &Int64{typ: int64Type}}
 
 	var result []int64
-	useReflect, err := codec.setType(reflect.TypeOf(result))
+	typ := reflect.TypeOf(result)
+	useReflect, err := codec.setType(typ, Path(""))
 	require.Nil(t, err)
 	require.False(t, useReflect)
 
-	codec.DecodeReflect(r, reflect.ValueOf(&result).Elem())
+	codec.DecodeReflect(r, reflect.ValueOf(&result).Elem(), Path(""))
 	require.Equal(t, []byte{}, r.Buf)
 
 	// force garbage collection to be sure that
@@ -118,7 +121,8 @@ func TestDecodeEmptySet(t *testing.T) {
 	codec := Set{child: &Int64{typ: int64Type}}
 
 	var result []int64
-	useReflect, err := codec.setType(reflect.TypeOf(result))
+	typ := reflect.TypeOf(result)
+	useReflect, err := codec.setType(typ, Path(""))
 	require.Nil(t, err)
 	require.False(t, useReflect)
 


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb-go/issues/5

This change adds the data structure field path to type miss-match error messages. An example error message would look like:
`expected mypackage.MyType.path.to.field to be int64, got int`
