### PR TITLE
remove old go versions from github workflows matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: ["1.11", "1.12", "1.13", "1.14", "1.15"]
+        go-version: ["1.14", "1.15"]
         edgedb-version: [stable, nightly]
         os: [ubuntu-latest, macos-latest]
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 [![Build Status](https://github.com/edgedb/edgedb-go/workflows/Tests/badge.svg?event=push&branch=master)](https://github.com/edgedb/edgedb-go/actions)
 [![Join GitHub discussions](https://img.shields.io/badge/join-github%20discussions-green)](https://github.com/edgedb/edgedb/discussions)
 
-Requires go 1.11 or higher.
-
 # ⚠️ WIP ⚠️
 This project is far from production ready. Contributions welcome! 😊
 


### PR DESCRIPTION
The test strategy matrix for this project used to result in github running 20 checks which takes a long time. This change removes versions of go that are no longer [supported by google](https://golang.org/doc/devel/release.html#policy). Surveying several (~12) popular go packages all but one only runs tests against the two latest versions of go.