### PR TITLE
fix uuid encoding

### DIFF
--- a/internal/buff/read.go
+++ b/internal/buff/read.go
@@ -20,8 +20,8 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 	"github.com/edgedb/edgedb-go/internal/soc"
-	"github.com/edgedb/edgedb-go/internal/types"
 )
 
 // Reader is a buffer reader.

--- a/internal/buff/read_test.go
+++ b/internal/buff/read_test.go
@@ -19,8 +19,8 @@ package buff
 import (
 	"testing"
 
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 	"github.com/edgedb/edgedb-go/internal/soc"
-	"github.com/edgedb/edgedb-go/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/buff/write.go
+++ b/internal/buff/write.go
@@ -20,7 +20,7 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/edgedb/edgedb-go/internal/types"
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 )
 
 // Writer is a write buffer.

--- a/internal/buff/write_test.go
+++ b/internal/buff/write_test.go
@@ -19,8 +19,8 @@ package buff
 import (
 	"testing"
 
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 	"github.com/edgedb/edgedb-go/internal/message"
-	"github.com/edgedb/edgedb-go/internal/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/codecs/array.go
+++ b/internal/codecs/array.go
@@ -22,7 +22,7 @@ import (
 	"unsafe"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
-	"github.com/edgedb/edgedb-go/internal/types"
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 )
 
 func popArrayCodec(

--- a/internal/codecs/base_scalar.go
+++ b/internal/codecs/base_scalar.go
@@ -26,7 +26,7 @@ import (
 	"unsafe"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
-	"github.com/edgedb/edgedb-go/internal/types"
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 )
 
 var (
@@ -75,7 +75,7 @@ var (
 func baseScalarCodec(id types.UUID) (Codec, error) {
 	switch id {
 	case uuidID:
-		return &UUID{id, uuidType}, nil
+		return &UUID{}, nil
 	case strID:
 		return &Str{id, strType}, nil
 	case bytesID:
@@ -114,15 +114,10 @@ func baseScalarCodec(id types.UUID) (Codec, error) {
 }
 
 // UUID is an EdgeDB UUID type codec.
-type UUID struct {
-	id  types.UUID
-	typ reflect.Type
-}
+type UUID struct{}
 
 // ID returns the descriptor id.
-func (c *UUID) ID() types.UUID {
-	return c.id
-}
+func (c *UUID) ID() types.UUID { return uuidID }
 
 func (c *UUID) setDefaultType() {}
 
@@ -131,26 +126,17 @@ func (c *UUID) setType(typ reflect.Type, path Path) (bool, error) {
 }
 
 func (c *UUID) checkType(typ reflect.Type, path Path) error {
-	switch {
-	case typ.Kind() != c.typ.Kind():
-		return fmt.Errorf("expected %v to be edgedb.UUID got %v", path, typ)
-	case typ.Elem() != c.typ.Elem():
-		return fmt.Errorf("expected %v to be edgedb.UUID got %v", path, typ)
-	case typ.Len() != c.typ.Len():
-		return fmt.Errorf("expected %v to be edgedb.UUID got %v", path, typ)
-	case typ.PkgPath() != "github.com/edgedb/edgedb-go":
-		return fmt.Errorf("expected %v to be edgedb.UUID got %v", path, typ)
-	case typ.Name() != "UUID":
-		return fmt.Errorf("expected %v to be edgedb.UUID got %v", path, typ)
+	if typ != uuidType {
+		return fmt.Errorf(
+			"expected %v to be edgedb.UUID got %v", path, typ,
+		)
 	}
 
 	return nil
 }
 
 // Type returns the reflect.Type that this codec decodes to.
-func (c *UUID) Type() reflect.Type {
-	return c.typ
-}
+func (c *UUID) Type() reflect.Type { return uuidType }
 
 // Decode a UUID.
 func (c *UUID) Decode(r *buff.Reader, out reflect.Value) {
@@ -175,13 +161,13 @@ func (c *UUID) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 
 // Encode a UUID.
 func (c *UUID) Encode(w *buff.Writer, val interface{}, path Path) error {
-	tmp, ok := val.(types.UUID)
+	in, ok := val.(types.UUID)
 	if !ok {
-		return fmt.Errorf("expected %v to be types.UUID got %T", path, val)
+		return fmt.Errorf("expected %v to be edgedb.UUID got %T", path, val)
 	}
 
 	w.PushUint32(16)
-	w.PushBytes(tmp[:])
+	w.PushBytes(in[:])
 	return nil
 }
 
@@ -238,7 +224,7 @@ func (c *Str) DecodePtr(r *buff.Reader, out unsafe.Pointer) {
 func (c *Str) Encode(w *buff.Writer, val interface{}, path Path) error {
 	in, ok := val.(string)
 	if !ok {
-		return fmt.Errorf("expected %v to be types.UUID got %T", path, val)
+		return fmt.Errorf("expected %v to be edgedb.UUID got %T", path, val)
 	}
 
 	w.PushString(in)

--- a/internal/codecs/base_scalar_test.go
+++ b/internal/codecs/base_scalar_test.go
@@ -23,7 +23,7 @@ import (
 	"unsafe"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
-	"github.com/edgedb/edgedb-go/internal/types"
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/codecs/codecs.go
+++ b/internal/codecs/codecs.go
@@ -23,7 +23,7 @@ import (
 	"unsafe"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
-	"github.com/edgedb/edgedb-go/internal/types"
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 )
 
 const (

--- a/internal/codecs/named_tuple.go
+++ b/internal/codecs/named_tuple.go
@@ -22,8 +22,8 @@ import (
 	"unsafe"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 	"github.com/edgedb/edgedb-go/internal/marshal"
-	"github.com/edgedb/edgedb-go/internal/types"
 )
 
 func popNamedTupleCodec(

--- a/internal/codecs/named_tuple_test.go
+++ b/internal/codecs/named_tuple_test.go
@@ -23,8 +23,8 @@ import (
 	"unsafe"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 	"github.com/edgedb/edgedb-go/internal/message"
-	"github.com/edgedb/edgedb-go/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/codecs/object.go
+++ b/internal/codecs/object.go
@@ -22,8 +22,8 @@ import (
 	"unsafe"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 	"github.com/edgedb/edgedb-go/internal/marshal"
-	"github.com/edgedb/edgedb-go/internal/types"
 )
 
 func popObjectCodec(

--- a/internal/codecs/object_test.go
+++ b/internal/codecs/object_test.go
@@ -23,7 +23,7 @@ import (
 	"unsafe"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
-	"github.com/edgedb/edgedb-go/internal/types"
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/codecs/set.go
+++ b/internal/codecs/set.go
@@ -22,7 +22,7 @@ import (
 	"unsafe"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
-	"github.com/edgedb/edgedb-go/internal/types"
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 )
 
 func popSetCodec(

--- a/internal/codecs/tuple.go
+++ b/internal/codecs/tuple.go
@@ -22,7 +22,7 @@ import (
 	"unsafe"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
-	"github.com/edgedb/edgedb-go/internal/types"
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 )
 
 func popTupleCodec(

--- a/internal/codecs/tuple_test.go
+++ b/internal/codecs/tuple_test.go
@@ -23,7 +23,7 @@ import (
 	"unsafe"
 
 	"github.com/edgedb/edgedb-go/internal/buff"
-	"github.com/edgedb/edgedb-go/internal/types"
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/edgedbtypes/uuid.go
+++ b/internal/edgedbtypes/uuid.go
@@ -14,10 +14,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package edgedbtypes
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 )
 
 // UUID a universally unique identifier
@@ -33,4 +35,29 @@ func (id UUID) String() string {
 		id[8:10],
 		id[10:16],
 	)
+}
+
+// MarshalText returns the id as a byte string.
+func (id UUID) MarshalText() ([]byte, error) {
+	return []byte(id.String()), nil
+}
+
+// UnmarshalText unmarshals the id from a string.
+func (id *UUID) UnmarshalText(b []byte) error {
+	s := string(b)
+	s = strings.Replace(s, "-", "", 4)
+
+	var tmp UUID
+	for i := 0; i < 16; i++ {
+		val, err := strconv.ParseUint(s[:2], 16, 8)
+		if err != nil {
+			return err
+		}
+
+		tmp[i] = uint8(val)
+		s = s[2:]
+	}
+
+	*id = tmp
+	return nil
 }

--- a/internal/edgedbtypes/uuid_test.go
+++ b/internal/edgedbtypes/uuid_test.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package edgedb
+package edgedbtypes
 
 import (
 	"encoding/json"
@@ -27,14 +27,6 @@ import (
 func TestUUIDString(t *testing.T) {
 	uuid := UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	assert.Equal(t, "00010203-0405-0607-0809-0a0b0c0d0e0f", uuid.String())
-}
-
-func TestUUIDFromString(t *testing.T) {
-	uuid, err := UUIDFromString("00010203-0405-0607-0809-0a0b0c0d0e0f")
-	require.Nil(t, err)
-
-	expected := UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
-	assert.Equal(t, expected, uuid)
 }
 
 func TestUUIDMarshalJSON(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -28,6 +28,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSendAndReceveUUID(t *testing.T) {
+	id := UUID{
+		0x75, 0x96, 0x37, 0xd8, 0x66, 0x35, 0x11, 0xe9,
+		0xb9, 0xd4, 0x09, 0x80, 0x02, 0xd4, 0x59, 0xd5,
+	}
+
+	var result UUID
+	ctx := context.Background()
+	err := conn.QueryOne(ctx, "SELECT <uuid>$0", &result, id)
+
+	expected := UUID{
+		0x75, 0x96, 0x37, 0xd8, 0x66, 0x35, 0x11, 0xe9,
+		0xb9, 0xd4, 0x09, 0x80, 0x02, 0xd4, 0x59, 0xd5,
+	}
+
+	assert.Nil(t, err, "unexpected error: %v", err)
+	assert.Equal(t, expected, result)
+	assert.Equal(t, expected, id, "input value was mutated")
+
+	var nested []interface{}
+	err = conn.QueryOne(ctx, "SELECT ([<uuid>$0],)", &nested, id)
+
+	assert.Nil(t, err, "unexpected error: %v", err)
+	assert.Equal(t, []interface{}{[]UUID{expected}}, nested)
+	assert.Equal(t, expected, id, "input value was mutated")
+}
+
 func TestMissmatchedCardinality(t *testing.T) {
 	ctx := context.Background()
 

--- a/uuid.go
+++ b/uuid.go
@@ -16,52 +16,8 @@
 
 package edgedb
 
-import (
-	"fmt"
-	"strconv"
-	"strings"
-)
+import "github.com/edgedb/edgedb-go/internal/edgedbtypes"
 
 // UUID a universally unique identifier
 // https://www.edgedb.com/docs/datamodel/scalars/uuid#type::std::uuid
-type UUID [16]byte
-
-func (id UUID) String() string {
-	return fmt.Sprintf(
-		"%x-%x-%x-%x-%x",
-		id[0:4],
-		id[4:6],
-		id[6:8],
-		id[8:10],
-		id[10:16],
-	)
-}
-
-// MarshalText returns the id as a byte string.
-func (id UUID) MarshalText() ([]byte, error) {
-	return []byte(id.String()), nil
-}
-
-// UnmarshalText unmarshals the id from a string.
-func (id *UUID) UnmarshalText(b []byte) (err error) {
-	*id, err = UUIDFromString(string(b))
-	return err
-}
-
-// UUIDFromString converts a string to a UUID.
-func UUIDFromString(s string) (UUID, error) {
-	s = strings.Replace(s, "-", "", 4)
-
-	var id UUID
-	for i := 0; i < 16; i++ {
-		val, err := strconv.ParseUint(s[:2], 16, 8)
-		if err != nil {
-			return UUID{}, err
-		}
-
-		id[i] = uint8(val)
-		s = s[2:]
-	}
-
-	return id, nil
-}
+type UUID = edgedbtypes.UUID


### PR DESCRIPTION
This change fixes a bug that made it impossible to use UUIDs as query arguments.