### PR TITLE
fix broken tests

### DIFF
--- a/connutils_test.go
+++ b/connutils_test.go
@@ -437,7 +437,7 @@ func TestConnectTimeout(t *testing.T) {
 		User:               opts.User,
 		Password:           opts.Password,
 		Database:           opts.Database,
-		ConnectTimeout:     1 * time.Millisecond,
+		ConnectTimeout:     2 * time.Nanosecond,
 		WaitUntilAvailable: 1 * time.Nanosecond,
 	})
 

--- a/query_test.go
+++ b/query_test.go
@@ -528,10 +528,10 @@ func TestSendAndReceveDuration(t *testing.T) {
 		str string
 		d   Duration
 	}{
-		{"00:00:00", Duration(0)},
-		{"-00:00:00.000001", Duration(-1)},
+		{"0", Duration(0)},
+		{"-0:00:00.000001", Duration(-1)},
 		{"24:00:00", Duration(86400000000)},
-		{"00:00:01", Duration(1_000_000)},
+		{"0:00:01", Duration(1_000_000)},
 		{"854015929:20:18.258432", Duration(3074457345618258432)},
 	}
 


### PR DESCRIPTION
The server recently changed the string format for durations. This change updates tests to match the new format.