### PR TITLE
add context to syntax errors

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -93,7 +93,7 @@ func (c *baseConn) connect(r *buff.Reader, cfg *connConfig) error {
 
 			once.Do(done)
 		case message.ErrorResponse:
-			err = wrapAll(err, decodeError(r))
+			err = wrapAll(err, decodeError(r, ""))
 			once.Do(done)
 		default:
 			if e := c.fallThrough(r); e != nil {
@@ -154,7 +154,7 @@ func (c *baseConn) authenticate(r *buff.Reader, cfg *connConfig) error {
 
 			done.Signal()
 		case message.ErrorResponse:
-			err = decodeError(r)
+			err = decodeError(r, "")
 			done.Signal()
 		default:
 			if e := c.fallThrough(r); e != nil {
@@ -209,7 +209,7 @@ func (c *baseConn) authenticate(r *buff.Reader, cfg *connConfig) error {
 			r.Discard(1) // transaction state
 			done.Signal()
 		case message.ErrorResponse:
-			err = wrapAll(decodeError(r))
+			err = wrapAll(decodeError(r, ""))
 			done.Signal()
 		default:
 			if e := c.fallThrough(r); e != nil {

--- a/granularflow.go
+++ b/granularflow.go
@@ -144,7 +144,7 @@ func (c *baseConn) prepare(r *buff.Reader, q *gfQuery) (idPair, error) {
 			r.Discard(1) // transaction state
 			done.Signal()
 		case message.ErrorResponse:
-			err = wrapAll(err, decodeError(r))
+			err = wrapAll(err, decodeError(r, q.cmd))
 		default:
 			if e := c.fallThrough(r); e != nil {
 				// the connection will not be usable after this x_x
@@ -207,7 +207,7 @@ func (c *baseConn) describe(r *buff.Reader, q *gfQuery) (descPair, error) {
 			r.Discard(1) // transaction state
 			done.Signal()
 		case message.ErrorResponse:
-			err = wrapAll(err, decodeError(r))
+			err = wrapAll(err, decodeError(r, q.cmd))
 		default:
 			if e := c.fallThrough(r); e != nil {
 				// the connection will not be usable after this x_x
@@ -286,7 +286,7 @@ func (c *baseConn) execute(r *buff.Reader, q *gfQuery, cdcs codecPair) error {
 				err = nil
 			}
 
-			err = wrapAll(err, decodeError(r))
+			err = wrapAll(err, decodeError(r, q.cmd))
 		default:
 			if e := c.fallThrough(r); e != nil {
 				// the connection will not be usable after this x_x
@@ -380,7 +380,7 @@ func (c *baseConn) optimistic(
 				err = nil
 			}
 
-			err = wrapAll(err, decodeError(r))
+			err = wrapAll(err, decodeError(r, q.cmd))
 		default:
 			if e := c.fallThrough(r); e != nil {
 				// the connection will not be usable after this x_x

--- a/query_test.go
+++ b/query_test.go
@@ -93,10 +93,14 @@ func TestParseAllMessagesAfterError(t *testing.T) {
 	// cause error during prepare
 	var number float64
 	err := conn.QueryOne(ctx, "SELECT 1 / $0", &number, int64(5))
-	expected := "edgedb.QueryError: missing a type cast before the parameter"
+	expected := `edgedb.QueryError: missing a type cast before the parameter
+query:1:12
+
+SELECT 1 / $0
+           ^ error`
 	assert.EqualError(t, err, expected)
 
-	// cause error during execute
+	// cause erroy during execute
 	err = conn.QueryOne(ctx, "SELECT 1 / 0", &number)
 	assert.EqualError(t, err, "edgedb.DivisionByZeroError: division by zero")
 
@@ -228,7 +232,11 @@ func TestError(t *testing.T) {
 	assert.EqualError(
 		t,
 		err,
-		"edgedb.EdgeQLSyntaxError: Unexpected 'malformed'",
+		`edgedb.EdgeQLSyntaxError: Unexpected 'malformed'
+query:1:1
+
+malformed query;
+^ error`,
 	)
 
 	var expected Error

--- a/scriptflow.go
+++ b/scriptflow.go
@@ -64,7 +64,7 @@ func (c *baseConn) scriptFlow(r *buff.Reader, q sfQuery) error {
 			r.Discard(1) // transaction state
 			done.Signal()
 		case message.ErrorResponse:
-			err = wrapAll(err, decodeError(r))
+			err = wrapAll(err, decodeError(r, q.cmd))
 			done.Signal()
 		default:
 			if e := c.fallThrough(r); e != nil {

--- a/types_test.go
+++ b/types_test.go
@@ -704,7 +704,6 @@ func (m CustomBytes) MarshalEdgeDBBytes() ([]byte, error) {
 
 func (m *CustomBytes) UnmarshalEdgeDBBytes(data []byte) error {
 	m.data = data
-	fmt.Println(m.data)
 	return nil
 }
 
@@ -838,7 +837,6 @@ func (m CustomJSON) MarshalEdgeDBJSON() ([]byte, error) {
 
 func (m *CustomJSON) UnmarshalEdgeDBJSON(data []byte) error {
 	m.data = data
-	fmt.Println(m.data)
 	return nil
 }
 
@@ -1719,7 +1717,6 @@ func (m CustomBigInt) MarshalEdgeDBBigInt() ([]byte, error) {
 
 func (m *CustomBigInt) UnmarshalEdgeDBBigInt(data []byte) error {
 	m.data = data
-	fmt.Println(m.data)
 	return nil
 }
 


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb-go/issues/116

A query snip-it with arrow and hint is introduced for syntax errors.

## Caveats 
This implementation is very crude and likely to work poorly with characters outside of the ascii range because bytes are construed as characters. It also replaces tabs with spaces in the query to avoid misalignment when printed.

There doesn't seem to be a library in go similar to rust's [codespan](https://github.com/brendanzab/codespan) so the only option seems to be to roll our own.

## Example
`SELECT (foo (((1 2) 3)) 4)` produces
```
edgedb.EdgeQLSyntaxError: Unexpected token: <Token ICONST "2">
query:1:18

SELECT (foo (((1 2) 3)) 4)
                 ^ It appears that a ',' is missing in a tuple before '2'
```