### PR TITLE
improve wrong number of arguments error

### DIFF
--- a/internal/codecs/tuple.go
+++ b/internal/codecs/tuple.go
@@ -63,8 +63,7 @@ func (c *tupleEncoder) Encode(
 
 	if len(in) != len(c.fields) {
 		return fmt.Errorf(
-			"expected %v to be []interface{} with len=%v, got len=%v",
-			path, len(c.fields), len(in),
+			"expected %v arguments got %v", len(c.fields), len(in),
 		)
 	}
 

--- a/query_test.go
+++ b/query_test.go
@@ -27,6 +27,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestWrongNumberOfArguments(t *testing.T) {
+	var result string
+	ctx := context.Background()
+	err := conn.QueryOne(ctx, `SELECT <str>$0`, &result)
+	assert.EqualError(t, err,
+		"edgedb.InvalidArgumentError: expected 1 arguments got 0")
+}
+
 func TestConnRejectsTransactions(t *testing.T) {
 	expected := "edgedb.DisabledCapabilityError: " +
 		"cannot execute transaction control commands"


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb-go/issues/112

This error now reads, "expected 3 arguments got 2".