### PR TITLE
implement subtransactions (RFC1004)

### DIFF
--- a/borrow.go
+++ b/borrow.go
@@ -1,0 +1,103 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/edgedb/edgedb-go/internal/header"
+)
+
+type borrowableConn struct {
+	*baseConn
+	reason string
+}
+
+func (c *borrowableConn) borrow(reason string) (*baseConn, error) {
+	switch c.reason {
+	case "":
+		// this is the expected value
+	case "transaction":
+		return nil, &interfaceError{
+			msg: "The connection is borrowed for a transaction. " +
+				"Use the methods on the transaction object instead.",
+		}
+	case "subtransaction":
+		return nil, &interfaceError{
+			msg: "The transaction is borrowed for a subtransaction. " +
+				"Use the methods on the subtransaction object instead.",
+		}
+	default:
+		panic(fmt.Sprintf("unexpected reason: %q", c.reason))
+	}
+
+	switch reason {
+	case "transaction", "subtransaction":
+		c.reason = reason
+		return c.baseConn, nil
+	default:
+		panic(fmt.Sprintf("unexpected reason: %q", reason))
+	}
+}
+
+func (c *borrowableConn) unborrow() {
+	if c.reason == "" {
+		panic("not currently borrowed, can not unborrow")
+	}
+
+	c.reason = ""
+}
+
+func (c *borrowableConn) assertUnborrowed() error {
+	switch c.reason {
+	case "":
+		return nil
+	case "transaction":
+		return &interfaceError{
+			msg: "The connection is borrowed for a transaction. " +
+				"Use the methods on the transaction object instead.",
+		}
+	case "subtransaction":
+		return &interfaceError{
+			msg: "The transaction is borrowed for a subtransaction. " +
+				"Use the methods on the subtransaction object instead.",
+		}
+	default:
+		panic(fmt.Sprintf("unexpected reason: %q", c.reason))
+	}
+}
+
+func (c *borrowableConn) headers() msgHeaders {
+	return msgHeaders{header.AllowCapabilities: noTxCapabilities}
+}
+
+func (c *borrowableConn) scriptFlow(ctx context.Context, q sfQuery) error {
+	if e := c.assertUnborrowed(); e != nil {
+		return e
+	}
+
+	return c.baseConn.scriptFlow(ctx, q)
+}
+
+func (c *borrowableConn) granularFlow(ctx context.Context, q *gfQuery) error {
+	if e := c.assertUnborrowed(); e != nil {
+		return e
+	}
+
+	return c.baseConn.granularFlow(ctx, q)
+}

--- a/connect.go
+++ b/connect.go
@@ -48,7 +48,7 @@ func (c *baseConn) connect(r *buff.Reader, cfg *connConfig) error {
 
 	c.protocolVersion = protocolVersionMax
 
-	if err := w.Send(c.conn); err != nil {
+	if err := w.Send(c.netConn); err != nil {
 		return &clientConnectionError{err: err}
 	}
 
@@ -68,7 +68,7 @@ func (c *baseConn) connect(r *buff.Reader, cfg *connConfig) error {
 
 			if protocolVersion.LT(protocolVersionMin) ||
 				protocolVersion.GT(protocolVersionMax) {
-				_ = c.conn.Close()
+				_ = c.netConn.Close()
 				msg := fmt.Sprintf(
 					"unsupported protocol version: %v.%v",
 					protocolVersion.Major,
@@ -117,7 +117,7 @@ func (c *baseConn) connect(r *buff.Reader, cfg *connConfig) error {
 		}
 	}
 
-	_, isTLS := c.conn.(*tls.Conn)
+	_, isTLS := c.netConn.(*tls.Conn)
 	if !isTLS && c.protocolVersion.GTE(protocolVersion0p11) {
 		_ = c.close()
 		return &clientConnectionError{msg: fmt.Sprintf(
@@ -153,7 +153,7 @@ func (c *baseConn) authenticate(r *buff.Reader, cfg *connConfig) error {
 	w.PushString(scramMsg)
 	w.EndMessage()
 
-	if e := w.Send(c.conn); e != nil {
+	if e := w.Send(c.netConn); e != nil {
 		return &clientConnectionError{err: e}
 	}
 
@@ -201,7 +201,7 @@ func (c *baseConn) authenticate(r *buff.Reader, cfg *connConfig) error {
 	w.PushString(scramMsg)
 	w.EndMessage()
 
-	if e := w.Send(c.conn); e != nil {
+	if e := w.Send(c.netConn); e != nil {
 		return &clientConnectionError{err: e}
 	}
 
@@ -254,7 +254,7 @@ func (c *baseConn) terminate() error {
 	w.BeginMessage(message.Terminate)
 	w.EndMessage()
 
-	if e := w.Send(c.conn); e != nil {
+	if e := w.Send(c.netConn); e != nil {
 		return &clientConnectionError{err: e}
 	}
 

--- a/granularflow.go
+++ b/granularflow.go
@@ -31,7 +31,7 @@ import (
 	"github.com/edgedb/edgedb-go/internal/message"
 )
 
-func (c *baseConn) granularFlow(r *buff.Reader, q *gfQuery) (err error) {
+func (c *baseConn) execGranularFlow(r *buff.Reader, q *gfQuery) (err error) {
 	ids, ok := c.getTypeIDs(q)
 	if !ok {
 		return c.pesimistic(r, q)
@@ -129,7 +129,7 @@ func (c *baseConn) prepare(r *buff.Reader, q *gfQuery) (idPair, error) {
 	w.BeginMessage(message.Sync)
 	w.EndMessage()
 
-	if e := w.Send(c.conn); e != nil {
+	if e := w.Send(c.netConn); e != nil {
 		return idPair{}, &clientConnectionError{err: e}
 	}
 
@@ -179,7 +179,7 @@ func (c *baseConn) describe(r *buff.Reader, q *gfQuery) (descPair, error) {
 	w.EndMessage()
 
 	var descs descPair
-	if e := w.Send(c.conn); e != nil {
+	if e := w.Send(c.netConn); e != nil {
 		return descPair{}, &clientConnectionError{err: e}
 	}
 
@@ -255,7 +255,7 @@ func (c *baseConn) execute(r *buff.Reader, q *gfQuery, cdcs codecPair) error {
 	w.BeginMessage(message.Sync)
 	w.EndMessage()
 
-	if e := w.Send(c.conn); e != nil {
+	if e := w.Send(c.netConn); e != nil {
 		return &clientConnectionError{err: e}
 	}
 
@@ -352,7 +352,7 @@ func (c *baseConn) optimistic(
 	w.BeginMessage(message.Sync)
 	w.EndMessage()
 
-	if e := w.Send(c.conn); e != nil {
+	if e := w.Send(c.netConn); e != nil {
 		return &clientConnectionError{err: e}
 	}
 

--- a/pool.go
+++ b/pool.go
@@ -105,20 +105,20 @@ func ConnectDSN(ctx context.Context, dsn string, opts Options) (*Pool, error) { 
 
 	False := false
 	p := &Pool{
-		isClosed: &False,
-		mu:       &sync.RWMutex{},
-		maxConns: maxConns,
-		minConns: minConns,
-		cfg:      cfg,
-		txOpts: TxOptions{
-			isolation:  RepeatableRead,
-			readOnly:   false,
-			deferrable: false,
-		},
-
+		isClosed:       &False,
+		mu:             &sync.RWMutex{},
 		freeConns:      make(chan *reconnectingConn, minConns),
 		potentialConns: make(chan struct{}, maxConns),
-
+		maxConns:       maxConns,
+		minConns:       minConns,
+		txOpts: TxOptions{
+			fromFactory: false,
+			readOnly:    false,
+			deferrable:  false,
+			isolation:   RepeatableRead,
+		},
+		retryOpts:     RetryOptions{},
+		cfg:           cfg,
 		typeIDCache:   cache.New(1_000),
 		inCodecCache:  cache.New(1_000),
 		outCodecCache: cache.New(1_000),

--- a/pool_test.go
+++ b/pool_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/edgedb/edgedb-go/internal/cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -138,10 +139,16 @@ func mockPool(opts Options) *Pool { // nolint:gocritic
 	return &Pool{
 		isClosed:       &False,
 		mu:             &sync.RWMutex{},
-		maxConns:       int(opts.MaxConns),
-		minConns:       int(opts.MinConns),
 		freeConns:      make(chan *reconnectingConn, opts.MinConns),
 		potentialConns: make(chan struct{}, opts.MaxConns),
+		maxConns:       int(opts.MaxConns),
+		minConns:       int(opts.MinConns),
+		txOpts:         TxOptions{},
+		retryOpts:      RetryOptions{},
+		cfg:            &connConfig{},
+		typeIDCache:    &cache.Cache{},
+		inCodecCache:   &cache.Cache{},
+		outCodecCache:  &cache.Cache{},
 	}
 }
 

--- a/poolconn_test.go
+++ b/poolconn_test.go
@@ -18,37 +18,13 @@ package edgedb
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestReleasePoolConn(t *testing.T) {
-	p := &Pool{freeConns: make(chan *reconnectingConn, 1)}
-	conn := &reconnectingConn{}
-	pConn := &PoolConn{pool: p, conn: conn}
-
-	err := pConn.Release()
-	require.NoError(t, err)
-
-	result := <-p.freeConns
-	assert.Equal(t, conn, result)
-
-	err = pConn.Release()
-	assert.EqualError(
-		t,
-		err,
-		"edgedb.InterfaceError: connection released more than once",
-	)
-
-	var edbErr Error
-	require.True(t, errors.As(err, &edbErr))
-	assert.True(t, edbErr.Category(InterfaceError))
-}
-
-func TestPoolConnectionRejectsTransaction(t *testing.T) {
+func TestPoolConnection(t *testing.T) {
 	ctx := context.Background()
 	p, err := Connect(ctx, opts)
 	require.NoError(t, err)
@@ -76,4 +52,17 @@ func TestPoolConnectionRejectsTransaction(t *testing.T) {
 
 	err = con.QuerySingleJSON(ctx, "START TRANSACTION", &result)
 	assert.EqualError(t, err, expected)
+
+	conCopy := con.WithTxOptions(NewTxOptions())
+
+	err = con.Release()
+	assert.NoError(t, err)
+
+	err = con.Release()
+	msg := "edgedb.InterfaceError: connection released more than once"
+	assert.EqualError(t, err, msg)
+
+	// Copied connections should not be releasable a second time.
+	err = conCopy.Release()
+	assert.EqualError(t, err, msg)
 }

--- a/query_test.go
+++ b/query_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestObjectWithoutID(t *testing.T) {
-	if conn.conn.protocolVersion.LT(protocolVersion0p10) {
+	if conn.transactableConn.protocolVersion.LT(protocolVersion0p10) {
 		t.Skip("not expected to pass on protocol versions below 0.10")
 	}
 

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -27,18 +27,19 @@ func TestRecconnectingConnBorrow(t *testing.T) {
 	err := b.assertUnborrowed()
 	require.NoError(t, err)
 
-	err = b.borrow("transaction")
+	_, err = b.borrow("transaction")
 	require.NoError(t, err)
 
-	err = b.borrow("something else")
+	_, err = b.borrow("something else")
 	expected := "edgedb.InterfaceError: " +
-		"connection is already borrowed for transaction"
+		"The connection is borrowed for a transaction. " +
+		"Use the methods on the transaction object instead."
 	require.EqualError(t, err, expected)
 
 	err = b.assertUnborrowed()
 	expected = "edgedb.InterfaceError: " +
-		"Connection is borrowed for a transaction. " +
-		"Use the methods on transaction object instead."
+		"The connection is borrowed for a transaction. " +
+		"Use the methods on the transaction object instead."
 	require.EqualError(t, err, expected)
 
 	b.unborrow()

--- a/scriptflow.go
+++ b/scriptflow.go
@@ -50,14 +50,14 @@ func writeHeaders(w *buff.Writer, headers msgHeaders) {
 	}
 }
 
-func (c *baseConn) scriptFlow(r *buff.Reader, q sfQuery) error {
+func (c *baseConn) execScriptFlow(r *buff.Reader, q sfQuery) error {
 	w := buff.NewWriter(c.writeMemory[:0])
 	w.BeginMessage(message.ExecuteScript)
 	writeHeaders(w, q.headers)
 	w.PushString(q.cmd)
 	w.EndMessage()
 
-	if e := w.Send(c.conn); e != nil {
+	if e := w.Send(c.netConn); e != nil {
 		return &clientConnectionError{err: e}
 	}
 

--- a/subtransaction.go
+++ b/subtransaction.go
@@ -1,0 +1,168 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedb
+
+import (
+	"context"
+)
+
+type subtxable interface {
+	borrow(string) (*baseConn, error)
+	unborrow()
+	txOptions() TxOptions
+	txstate() *txState
+}
+
+func runSubtx(ctx context.Context, action SubtxBlock, c subtxable) error {
+	conn, err := c.borrow("subtransaction")
+	if err != nil {
+		return err
+	}
+	defer c.unborrow()
+
+	subtx := &Subtx{
+		borrowableConn: borrowableConn{
+			baseConn: conn,
+		},
+		txState: c.txstate(),
+		options: c.txOptions(),
+	}
+
+	if e := subtx.declare(ctx); e != nil {
+		return e
+	}
+
+	if e := action(ctx, subtx); e != nil {
+		return firstError(subtx.rollback(ctx), e)
+	}
+
+	return subtx.release(ctx)
+}
+
+// SubtxBlock is work to be done in a subtransaction.
+type SubtxBlock func(context.Context, *Subtx) error
+
+// Subtx is a subtransaction.
+type Subtx struct {
+	borrowableConn
+	*txState
+	options TxOptions
+	name    string
+}
+
+func (t *Subtx) declare(ctx context.Context) error {
+	if e := t.assertStarted("start subtransaction"); e != nil {
+		return e
+	}
+
+	t.name = t.nextSavepointName()
+	cmd := "DECLARE SAVEPOINT " + t.name
+	return t.scriptFlow(ctx, sfQuery{cmd: cmd})
+}
+
+func (t *Subtx) release(ctx context.Context) error {
+	if e := t.assertStarted("release subtransaction"); e != nil {
+		return e
+	}
+
+	cmd := "RELEASE SAVEPOINT " + t.name
+	return t.scriptFlow(ctx, sfQuery{cmd: cmd})
+}
+
+func (t *Subtx) rollback(ctx context.Context) error {
+	if e := t.assertStarted("rollback subtransaction"); e != nil {
+		return e
+	}
+
+	cmd := "ROLLBACK TO SAVEPOINT " + t.name
+	return t.scriptFlow(ctx, sfQuery{cmd: cmd})
+}
+
+func (t *Subtx) txOptions() TxOptions { return t.options }
+
+func (t *Subtx) txstate() *txState { return t.txState }
+
+// Subtx runs an action in a savepoint.
+// If the action returns an error the savepoint is rolled back,
+// otherwise it is released.
+func (t *Subtx) Subtx(ctx context.Context, action SubtxBlock) error {
+	return runSubtx(ctx, action, t)
+}
+
+// Execute an EdgeQL command (or commands).
+func (t *Subtx) Execute(ctx context.Context, cmd string) error {
+	if e := t.assertStarted("Execute"); e != nil {
+		return e
+	}
+
+	return t.scriptFlow(ctx, sfQuery{
+		cmd:     cmd,
+		headers: t.headers(),
+	})
+}
+
+func (t *Subtx) granularFlow(ctx context.Context, q *gfQuery) error {
+	if e := t.assertStarted(q.method); e != nil {
+		return e
+	}
+
+	return t.borrowableConn.granularFlow(ctx, q)
+}
+
+// Query runs a query and returns the results.
+func (t *Subtx) Query(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
+	return runQuery(ctx, t, "Query", cmd, out, args)
+}
+
+// QuerySingle runs a singleton-returning query and returns its element.
+// If the query executes successfully but doesn't return a result
+// a NoDataError is returned.
+func (t *Subtx) QuerySingle(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
+	return runQuery(ctx, t, "QuerySingle", cmd, out, args)
+}
+
+// QueryJSON runs a query and return the results as JSON.
+func (t *Subtx) QueryJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
+	return runQuery(ctx, t, "QueryJSON", cmd, out, args)
+}
+
+// QuerySingleJSON runs a singleton-returning query.
+// If the query executes successfully but doesn't have a result
+// a NoDataError is returned.
+func (t *Subtx) QuerySingleJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
+	return runQuery(ctx, t, "QuerySingleJSON", cmd, out, args)
+}

--- a/subtransaction_test.go
+++ b/subtransaction_test.go
@@ -1,0 +1,212 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubtxRollback(t *testing.T) {
+	ctx := context.Background()
+
+	insertName := func(s string) string {
+		return fmt.Sprintf("INSERT TxTest {name := 'subtx %v'};", s)
+	}
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		err := tx.Subtx(ctx, func(ctx context.Context, stx *Subtx) error {
+			err := stx.Execute(ctx, insertName("rollback 1"))
+			assert.Nil(t, err, "unexpected error: %v", err)
+
+			return firstError(err, errors.New("user error 1"))
+		})
+		assert.EqualError(t, err, "user error 1")
+		if err != nil && err.Error() != "user error 1" {
+			return err
+		}
+
+		err = tx.Subtx(ctx, func(ctx context.Context, stx *Subtx) error {
+			err = stx.Subtx(ctx, func(ctx context.Context, stx2 *Subtx) error {
+				err = stx2.Execute(ctx, insertName("commit 1"))
+				assert.Nil(t, err, "unexpected error: %v", err)
+				return err
+			})
+			assert.Nil(t, err, "unexpected error: %v", err)
+			if err != nil {
+				return err
+			}
+
+			err = stx.Subtx(ctx, func(ctx context.Context, stx2 *Subtx) error {
+				err = stx2.Execute(ctx, insertName("rollback 2"))
+				assert.Nil(t, err, "unexpected error: %v", err)
+
+				return firstError(err, errors.New("user error 2"))
+			})
+			assert.EqualError(t, err, "user error 2")
+			if err != nil && err.Error() != "user error 2" {
+				return err
+			}
+
+			err = stx.Execute(ctx, insertName("commit 2"))
+			assert.Nil(t, err, "unexpected error: %v", err)
+
+			return err
+		})
+		assert.Nil(t, err, "unexpected error: %v", err)
+
+		return err
+	})
+	assert.Nil(t, err, "unexpected error: %v", err)
+
+	var names []string
+	err = conn.Query(
+		ctx, `
+		SELECT names := (SELECT TxTest {name}).name
+		FILTER names LIKE 'subtx %'
+		ORDER BY names`,
+		&names,
+	)
+	require.Nil(t, err, "unexpected error: %v", err)
+
+	expected := []string{
+		"subtx commit 1",
+		"subtx commit 2",
+	}
+
+	require.Equal(t, expected, names, "subtransaction wasn't rolled back")
+}
+
+func TestSubtxBorrowing(t *testing.T) {
+	ctx := context.Background()
+
+	noOpSubtx := func(ctx context.Context, stx *Subtx) error { return nil }
+	noOpTx := func(ctx context.Context, tx *Tx) error { return nil }
+
+	expected := "edgedb.InterfaceError: " +
+		"The connection is borrowed for a transaction. " +
+		"Use the methods on the transaction object instead."
+
+	connCopy := conn.WithTxOptions(NewTxOptions())
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		// the connection should not be borrowable
+		err := conn.Execute(ctx, "SELECT 1")
+		assert.EqualError(t, err, expected)
+
+		var result []byte
+		err = conn.Query(ctx, "SELECT b''", &result)
+		assert.EqualError(t, err, expected)
+
+		err = conn.QueryOne(ctx, "SELECT b''", &result)
+		assert.EqualError(t, err, expected)
+
+		err = conn.QueryJSON(ctx, "SELECT b''", &result)
+		assert.EqualError(t, err, expected)
+
+		err = conn.QueryOneJSON(ctx, "SELECT b''", &result)
+		assert.EqualError(t, err, expected)
+
+		err = conn.RawTx(ctx, noOpTx)
+		assert.EqualError(t, err, expected)
+
+		err = conn.RetryingTx(ctx, noOpTx)
+		assert.EqualError(t, err, expected)
+
+		// copied connections should not be borrowable either
+		err = connCopy.Execute(ctx, "SELECT 1")
+		assert.EqualError(t, err, expected)
+
+		err = connCopy.Query(ctx, "SELECT b''", &result)
+		assert.EqualError(t, err, expected)
+
+		err = connCopy.QueryOne(ctx, "SELECT b''", &result)
+		assert.EqualError(t, err, expected)
+
+		err = connCopy.QueryJSON(ctx, "SELECT b''", &result)
+		assert.EqualError(t, err, expected)
+
+		err = connCopy.QueryOneJSON(ctx, "SELECT b''", &result)
+		assert.EqualError(t, err, expected)
+
+		err = connCopy.RawTx(ctx, noOpTx)
+		assert.EqualError(t, err, expected)
+
+		err = connCopy.RetryingTx(ctx, noOpTx)
+		assert.EqualError(t, err, expected)
+
+		err = tx.Subtx(ctx, func(ctx context.Context, stx *Subtx) error {
+			expected := "edgedb.InterfaceError: " +
+				"The transaction is borrowed for a subtransaction. " +
+				"Use the methods on the subtransaction object instead."
+
+			err = tx.Execute(ctx, "SELECT 1")
+			assert.EqualError(t, err, expected)
+
+			var result []byte
+			err = tx.Query(ctx, "SELECT b''", &result)
+			assert.EqualError(t, err, expected)
+
+			err = tx.QueryOne(ctx, "SELECT b''", &result)
+			assert.EqualError(t, err, expected)
+
+			err = tx.QueryJSON(ctx, "SELECT b''", &result)
+			assert.EqualError(t, err, expected)
+
+			err = tx.QueryOneJSON(ctx, "SELECT b''", &result)
+			assert.EqualError(t, err, expected)
+
+			err = tx.Subtx(ctx, noOpSubtx)
+			assert.EqualError(t, err, expected)
+
+			err = stx.Subtx(ctx, func(ctx context.Context, stx2 *Subtx) error {
+				err = stx.Execute(ctx, "SELECT 1")
+				assert.EqualError(t, err, expected)
+
+				var result []byte
+				err = stx.Query(ctx, "SELECT b''", &result)
+				assert.EqualError(t, err, expected)
+
+				err = stx.QuerySingle(ctx, "SELECT b''", &result)
+				assert.EqualError(t, err, expected)
+
+				err = stx.QueryJSON(ctx, "SELECT b''", &result)
+				assert.EqualError(t, err, expected)
+
+				err = stx.QuerySingleJSON(ctx, "SELECT b''", &result)
+				assert.EqualError(t, err, expected)
+
+				err = stx.Subtx(ctx, noOpSubtx)
+				assert.EqualError(t, err, expected)
+
+				return nil
+			})
+			assert.Nil(t, err, "unexpected error: %v", err)
+
+			return nil
+		})
+		assert.Nil(t, err, "unexpected error: %v", err)
+
+		return nil
+	})
+	assert.Nil(t, err, "unexpected error: %v", err)
+}

--- a/transactable.go
+++ b/transactable.go
@@ -19,81 +19,39 @@ package edgedb
 import (
 	"context"
 	"errors"
-
-	"github.com/edgedb/edgedb-go/internal/soc"
+	"time"
 )
 
-// PoolConn is a pooled connection.
-//
-// Deprecated: use the query methods on Pool instead
-type PoolConn struct {
-	transactableConn
-	isClosed *bool
-	pool     *Pool
-	err      *error
-}
-
-// Release the connection back to its pool.
-// Release returns an error if called more than once.
-// A PoolConn is not usable after Release has been called.
-func (c *PoolConn) Release() error {
-	if *c.isClosed {
-		return &interfaceError{msg: "connection released more than once"}
-	}
-
-	var err error
-	if c.err != nil {
-		err = *c.err
-	}
-
-	err = c.pool.release(&c.transactableConn, err)
-	c.pool = nil
-	c.transactableConn = transactableConn{}
-	c.err = nil
-	*c.isClosed = true
-
-	return err
-}
-
-// checkErr records errors that indicate the connection should be closed
-// so that this connection can be recycled when it is released.
-func (c *PoolConn) checkErr(err error) {
-	if soc.IsPermanentNetErr(err) {
-		c.err = &err
-		return
-	}
-
-	var edbErr Error
-	if errors.As(err, &edbErr) && edbErr.Category(UnexpectedMessageError) {
-		c.err = &err
-	}
+type transactableConn struct {
+	*reconnectingConn
+	txOpts    TxOptions
+	retryOpts RetryOptions
 }
 
 // Execute an EdgeQL command (or commands).
-func (c *PoolConn) Execute(ctx context.Context, cmd string) error {
-	err := c.transactableConn.Execute(ctx, cmd)
-	c.checkErr(err)
-	return err
+func (c *transactableConn) Execute(ctx context.Context, cmd string) error {
+	return c.scriptFlow(ctx, sfQuery{
+		cmd:     cmd,
+		headers: c.headers(),
+	})
 }
 
 // Query runs a query and returns the results.
-func (c *PoolConn) Query(
+func (c *transactableConn) Query(
 	ctx context.Context,
 	cmd string,
 	out interface{},
 	args ...interface{},
 ) error {
-	err := c.transactableConn.Query(ctx, cmd, out, args...)
-	c.checkErr(err)
-	return err
+	return runQuery(ctx, c, "Query", cmd, out, args)
 }
 
 // QueryOne runs a singleton-returning query and returns its element.
 // If the query executes successfully but doesn't return a result
 // a NoDataError is returned.
 //
-// Deprecated: use QuerySingle()
-func (c *PoolConn) QueryOne(
+// Deprecated: use QuerySingle() instead
+func (c *transactableConn) QueryOne(
 	ctx context.Context,
 	cmd string,
 	out interface{},
@@ -105,70 +63,135 @@ func (c *PoolConn) QueryOne(
 // QuerySingle runs a singleton-returning query and returns its element.
 // If the query executes successfully but doesn't return a result
 // a NoDataError is returned.
-func (c *PoolConn) QuerySingle(
+func (c *transactableConn) QuerySingle(
 	ctx context.Context,
 	cmd string,
 	out interface{},
 	args ...interface{},
 ) error {
-	err := c.transactableConn.QuerySingle(ctx, cmd, out, args...)
-	c.checkErr(err)
-	return err
+	return runQuery(ctx, c, "QuerySingle", cmd, out, args)
 }
 
 // QueryJSON runs a query and return the results as JSON.
-func (c *PoolConn) QueryJSON(
+func (c *transactableConn) QueryJSON(
 	ctx context.Context,
 	cmd string,
 	out *[]byte,
 	args ...interface{},
 ) error {
-	err := c.transactableConn.QueryJSON(ctx, cmd, out, args...)
-	c.checkErr(err)
-	return err
+	return runQuery(ctx, c, "QueryJSON", cmd, out, args)
 }
 
 // QueryOneJSON runs a singleton-returning query.
 // If the query executes successfully but doesn't have a result
 // a NoDataError is returned.
 //
-// Deprecated: use QuerySingleJSON()
-func (c *PoolConn) QueryOneJSON(
+// Deprecated: use QuerySingleJSON() instead
+func (c *transactableConn) QueryOneJSON(
 	ctx context.Context,
 	cmd string,
 	out *[]byte,
 	args ...interface{},
 ) error {
-	return c.QuerySingleJSON(ctx, cmd, out, args...)
+	return c.QuerySingle(ctx, cmd, out, args...)
 }
 
 // QuerySingleJSON runs a singleton-returning query.
 // If the query executes successfully but doesn't have a result
 // a NoDataError is returned.
-func (c *PoolConn) QuerySingleJSON(
+func (c *transactableConn) QuerySingleJSON(
 	ctx context.Context,
 	cmd string,
 	out *[]byte,
 	args ...interface{},
 ) error {
-	err := c.transactableConn.QuerySingleJSON(ctx, cmd, out, args...)
-	c.checkErr(err)
-	return err
+	return runQuery(ctx, c, "QuerySingleJSON", cmd, out, args)
 }
 
 // RawTx runs an action in a transaction.
 // If the action returns an error the transaction is rolled back,
 // otherwise it is committed.
-func (c *PoolConn) RawTx(ctx context.Context, action TxBlock) error {
-	err := c.transactableConn.RawTx(ctx, action)
-	c.checkErr(err)
-	return err
+func (c *transactableConn) RawTx(ctx context.Context, action TxBlock) error {
+	conn, err := c.borrow("transaction")
+	if err != nil {
+		return err
+	}
+	defer c.unborrow()
+
+	if e := c.ensureConnection(ctx); e != nil {
+		return e
+	}
+
+	tx := &Tx{
+		borrowableConn: borrowableConn{
+			baseConn: conn,
+		},
+		txState: &txState{},
+		options: c.txOpts,
+	}
+	if e := tx.start(ctx); e != nil {
+		return e
+	}
+
+	if e := action(ctx, tx); e != nil {
+		return firstError(tx.rollback(ctx), e)
+	}
+
+	return tx.commit(ctx)
 }
 
 // RetryingTx does the same as RawTx but retries failed actions
 // if they might succeed on a subsequent attempt.
-func (c *PoolConn) RetryingTx(ctx context.Context, action TxBlock) error {
-	err := c.transactableConn.RetryingTx(ctx, action)
-	c.checkErr(err)
-	return err
+func (c *transactableConn) RetryingTx(
+	ctx context.Context,
+	action TxBlock,
+) error {
+	conn, err := c.borrow("transaction")
+	if err != nil {
+		return err
+	}
+	defer c.unborrow()
+
+	var edbErr Error
+
+	for i := 1; true; i++ {
+		if e := c.ensureConnection(ctx); e != nil {
+			return e
+		}
+
+		tx := &Tx{
+			borrowableConn: borrowableConn{
+				baseConn: conn,
+			},
+			txState: &txState{},
+			options: c.txOpts,
+		}
+		if e := tx.start(ctx); e != nil {
+			return e
+		}
+
+		err := action(ctx, tx)
+		if err == nil {
+			return tx.commit(ctx)
+		}
+
+		if e := tx.rollback(ctx); e != nil && !errors.As(e, &edbErr) {
+			return e
+		}
+
+		if errors.As(err, &edbErr) && edbErr.HasTag(ShouldRetry) {
+			rule := c.retryOpts.ruleForException(edbErr)
+
+			if i >= rule.attempts {
+				break
+			}
+
+			time.Sleep(rule.backoff(i))
+			continue
+		}
+
+		return err
+	}
+
+	panic("unreachable")
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -115,23 +115,6 @@ func TestTxCommits(t *testing.T) {
 	)
 }
 
-func TestTxCanNotUseConn(t *testing.T) {
-	ctx := context.Background()
-	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
-		var num []int64
-		return conn.Query(ctx, "SELECT 7*9;", &num)
-	})
-
-	var edbErr Error
-	require.True(t, errors.As(err, &edbErr), "wrong error: %v", err)
-	require.True(t, edbErr.Category(InterfaceError), "wrong error: %v", err)
-
-	expected := "edgedb.InterfaceError: " +
-		"Connection is borrowed for a transaction. " +
-		"Use the methods on transaction object instead."
-	require.EqualError(t, err, expected)
-}
-
 func newTxOpts(level IsolationLevel, readOnly, deferrable bool) TxOptions {
 	return NewTxOptions().
 		WithIsolation(level).

--- a/types_test.go
+++ b/types_test.go
@@ -3284,7 +3284,7 @@ type OtherSample struct {
 }
 
 func TestMissingObjectFields(t *testing.T) {
-	if conn.conn.protocolVersion.LT(protocolVersion0p11) {
+	if conn.transactableConn.protocolVersion.LT(protocolVersion0p11) {
 		t.Skip()
 	}
 


### PR DESCRIPTION
Public API changes:
- add `type Subtx struct`
- add `type SubtxBlock func(context.Context, *Subtx) error`
- add a `Subtx(context.Context, action SubtxBlock) error` method to `Tx` and `Subtx` structs
- rename `Action` to `TxBlock`

Internal Changes:
- Separated `type reconnectingConn struct` into `reconnectingConn`, `transactableConn`, and `borrowableConn`
- moved `txOpts` and `retryOpts` fields from `PoolConn` and `Conn` to `transactableConn`
- added helper function for running granular flow queries
- rename `baseConn.conn` to `baseConn.netConn`
- rename `PoolConn.conn` to `PoolConn.transactableConnactor` out `borrowableConn`
