### PR TITLE
remove unused connection attribute

### DIFF
--- a/edgedb.go
+++ b/edgedb.go
@@ -92,8 +92,6 @@ type baseConn struct {
 	inCodecCache  *cache.Cache
 	outCodecCache *cache.Cache
 
-	serverSettings map[string]string
-
 	cfg *connConfig
 }
 

--- a/fallthrough.go
+++ b/fallthrough.go
@@ -36,7 +36,7 @@ func (c *baseConn) fallThrough(r *buff.Reader) error {
 	case message.ParameterStatus:
 		name := r.PopString()
 		value := r.PopString()
-		c.serverSettings[name] = value
+		c.cfg.serverSettings[name] = value
 	case message.LogMessage:
 		severity := logMsgSeverityLookup[r.PopUint8()]
 		code := r.PopUint32()


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb-go/issues/126 which didn't have to do with options.

When running edgedb/edgedb-go against a development server (`edb server`) the server sent a [ParameterStatus message](https://www.edgedb.com/docs/internals/protocol/messages#parameterstatus) that the packaged server builds don't seem to send. The bit of code that is changed in this PR is not usually exercised because the tests don't have a way of triggering server initiated messages.