### PR TITLE
differentiate missing from zero values

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -97,36 +97,42 @@
 // The following list shows the marshal/unmarshal
 // mapping between EdgeDB types and go types:
 //
-//   EdgeDB                Go
-//   ---------             ---------
-//   Set                   []anytype
-//   array<anytype>        []anytype
-//   tuple                 struct
-//   named tuple           struct
-//   Object                struct
-//   bool                  bool
-//   bytes                 []byte
-//   str                   string
-//   anyenum               string
-//   datetime              time.Time
-//   cal::local_datetime   edgedb.LocalDateTime
-//   cal::local_date       edgedb.LocalDate
-//   cal::local_time       edgedb.LocalTime
-//   duration              time.Duration
-//   float32               float32
-//   float64               float64
-//   int16                 int16
-//   int32                 int32
-//   int64                 int64
-//   uuid                  edgedb.UUID
-//   json                  []byte
-//   bigint                *big.Int
+//   EdgeDB                   Go
+//   ---------                ---------
+//   Set                      []anytype
+//   array<anytype>           []anytype
+//   tuple                    struct
+//   named tuple              struct
+//   Object                   struct
+//   bool                     bool, edgedb.OptionalBool
+//   bytes                    []byte, edgedb.OptionalBytes
+//   str                      string, edgedb.OptionalStr
+//   anyenum                  string, edgedb.OptionalStr
+//   datetime                 time.Time, edgedb.OptionalDateTime
+//   cal::local_datetime      edgedb.LocalDateTime,
+//                            edgedb.OptionalLocalDateTime
+//   cal::local_date          edgedb.LocalDate, edgedb.OptionalLocalDate
+//   cal::local_time          edgedb.LocalTime, edgedb.OptionalLocalTime
+//   duration                 time.Duration, edgedb.OptionalDuration
+//   cal::relative_duraation  edgedb.RelativeDuration,
+//                            edgedb.OptionalRelativeDuration
+//   float32                  float32, edgedb.OptionalFloat32
+//   float64                  float64, edgedb.OptionalFloat64
+//   int16                    int16, edgedb.OptionalFloat16
+//   int32                    int32, edgedb.OptionalInt16
+//   int64                    int64, edgedb.OptionalInt64
+//   uuid                     edgedb.UUID, edgedb.OptionalUUID
+//   json                     []byte, edgedb.OptionalBytes
+//   bigint                   *big.Int, edgedb.OptionalBigInt
 //
-//   decimal               user defined (see Custom Codecs)
+//   decimal                  user defined (see Custom Marshalers)
 //
-// Custom Codecs
+// Shape fileds that are not required must use optional types for receiving
+// query results. The edgedb.Optional struct can be embedded to make structs
+// optional.
 //
-// User defined marshaler/unmarshalers can be defined for any scalar EdgeDB
-// type except arrays. The marshaler interfaces are documented in the
-// internal/codecs package.
+// Custom Marshalers
+//
+// Interfaces for user defined marshaler/unmarshalers  are documented in the
+// internal/marshal package.
 package edgedb

--- a/edgedb.go
+++ b/edgedb.go
@@ -29,6 +29,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/edgedb/edgedb-go/internal"
 	"github.com/edgedb/edgedb-go/internal/buff"
 	"github.com/edgedb/edgedb-go/internal/cache"
 	"github.com/edgedb/edgedb-go/internal/soc"
@@ -54,7 +55,7 @@ type baseConn struct {
 	outCodecCache *cache.Cache
 
 	cfg             *connConfig
-	protocolVersion version
+	protocolVersion internal.ProtocolVersion
 
 	// writeMemory is preallocated memory for payloads to be sent to the server
 	writeMemory [1024]byte

--- a/internal/codecs/noop.go
+++ b/internal/codecs/noop.go
@@ -38,3 +38,5 @@ type noOpDecoder struct{}
 func (c noOpDecoder) DescriptorID() types.UUID { return descriptor.IDZero }
 
 func (c noOpDecoder) Decode(r *buff.Reader, out unsafe.Pointer) {}
+
+func (c noOpDecoder) DecodeMissing(out unsafe.Pointer) { panic("unreachable") }

--- a/internal/edgedbtypes/bool.go
+++ b/internal/edgedbtypes/bool.go
@@ -1,0 +1,39 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedbtypes
+
+// OptionalBool is an optional bool. Optional types must be used for out
+// parameters when a shape field is not required.
+type OptionalBool struct {
+	val   bool
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalBool) Get() (bool, bool) { return o.val, o.isSet }
+
+// Set sets the value.
+func (o *OptionalBool) Set(val bool) {
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalBool) Unset() {
+	o.val = false
+	o.isSet = false
+}

--- a/internal/edgedbtypes/bytes.go
+++ b/internal/edgedbtypes/bytes.go
@@ -1,0 +1,45 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedbtypes
+
+// OptionalBytes is an optional []byte. Optional types must be used for out
+// parameters when a shape field is not required.
+type OptionalBytes struct {
+	val   []byte
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalBytes) Get() ([]byte, bool) { return o.val, o.isSet }
+
+// Set sets the value.
+func (o *OptionalBytes) Set(val []byte) {
+	if val == nil {
+		// todo I'm not sure about this behavior...
+		o.Unset()
+		return
+	}
+
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalBytes) Unset() {
+	o.val = nil
+	o.isSet = false
+}

--- a/internal/edgedbtypes/datetime.go
+++ b/internal/edgedbtypes/datetime.go
@@ -36,6 +36,30 @@ const (
 	timeShift = 62135596800
 )
 
+// OptionalDateTime is an optional time.Time.  Optional types must be used for
+// out parameters when a shape field is not required.
+type OptionalDateTime struct {
+	val   time.Time
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalDateTime) Get() (time.Time, bool) {
+	return o.val, o.isSet
+}
+
+// Set sets the value.
+func (o *OptionalDateTime) Set(val time.Time) {
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalDateTime) Unset() {
+	o.val = time.Time{}
+	o.isSet = false
+}
+
 // NewLocalDateTime returns a new LocalDateTime
 func NewLocalDateTime(
 	year int, month time.Month, day, hour, minute, second, microsecond int,
@@ -60,6 +84,30 @@ func (dt LocalDateTime) String() string {
 	return time.Unix(sec, nsec).UTC().Format("2006-01-02T15:04:05.999999")
 }
 
+// OptionalLocalDateTime is an optional LocalDateTime. Optional types must be
+// used for out parameters when a shape field is not required.
+type OptionalLocalDateTime struct {
+	val   LocalDateTime
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalLocalDateTime) Get() (LocalDateTime, bool) {
+	return o.val, o.isSet
+}
+
+// Set sets the value.
+func (o *OptionalLocalDateTime) Set(val LocalDateTime) {
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalLocalDateTime) Unset() {
+	o.val = LocalDateTime{}
+	o.isSet = false
+}
+
 // NewLocalDate returns a new LocalDate
 func NewLocalDate(year int, month time.Month, day int) LocalDate {
 	t := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
@@ -77,6 +125,28 @@ func (d LocalDate) String() string {
 		int64(d.days)*86400-timeShift,
 		0,
 	).UTC().Format("2006-01-02")
+}
+
+// OptionalLocalDate is an optional LocalDate. Optional types must be used for
+// out parameters when a shape field is not required.
+type OptionalLocalDate struct {
+	val   LocalDate
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalLocalDate) Get() (LocalDate, bool) { return o.val, o.isSet }
+
+// Set sets the value.
+func (o *OptionalLocalDate) Set(val LocalDate) {
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalLocalDate) Unset() {
+	o.val = LocalDate{}
+	o.isSet = false
 }
 
 // NewLocalTime returns a new LocalTime
@@ -114,6 +184,28 @@ func (t LocalTime) String() string {
 		t.usec/1_000_000,
 		(t.usec%1_000_000)*1_000,
 	).UTC().Format("15:04:05.999999")
+}
+
+// OptionalLocalTime is an optional LocalTime. Optional types must be used for
+// out parameters when a shape field is not required.
+type OptionalLocalTime struct {
+	val   LocalTime
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalLocalTime) Get() (LocalTime, bool) { return o.val, o.isSet }
+
+// Set sets the value.
+func (o *OptionalLocalTime) Set(val LocalTime) {
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalLocalTime) Unset() {
+	o.val = LocalTime{}
+	o.isSet = false
 }
 
 // Duration represents the elapsed time between two instants
@@ -168,6 +260,28 @@ func (d Duration) String() string {
 	}
 
 	return strings.Join(buf, "")
+}
+
+// OptionalDuration is an optional Duration. Optional types must be used for
+// out parameters when a shape field is not required.
+type OptionalDuration struct {
+	val   Duration
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalDuration) Get() (Duration, bool) { return o.val, o.isSet }
+
+// Set sets the value.
+func (o *OptionalDuration) Set(val Duration) {
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalDuration) Unset() {
+	o.val = 0
+	o.isSet = false
 }
 
 // NewRelativeDuration returns a new RelativeDuration
@@ -257,4 +371,28 @@ func (rd RelativeDuration) String() string {
 	}
 
 	return strings.Join(buf, "")
+}
+
+// OptionalRelativeDuration is an optional RelativeDuration. Optional types
+// must be used for out parameters when a shape field is not required.
+type OptionalRelativeDuration struct {
+	val   RelativeDuration
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalRelativeDuration) Get() (RelativeDuration, bool) {
+	return o.val, o.isSet
+}
+
+// Set sets the value.
+func (o *OptionalRelativeDuration) Set(val RelativeDuration) {
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalRelativeDuration) Unset() {
+	o.val = RelativeDuration{}
+	o.isSet = false
 }

--- a/internal/edgedbtypes/numbers.go
+++ b/internal/edgedbtypes/numbers.go
@@ -1,0 +1,141 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedbtypes
+
+// Optional represents a shape field that is not required.
+type Optional struct {
+	isSet bool
+}
+
+// Missing returns true if the value is missing.
+func (o *Optional) Missing() bool { return !o.isSet }
+
+// SetMissing sets the structs missing status. true means missing and false
+// means present.
+func (o *Optional) SetMissing(missing bool) { o.isSet = !missing }
+
+// OptionalInt16 is an optional int16. Optional types must be used for out
+// parameters when a shape field is not required.
+type OptionalInt16 struct {
+	val   int16
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalInt16) Get() (int16, bool) { return o.val, o.isSet }
+
+// Set sets the value.
+func (o *OptionalInt16) Set(val int16) {
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalInt16) Unset() {
+	o.val = 0
+	o.isSet = false
+}
+
+// OptionalInt32 is an optional int32. Optional types must be used for out
+// parameters when a shape field is not required.
+type OptionalInt32 struct {
+	val   int32
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalInt32) Get() (int32, bool) { return o.val, o.isSet }
+
+// Set sets the value.
+func (o *OptionalInt32) Set(val int32) {
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalInt32) Unset() {
+	o.val = 0
+	o.isSet = false
+}
+
+// OptionalInt64 is an optional int64. Optional types must be used for out
+// parameters when a shape field is not required.
+type OptionalInt64 struct {
+	val   int64
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalInt64) Get() (int64, bool) { return o.val, o.isSet }
+
+// Set sets the value.
+func (o *OptionalInt64) Set(val int64) *OptionalInt64 {
+	o.val = val
+	o.isSet = true
+	return o
+}
+
+// Unset marks the value as missing.
+func (o *OptionalInt64) Unset() *OptionalInt64 {
+	o.val = 0
+	o.isSet = false
+	return o
+}
+
+// OptionalFloat32 is an optional float32. Optional types must be used for out
+// parameters when a shape field is not required.
+type OptionalFloat32 struct {
+	val   float32
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalFloat32) Get() (float32, bool) { return o.val, o.isSet }
+
+// Set sets the value.
+func (o *OptionalFloat32) Set(val float32) {
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalFloat32) Unset() {
+	o.val = 0
+	o.isSet = false
+}
+
+// OptionalFloat64 is an optional float64. Optional types must be used for out
+// parameters when a shape field is not required.
+type OptionalFloat64 struct {
+	val   float64
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalFloat64) Get() (float64, bool) { return o.val, o.isSet }
+
+// Set sets the value.
+func (o *OptionalFloat64) Set(val float64) {
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalFloat64) Unset() {
+	o.val = 0
+	o.isSet = false
+}

--- a/internal/edgedbtypes/numerics.go
+++ b/internal/edgedbtypes/numerics.go
@@ -1,0 +1,46 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedbtypes
+
+import "math/big"
+
+// OptionalBigInt is an optional *big.Int. Optional types must be used for out
+// parameters when a shape field is not required.
+type OptionalBigInt struct {
+	val   *big.Int
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalBigInt) Get() (*big.Int, bool) { return o.val, o.isSet }
+
+// Set sets the value.
+func (o *OptionalBigInt) Set(val *big.Int) {
+	if val == nil {
+		o.Unset()
+		return
+	}
+
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalBigInt) Unset() {
+	o.val = nil
+	o.isSet = false
+}

--- a/internal/edgedbtypes/str.go
+++ b/internal/edgedbtypes/str.go
@@ -1,0 +1,39 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedbtypes
+
+// OptionalStr is an optional string. Optional types must be used for out
+// parameters when a shape field is not required.
+type OptionalStr struct {
+	val   string
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalStr) Get() (string, bool) { return o.val, o.isSet }
+
+// Set sets the value.
+func (o *OptionalStr) Set(val string) {
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalStr) Unset() {
+	o.val = ""
+	o.isSet = false
+}

--- a/internal/edgedbtypes/uuid.go
+++ b/internal/edgedbtypes/uuid.go
@@ -76,3 +76,25 @@ func (id *UUID) UnmarshalText(b []byte) error {
 	*id = tmp
 	return nil
 }
+
+// OptionalUUID is an optional UUID. Optional types must be used for out
+// parameters when a shape field is not required.
+type OptionalUUID struct {
+	val   UUID
+	isSet bool
+}
+
+// Get returns the value and a boolean indicating if the value is present.
+func (o *OptionalUUID) Get() (UUID, bool) { return o.val, o.isSet }
+
+// Set sets the value.
+func (o *OptionalUUID) Set(val UUID) {
+	o.val = val
+	o.isSet = true
+}
+
+// Unset marks the value as missing.
+func (o *OptionalUUID) Unset() {
+	o.val = UUID{}
+	o.isSet = false
+}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,0 +1,56 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+// ProtocolVersion represents an EdgeDB protocol version
+type ProtocolVersion struct {
+	Major uint16
+	Minor uint16
+}
+
+// GT returns true if v > other
+func (v ProtocolVersion) GT(other ProtocolVersion) bool {
+	switch {
+	case v.Major > other.Major:
+		return true
+	case v.Major < other.Major:
+		return false
+	default:
+		return v.Minor > other.Minor
+	}
+}
+
+// GTE returns true if v >= other
+func (v ProtocolVersion) GTE(other ProtocolVersion) bool {
+	if v == other {
+		return true
+	}
+
+	return v.GT(other)
+}
+
+// LT returns true if v < other
+func (v ProtocolVersion) LT(other ProtocolVersion) bool {
+	switch {
+	case v.Major < other.Major:
+		return true
+	case v.Major > other.Major:
+		return false
+	default:
+		return v.Minor < other.Minor
+	}
+}

--- a/internal/introspect/marshal.go
+++ b/internal/introspect/marshal.go
@@ -1,0 +1,92 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package introspect
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func fieldByTag(t reflect.Type, name string) (reflect.StructField, bool) {
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.Tag.Get("edgedb") == name {
+			return field, true
+		}
+	}
+
+	return reflect.StructField{}, false
+}
+
+// StructField finds a field where name matches either the tag or name.
+func StructField(t reflect.Type, name string) (reflect.StructField, bool) {
+	if f, ok := fieldByTag(t, name); ok {
+		return f, true
+	}
+
+	if f, ok := t.FieldByName(name); ok {
+		return f, true
+	}
+
+	return reflect.StructField{}, false
+}
+
+// ValueOf returns the reflect.Value of an out parameter or an error
+// if the out parameter is not valid.
+func ValueOf(i interface{}) (reflect.Value, error) {
+	v := reflect.ValueOf(i)
+	if !v.IsValid() {
+		return reflect.Value{}, fmt.Errorf(
+			"the \"out\" argument must be a pointer, got untyped nil",
+		)
+	}
+
+	if v.Kind() != reflect.Ptr {
+		return reflect.Value{}, fmt.Errorf(
+			"the \"out\" argument must be a pointer, got %v",
+			v.Type(),
+		)
+	}
+
+	e := v.Elem()
+	if !e.IsValid() {
+		return reflect.Value{}, fmt.Errorf(
+			"the \"out\" argument must point to a valid value, got %+v",
+			i,
+		)
+	}
+
+	return e, nil
+}
+
+// ValueOfSlice returns the reflect.Value of an out parameter slice or an error
+// if the out parameter is not valid.
+func ValueOfSlice(i interface{}) (reflect.Value, error) {
+	v, err := ValueOf(i)
+	if err != nil {
+		return v, err
+	}
+
+	if v.Kind() != reflect.Slice {
+		return reflect.Value{}, fmt.Errorf(
+			"the \"out\" argument must be a pointer to a slice, got %+v",
+			reflect.ValueOf(i).Type(),
+		)
+	}
+
+	return v, nil
+}

--- a/internal/introspect/marshal_test.go
+++ b/internal/introspect/marshal_test.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package marshal
+package introspect
 
 import (
 	"errors"

--- a/internal/marshal/marshal.go
+++ b/internal/marshal/marshal.go
@@ -14,79 +14,403 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package marshal documents marshaling interfaces.
+//
+// User defined marshaler/unmarshalers can be defined for any scalar EdgeDB
+// type except arrays. They must implement the interface for their type.
+// For example a custom int64 unmarshaler should implement Int64Unmarshaler.
+//
+// Optional Fields
+//
+// When shape fields in a query result are optional (not required) the client
+// requires the out value's optional fields to implement OptionalUnmarshaler.
+// For scalar types, this means that the field value will need to implement a
+// custom marshaler interface i.e. Int64Unmarshaler AND OptionalUnmarshaler.
+// For shapes, only OptionalUnmarshaler needs to be implemented.
 package marshal
 
-import (
-	"fmt"
-	"reflect"
-)
-
-func fieldByTag(t reflect.Type, name string) (reflect.StructField, bool) {
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
-		if field.Tag.Get("edgedb") == name {
-			return field, true
-		}
-	}
-
-	return reflect.StructField{}, false
+// OptionalUnmarshaler is used for optional (not required) shape field values.
+type OptionalUnmarshaler interface {
+	// SetMissing is call with true when the value is missing and false when
+	// the value is present.
+	SetMissing(bool)
 }
 
-// StructField finds a field where name matches either the tag or name.
-func StructField(t reflect.Type, name string) (reflect.StructField, bool) {
-	if f, ok := fieldByTag(t, name); ok {
-		return f, true
-	}
-
-	if f, ok := t.FieldByName(name); ok {
-		return f, true
-	}
-
-	return reflect.StructField{}, false
+// StrMarshaler is the interface implemented by an object
+// that can marshal itself into the str wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-str
+//
+// MarshalEdgeDBStr encodes the receiver
+// into a binary form and returns the result.
+type StrMarshaler interface {
+	MarshalEdgeDBStr() ([]byte, error)
 }
 
-// ValueOf returns the reflect.Value of an out parameter or an error
-// if the out parameter is not valid.
-func ValueOf(i interface{}) (reflect.Value, error) {
-	v := reflect.ValueOf(i)
-	if !v.IsValid() {
-		return reflect.Value{}, fmt.Errorf(
-			"the \"out\" argument must be a pointer, got untyped nil",
-		)
-	}
-
-	if v.Kind() != reflect.Ptr {
-		return reflect.Value{}, fmt.Errorf(
-			"the \"out\" argument must be a pointer, got %v",
-			v.Type(),
-		)
-	}
-
-	e := v.Elem()
-	if !e.IsValid() {
-		return reflect.Value{}, fmt.Errorf(
-			"the \"out\" argument must point to a valid value, got %+v",
-			i,
-		)
-	}
-
-	return e, nil
+// StrUnmarshaler is the interface implemented by an object
+// that can unmarshal the str wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-str
+//
+// UnmarshalEdgeDBStr must be able to decode the str wire format.
+// UnmarshalEdgeDBStr must copy the data if it wishes to retain the data
+// after returning.
+type StrUnmarshaler interface {
+	UnmarshalEdgeDBStr(data []byte) error
 }
 
-// ValueOfSlice returns the reflect.Value of an out parameter slice or an error
-// if the out parameter is not valid.
-func ValueOfSlice(i interface{}) (reflect.Value, error) {
-	v, err := ValueOf(i)
-	if err != nil {
-		return v, err
-	}
+// BoolMarshaler is the interface implemented by an object
+// that can marshal itself into the bool wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-bool
+//
+// MarshalEdgeDBBool encodes the receiver
+// into a binary form and returns the result.
+type BoolMarshaler interface {
+	MarshalEdgeDBBool() ([]byte, error)
+}
 
-	if v.Kind() != reflect.Slice {
-		return reflect.Value{}, fmt.Errorf(
-			"the \"out\" argument must be a pointer to a slice, got %+v",
-			reflect.ValueOf(i).Type(),
-		)
-	}
+// BoolUnmarshaler is the interface implemented by an object
+// that can unmarshal the bool wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-bool
+//
+// UnmarshalEdgeDBBool must be able to decode the bool wire format.
+// UnmarshalEdgeDBBool must copy the data if it wishes to retain the data
+// after returning.
+type BoolUnmarshaler interface {
+	UnmarshalEdgeDBBool(data []byte) error
+}
 
-	return v, nil
+// JSONMarshaler is the interface implemented by an object
+// that can marshal itself into the json wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-json
+//
+// MarshalEdgeDBJSON encodes the receiver
+// into a binary form and returns the result.
+type JSONMarshaler interface {
+	MarshalEdgeDBJSON() ([]byte, error)
+}
+
+// JSONUnmarshaler is the interface implemented by an object
+// that can unmarshal the json wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-json
+//
+// UnmarshalEdgeDBJSON must be able to decode the json wire format.
+// UnmarshalEdgeDBJSON must copy the data if it wishes to retain the data
+// after returning.
+type JSONUnmarshaler interface {
+	UnmarshalEdgeDBJSON(data []byte) error
+}
+
+// UUIDMarshaler is the interface implemented by an object
+// that can marshal itself into the uuid wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-uuid
+//
+// MarshalEdgeDBUUID encodes the receiver
+// into a binary form and returns the result.
+type UUIDMarshaler interface {
+	MarshalEdgeDBUUID() ([]byte, error)
+}
+
+// UUIDUnmarshaler is the interface implemented by an object
+// that can unmarshal the uuid wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-uuid
+//
+// UnmarshalEdgeDBUUID must be able to decode the uuid wire format.
+// UnmarshalEdgeDBUUID must copy the data if it wishes to retain the data
+// after returning.
+type UUIDUnmarshaler interface {
+	UnmarshalEdgeDBUUID(data []byte) error
+}
+
+// BytesMarshaler is the interface implemented by an object
+// that can marshal itself into the bytes wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-bytes
+//
+// MarshalEdgeDBBytes encodes the receiver
+// into a binary form and returns the result.
+type BytesMarshaler interface {
+	MarshalEdgeDBBytes() ([]byte, error)
+}
+
+// BytesUnmarshaler is the interface implemented by an object
+// that can unmarshal the bytes wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-bytes
+//
+// UnmarshalEdgeDBBytes must be able to decode the bytes wire format.
+// UnmarshalEdgeDBBytes must copy the data if it wishes to retain the data
+// after returning.
+type BytesUnmarshaler interface {
+	UnmarshalEdgeDBBytes(data []byte) error
+}
+
+// BigIntMarshaler is the interface implemented by an object
+// that can marshal itself into the bigint wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-bigint
+//
+// MarshalEdgeDBBigInt encodes the receiver
+// into a binary form and returns the result.
+type BigIntMarshaler interface {
+	MarshalEdgeDBBigInt() ([]byte, error)
+}
+
+// BigIntUnmarshaler is the interface implemented by an object
+// that can unmarshal the bigint wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-bigint
+//
+// UnmarshalEdgeDBBigInt must be able to decode the bigint wire format.
+// UnmarshalEdgeDBBigInt must copy the data if it wishes to retain the data
+// after returning.
+type BigIntUnmarshaler interface {
+	UnmarshalEdgeDBBigInt(data []byte) error
+}
+
+// DecimalMarshaler is the interface implemented by an object
+// that can marshal itself into the decimal wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-decimal
+//
+// MarshalEdgeDBDecimal encodes the receiver
+// into a binary form and returns the result.
+type DecimalMarshaler interface {
+	MarshalEdgeDBDecimal() ([]byte, error)
+}
+
+// DecimalUnmarshaler is the interface implemented by an object
+// that can unmarshal the decimal wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-decimal
+//
+// UnmarshalEdgeDBDecimal must be able to decode the decimal wire format.
+// UnmarshalEdgeDBDecimal must copy the data if it wishes to retain the data
+// after returning.
+type DecimalUnmarshaler interface {
+	UnmarshalEdgeDBDecimal(data []byte) error
+}
+
+// DateTimeMarshaler is the interface implemented by an object
+// that can marshal itself into the datetime wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-datetime
+//
+// MarshalEdgeDBDateTime encodes the receiver
+// into a binary form and returns the result.
+type DateTimeMarshaler interface {
+	MarshalEdgeDBDateTime() ([]byte, error)
+}
+
+// DateTimeUnmarshaler is the interface implemented by an object
+// that can unmarshal the datetime wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-datetime
+//
+// UnmarshalEdgeDBDateTime must be able to decode the datetime wire format.
+// UnmarshalEdgeDBDateTime must copy the data if it wishes to retain the data
+// after returning.
+type DateTimeUnmarshaler interface {
+	UnmarshalEdgeDBDateTime(data []byte) error
+}
+
+// LocalDateTimeMarshaler is the interface implemented by an object
+// that can marshal itself into the local_datetime wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats
+//
+// MarshalEdgeDBLocalDateTime encodes the receiver
+// into a binary form and returns the result.
+type LocalDateTimeMarshaler interface {
+	MarshalEdgeDBLocalDateTime() ([]byte, error)
+}
+
+// LocalDateTimeUnmarshaler is the interface implemented by an object
+// that can unmarshal the local_datetime wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats
+//
+// UnmarshalEdgeDBLocalDateTime must be able to decode the local_datetime wire
+// format. UnmarshalEdgeDBLocalDateTime must copy the data if it wishes to
+// retain the data after returning.
+type LocalDateTimeUnmarshaler interface {
+	UnmarshalEdgeDBLocalDateTime(data []byte) error
+}
+
+// LocalDateMarshaler is the interface implemented by an object
+// that can marshal itself into the local_date wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-local-date
+//
+// MarshalEdgeDBLocalDate encodes the receiver
+// into a binary form and returns the result.
+type LocalDateMarshaler interface {
+	MarshalEdgeDBLocalDate() ([]byte, error)
+}
+
+// LocalDateUnmarshaler is the interface implemented by an object
+// that can unmarshal the local_date wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-local-date
+//
+// UnmarshalEdgeDBLocalDate must be able to decode the local_date wire format.
+// UnmarshalEdgeDBLocalDate must copy the data if it wishes to retain the data
+// after returning.
+type LocalDateUnmarshaler interface {
+	UnmarshalEdgeDBLocalDate(data []byte) error
+}
+
+// LocalTimeMarshaler is the interface implemented by an object
+// that can marshal itself into the local_time wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-local-time
+//
+// MarshalEdgeDBLocalTime encodes the receiver
+// into a binary form and returns the result.
+type LocalTimeMarshaler interface {
+	MarshalEdgeDBLocalTime() ([]byte, error)
+}
+
+// LocalTimeUnmarshaler is the interface implemented by an object
+// that can unmarshal the local_time wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-local-time
+//
+// UnmarshalEdgeDBLocalTime must be able to decode the local_time wire format.
+// UnmarshalEdgeDBLocalTime must copy the data if it wishes to retain the data
+// after returning.
+type LocalTimeUnmarshaler interface {
+	UnmarshalEdgeDBLocalTime(data []byte) error
+}
+
+// DurationMarshaler is the interface implemented by an object
+// that can marshal itself into the duration wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-duration
+//
+// MarshalEdgeDBDuration encodes the receiver
+// into a binary form and returns the result.
+type DurationMarshaler interface {
+	MarshalEdgeDBDuration() ([]byte, error)
+}
+
+// DurationUnmarshaler is the interface implemented by an object
+// that can unmarshal the duration wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-duration
+//
+// UnmarshalEdgeDBDuration must be able to decode the duration wire format.
+// UnmarshalEdgeDBDuration must copy the data if it wishes to retain the data
+// after returning.
+type DurationUnmarshaler interface {
+	UnmarshalEdgeDBDuration(data []byte) error
+}
+
+// RelativeDurationMarshaler is the interface implemented by an object that can
+// marshal itself into the cal::relative_duration wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats
+//
+// MarshalEdgeDBRelativeDuration encodes the receiver into a binary form and
+// returns the result.
+type RelativeDurationMarshaler interface {
+	MarshalEdgeDBRelativeDuration() ([]byte, error)
+}
+
+// RelativeDurationUnmarshaler is the interface implemented by an object that
+// can unmarshal the cal::relative_duration wire format representation of
+// itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-duration
+//
+// UnmarshalEdgeDBRelativeDuration must be able to decode the
+// cal::relative_duration wire format.  UnmarshalEdgeDBRelativeDuration must
+// copy the data if it wishes to retain the data after returning.
+type RelativeDurationUnmarshaler interface {
+	UnmarshalEdgeDBRelativeDuration(data []byte) error
+}
+
+// Int16Marshaler is the interface implemented by an object
+// that can marshal itself into the int16 wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-int16
+//
+// MarshalEdgeDBInt16 encodes the receiver
+// into a binary form and returns the result.
+type Int16Marshaler interface {
+	MarshalEdgeDBInt16() ([]byte, error)
+}
+
+// Int16Unmarshaler is the interface implemented by an object
+// that can unmarshal the int16 wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-int16
+//
+// UnmarshalEdgeDBInt16 must be able to decode the int16 wire format.
+// UnmarshalEdgeDBInt16 must copy the data if it wishes to retain the data
+// after returning.
+type Int16Unmarshaler interface {
+	UnmarshalEdgeDBInt16(data []byte) error
+}
+
+// Int32Marshaler is the interface implemented by an object
+// that can marshal itself into the int32 wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-int32
+//
+// MarshalEdgeDBInt32 encodes the receiver
+// into a binary form and returns the result.
+type Int32Marshaler interface {
+	MarshalEdgeDBInt32() ([]byte, error)
+}
+
+// Int32Unmarshaler is the interface implemented by an object
+// that can unmarshal the int32 wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-int32
+//
+// UnmarshalEdgeDBInt32 must be able to decode the int32 wire format.
+// UnmarshalEdgeDBInt32 must copy the data if it wishes to retain the data
+// after returning.
+type Int32Unmarshaler interface {
+	UnmarshalEdgeDBInt32(data []byte) error
+}
+
+// Int64Marshaler is the interface implemented by an object
+// that can marshal itself into the int64 wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-int64
+//
+// MarshalEdgeDBInt64 encodes the receiver
+// into a binary form and returns the result.
+type Int64Marshaler interface {
+	MarshalEdgeDBInt64() ([]byte, error)
+}
+
+// Int64Unmarshaler is the interface implemented by an object
+// that can unmarshal the int64 wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-int64
+//
+// UnmarshalEdgeDBInt64 must be able to decode the int64 wire format.
+// UnmarshalEdgeDBInt64 must copy the data if it wishes to retain the data
+// after returning.
+type Int64Unmarshaler interface {
+	UnmarshalEdgeDBInt64(data []byte) error
+}
+
+// Float32Marshaler is the interface implemented by an object
+// that can marshal itself into the float32 wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-float32
+//
+// MarshalEdgeDBFloat32 encodes the receiver
+// into a binary form and returns the result.
+type Float32Marshaler interface {
+	MarshalEdgeDBFloat32() ([]byte, error)
+}
+
+// Float32Unmarshaler is the interface implemented by an object
+// that can unmarshal the float32 wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-float32
+//
+// UnmarshalEdgeDBFloat32 must be able to decode the float32 wire format.
+// UnmarshalEdgeDBFloat32 must copy the data if it wishes to retain the data
+// after returning.
+type Float32Unmarshaler interface {
+	UnmarshalEdgeDBFloat32(data []byte) error
+}
+
+// Float64Marshaler is the interface implemented by an object
+// that can marshal itself into the float64 wire format.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-float64
+//
+// MarshalEdgeDBFloat64 encodes the receiver
+// into a binary form and returns the result.
+type Float64Marshaler interface {
+	MarshalEdgeDBFloat64() ([]byte, error)
+}
+
+// Float64Unmarshaler is the interface implemented by an object
+// that can unmarshal the float64 wire format representation of itself.
+// https://www.edgedb.com/docs/internals/protocol/dataformats#std-float64
+//
+// UnmarshalEdgeDBFloat64 must be able to decode the float64 wire format.
+// UnmarshalEdgeDBFloat64 must copy the data if it wishes to retain the data
+// after returning.
+type Float64Unmarshaler interface {
+	UnmarshalEdgeDBFloat64(data []byte) error
 }

--- a/options.go
+++ b/options.go
@@ -31,27 +31,6 @@ func NewOptionalBool(v bool) OptionalBool {
 	return o
 }
 
-// OptionalBool is an optional bool.
-type OptionalBool struct {
-	val   bool
-	isSet bool
-}
-
-// Get returns the value and a boolean indicating if the value is present.
-func (o *OptionalBool) Get() (bool, bool) { return o.val, o.isSet }
-
-// Set sets the value.
-func (o *OptionalBool) Set(val bool) {
-	o.val = val
-	o.isSet = true
-}
-
-// Unset marks the value as missing.
-func (o *OptionalBool) Unset() {
-	o.val = false
-	o.isSet = false
-}
-
 // Options for connecting to an EdgeDB server
 type Options struct {
 	// Hosts is a slice of database host addresses as one of the following

--- a/query.go
+++ b/query.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/edgedb/edgedb-go/internal/cardinality"
 	"github.com/edgedb/edgedb-go/internal/format"
-	"github.com/edgedb/edgedb-go/internal/marshal"
+	"github.com/edgedb/edgedb-go/internal/introspect"
 )
 
 // sfQuery is a script flow query
@@ -62,9 +62,9 @@ func newQuery(
 	var err error
 
 	if fmt == format.JSON || expCard == cardinality.AtMostOne {
-		q.out, err = marshal.ValueOf(out)
+		q.out, err = introspect.ValueOf(out)
 	} else {
-		q.out, err = marshal.ValueOfSlice(out)
+		q.out, err = introspect.ValueOfSlice(out)
 		if err == nil {
 			q.out.SetLen(0)
 		}

--- a/query_test.go
+++ b/query_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestObjectWithoutID(t *testing.T) {
-	if conn.conn.protocolVersion.lt(version{0, 10}) {
+	if conn.conn.protocolVersion.LT(protocolVersion0p10) {
 		t.Skip("not expected to pass on protocol versions below 0.10")
 	}
 
@@ -110,9 +110,9 @@ func TestMissmatchedResultType(t *testing.T) {
 	ctx := context.Background()
 	err := conn.QuerySingle(ctx, "SELECT (x := (y := (z := 7)))", &result)
 
-	expected := "edgedb.UnsupportedFeatureError: " +
+	expected := "edgedb.InvalidArgumentError: " +
 		"the \"out\" argument does not match query schema: " +
-		"expected edgedb.A.x.y.z to be int64 got int"
+		"expected edgedb.A.x.y.z to be int64 or edgedb.OptionalInt64 got int"
 	assert.EqualError(t, err, expected)
 }
 
@@ -156,7 +156,8 @@ func TestArgumentTypeMissmatch(t *testing.T) {
 
 	require.NotNil(t, err)
 	assert.EqualError(t, err,
-		"edgedb.InvalidArgumentError: expected args[0] to be int16 got int")
+		"edgedb.InvalidArgumentError: expected args[0] to be int16, "+
+			"edgedb.OptionalInt16 or Int16Marshaler got int")
 }
 
 func TestNamedQueryArguments(t *testing.T) {

--- a/tutorial_test.go
+++ b/tutorial_test.go
@@ -33,11 +33,11 @@ type Person struct {
 }
 
 type Movie struct {
-	ID       UUID     `edgedb:"id"`
-	Title    string   `edgedb:"title"`
-	Year     int64    `edgedb:"year"`
-	Director Person   `edgedb:"director"`
-	Actors   []Person `edgedb:"actors"`
+	ID       UUID          `edgedb:"id"`
+	Title    string        `edgedb:"title"`
+	Year     OptionalInt64 `edgedb:"year"`
+	Director Person        `edgedb:"director"`
+	Actors   []Person      `edgedb:"actors"`
 }
 
 func TestTutorial(t *testing.T) {
@@ -59,8 +59,6 @@ func TestTutorial(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-
-	defer edb.Close() // nolint:errcheck
 
 	err = edb.Execute(ctx, `
 		START MIGRATION TO {
@@ -161,7 +159,6 @@ func TestTutorial(t *testing.T) {
 	expected := []Movie{
 		{
 			Title: "Blade Runner 2049",
-			Year:  int64(2017),
 			Director: Person{
 				FirstName: "Denis",
 				LastName:  "Villeneuve",
@@ -187,9 +184,11 @@ func TestTutorial(t *testing.T) {
 				FirstName: "Denis",
 				LastName:  "Villeneuve",
 			},
-			Actors: []Person(nil),
+			Actors: []Person{},
 		},
 	}
+	expected[0].Year.Set(2017)
 
 	assert.Equal(t, expected, out)
+	assert.Nil(t, edb.Close())
 }

--- a/types.go
+++ b/types.go
@@ -38,6 +38,57 @@ type (
 
 	// RelativeDuration represents a fuzzy/human span of time.
 	RelativeDuration = edgedbtypes.RelativeDuration
+
+	// Optional ...
+	Optional = edgedbtypes.Optional
+
+	// OptionalBool is a bool value that is not required.
+	OptionalBool = edgedbtypes.OptionalBool
+
+	// OptionalBytes is a []byte value that is not required.
+	OptionalBytes = edgedbtypes.OptionalBytes
+
+	// OptionalStr is a string that is not required.
+	OptionalStr = edgedbtypes.OptionalStr
+
+	// OptionalInt16 is an int16 that is not required.
+	OptionalInt16 = edgedbtypes.OptionalInt16
+
+	// OptionalInt32 is an int32 that is not required.
+	OptionalInt32 = edgedbtypes.OptionalInt32
+
+	// OptionalInt64 is an int64 that is not required.
+	OptionalInt64 = edgedbtypes.OptionalInt64
+
+	// OptionalFloat32  is a float32 that is not required.
+	OptionalFloat32 = edgedbtypes.OptionalFloat32
+
+	// OptionalFloat64 is a float64 that is not required.
+	OptionalFloat64 = edgedbtypes.OptionalFloat64
+
+	// OptionalBigInt is a big.Int that is not required.
+	OptionalBigInt = edgedbtypes.OptionalBigInt
+
+	// OptionalUUID is a UUID that is not required.
+	OptionalUUID = edgedbtypes.OptionalUUID
+
+	// OptionalDateTime is a time.Time that is not required.
+	OptionalDateTime = edgedbtypes.OptionalDateTime
+
+	// OptionalLocalDateTime is a LocalDateTime that is not required.
+	OptionalLocalDateTime = edgedbtypes.OptionalLocalDateTime
+
+	// OptionalLocalTime is a LocalTime that is not required.
+	OptionalLocalTime = edgedbtypes.OptionalLocalTime
+
+	// OptionalLocalDate is a LocalDate that is not required.
+	OptionalLocalDate = edgedbtypes.OptionalLocalDate
+
+	// OptionalDuration is a Duration that is not required.
+	OptionalDuration = edgedbtypes.OptionalDuration
+
+	// OptionalRelativeDuration is a RelativeDuration that is not required.
+	OptionalRelativeDuration = edgedbtypes.OptionalRelativeDuration
 )
 
 var (

--- a/types_test.go
+++ b/types_test.go
@@ -19,6 +19,7 @@ package edgedb
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -156,6 +157,58 @@ func TestSendAndReceiveInt64Marshaler(t *testing.T) {
 	)
 }
 
+func TestSendAndReceiveOptionalInt64(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE Int64FieldHolder {
+				CREATE PROPERTY int64 -> int64;
+			};
+
+			INSERT Int64FieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			Int64 OptionalInt64 `edgedb:"int64"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT Int64FieldHolder { int64 } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.Int64.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalInt64{}
+		arg.Set(64)
+		e = tx.QueryOne(ctx, `
+			SELECT Int64FieldHolder { int64 := <int64>$0 } LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.Int64.Set(64)
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
+}
+
 func TestSendAndReceiveInt32(t *testing.T) {
 	ctx := context.Background()
 
@@ -257,6 +310,58 @@ func TestSendAndReceiveInt32Marshaler(t *testing.T) {
 		},
 		result,
 	)
+}
+
+func TestSendAndReceiveOptionalInt32(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE Int32FieldHolder {
+				CREATE PROPERTY int32 -> int32;
+			};
+
+			INSERT Int32FieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			Int32 OptionalInt32 `edgedb:"int32"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT Int32FieldHolder { int32 } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.Int32.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalInt32{}
+		arg.Set(32)
+		e = tx.QueryOne(ctx, `
+			SELECT Int32FieldHolder { int32 := <int32>$0 } LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.Int32.Set(32)
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
 }
 
 func TestSendAndReceiveInt16(t *testing.T) {
@@ -362,6 +467,58 @@ func TestSendAndReceiveInt16Marshaler(t *testing.T) {
 	)
 }
 
+func TestSendAndReceiveOptionalInt16(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE Int16FieldHolder {
+				CREATE PROPERTY int16 -> int16;
+			};
+
+			INSERT Int16FieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			Int16 OptionalInt16 `edgedb:"int16"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT Int16FieldHolder { int16 } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.Int16.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalInt16{}
+		arg.Set(16)
+		e = tx.QueryOne(ctx, `
+			SELECT Int16FieldHolder { int16 := <int16>$0 } LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.Int16.Set(16)
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
+}
+
 func TestSendAndReceiveBool(t *testing.T) {
 	ctx := context.Background()
 
@@ -444,6 +601,58 @@ func TestSendAndReceiveBoolMarshaler(t *testing.T) {
 		},
 		result,
 	)
+}
+
+func TestSendAndReceiveOptionalBool(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE BoolFieldHolder {
+				CREATE PROPERTY bool -> bool;
+			};
+
+			INSERT BoolFieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			Bool OptionalBool `edgedb:"bool"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT BoolFieldHolder { bool } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.Bool.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalBool{}
+		arg.Set(true)
+		e = tx.QueryOne(ctx, `
+			SELECT BoolFieldHolder { bool := <bool>$0 } LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.Bool.Set(true)
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
 }
 
 func TestSendAndReceiveFloat64(t *testing.T) {
@@ -554,6 +763,58 @@ func TestSendAndReceiveFloat64Marshaler(t *testing.T) {
 	)
 }
 
+func TestSendAndReceiveOptionalFloat64(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE Float64FieldHolder {
+				CREATE PROPERTY float64 -> float64;
+			};
+
+			INSERT Float64FieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			Float64 OptionalFloat64 `edgedb:"float64"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT Float64FieldHolder { float64 } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.Float64.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalFloat64{}
+		arg.Set(64)
+		e = tx.QueryOne(ctx, `
+			SELECT Float64FieldHolder { float64 := <float64>$0 } LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.Float64.Set(64)
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
+}
+
 func TestSendAndReceiveFloat32(t *testing.T) {
 	ctx := context.Background()
 
@@ -662,6 +923,58 @@ func TestSendAndReceiveFloat32Marshaler(t *testing.T) {
 	)
 }
 
+func TestSendAndReceiveOptionalFloat32(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE Float32FieldHolder {
+				CREATE PROPERTY float32 -> float32;
+			};
+
+			INSERT Float32FieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			Float32 OptionalFloat32 `edgedb:"float32"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT Float32FieldHolder { float32 } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.Float32.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalFloat32{}
+		arg.Set(32)
+		e = tx.QueryOne(ctx, `
+			SELECT Float32FieldHolder { float32 := <float32>$0 } LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.Float32.Set(32)
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
+}
+
 func TestSendAndReceiveBytes(t *testing.T) {
 	ctx := context.Background()
 
@@ -736,6 +1049,58 @@ func TestSendAndReceiveBytesMarshaler(t *testing.T) {
 	)
 }
 
+func TestSendAndReceiveOptionalBytes(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE BytesFieldHolder {
+				CREATE PROPERTY bytes -> bytes;
+			};
+
+			INSERT BytesFieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			Bytes OptionalBytes `edgedb:"bytes"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT BytesFieldHolder { bytes } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.Bytes.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalBytes{}
+		arg.Set([]byte("hello"))
+		e = tx.QueryOne(ctx, `
+			SELECT BytesFieldHolder { bytes := <bytes>$0 } LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.Bytes.Set([]byte("hello"))
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
+}
+
 func TestSendAndReceiveStr(t *testing.T) {
 	ctx := context.Background()
 
@@ -798,6 +1163,58 @@ func TestSendAndReceiveStrMarshaler(t *testing.T) {
 		},
 		result,
 	)
+}
+
+func TestSendAndReceiveOptionalStr(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE StrFieldHolder {
+				CREATE PROPERTY string -> str;
+			};
+
+			INSERT StrFieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			String OptionalStr `edgedb:"string"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT StrFieldHolder { string } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.String.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalStr{}
+		arg.Set("hello")
+		e = tx.QueryOne(ctx, `
+			SELECT StrFieldHolder { string := <str>$0 } LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.String.Set("hello")
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
 }
 
 func TestSendAndReceiveJSON(t *testing.T) {
@@ -864,6 +1281,58 @@ func TestSendAndReceiveJSONMarshaler(t *testing.T) {
 		},
 		result,
 	)
+}
+
+func TestSendAndReceiveOptionalJSON(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE JSONFieldHolder {
+				CREATE PROPERTY json -> json;
+			};
+
+			INSERT JSONFieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			JSON OptionalBytes `edgedb:"json"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT JSONFieldHolder { json } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.JSON.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalBytes{}
+		arg.Set([]byte(`"hello"`))
+		e = tx.QueryOne(ctx, `
+			SELECT JSONFieldHolder { json := <json>$0 } LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.JSON.Set([]byte(`"hello"`))
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
 }
 
 func TestSendAndReceiveEnum(t *testing.T) {
@@ -1059,6 +1528,61 @@ func TestSendAndReceiveDurationMarshaler(t *testing.T) {
 	)
 }
 
+func TestSendAndReceiveOptionalDuration(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE DurationFieldHolder {
+				CREATE PROPERTY duration -> duration;
+			};
+
+			INSERT DurationFieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			Duration OptionalDuration `edgedb:"duration"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT DurationFieldHolder { duration } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.Duration.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalDuration{}
+		arg.Set(123)
+		e = tx.QueryOne(ctx, `
+			SELECT DurationFieldHolder {
+				duration := <duration>$0
+			}
+			LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.Duration.Set(123)
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
+}
+
 func TestSendAndReceiveRelativeDuration(t *testing.T) {
 	ctx := context.Background()
 
@@ -1171,6 +1695,67 @@ func TestSendAndReceiveRelativeDurationMarshaler(t *testing.T) {
 		},
 		result,
 	)
+}
+
+func TestSendAndReceiveOptionalRelativeDuration(t *testing.T) {
+	ctx := context.Background()
+
+	var duration RelativeDuration
+	err := conn.QueryOne(ctx, "SELECT <cal::relative_duration>'1y'", &duration)
+	if err != nil {
+		t.Skip("server version is too old for this feature")
+	}
+
+	err = conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE RelativeDurationFieldHolder {
+				CREATE PROPERTY duration -> cal::relative_duration;
+			};
+
+			INSERT RelativeDurationFieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			RelativeDuration OptionalRelativeDuration `edgedb:"duration"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT RelativeDurationFieldHolder { duration } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.RelativeDuration.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalRelativeDuration{}
+		arg.Set(NewRelativeDuration(1, 2, 3))
+		e = tx.QueryOne(ctx, `
+			SELECT RelativeDurationFieldHolder {
+				duration := <cal::relative_duration>$0
+			}
+			LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.RelativeDuration.Set(NewRelativeDuration(1, 2, 3))
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
 }
 
 func TestSendAndReceiveLocalTime(t *testing.T) {
@@ -1296,6 +1881,61 @@ func TestSendAndReceiveLocalTimeMarshaler(t *testing.T) {
 	)
 }
 
+func TestSendAndReceiveOptionalLocalTime(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE LocalTimeFieldHolder {
+				CREATE PROPERTY local_time -> cal::local_time;
+			};
+
+			INSERT LocalTimeFieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			LocalTime OptionalLocalTime `edgedb:"local_time"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT LocalTimeFieldHolder { local_time } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.LocalTime.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalLocalTime{}
+		arg.Set(NewLocalTime(11, 53, 27, 4))
+		e = tx.QueryOne(ctx, `
+			SELECT LocalTimeFieldHolder {
+				local_time := <cal::local_time>$0
+			}
+			LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.LocalTime.Set(NewLocalTime(11, 53, 27, 4))
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
+}
+
 func TestSendAndReceiveLocalDate(t *testing.T) {
 	ctx := context.Background()
 
@@ -1408,6 +2048,61 @@ func TestSendAndReceiveLocalDateMarshaler(t *testing.T) {
 		},
 		result,
 	)
+}
+
+func TestSendAndReceiveOptionalLocalDate(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE LocalDateFieldHolder {
+				CREATE PROPERTY local_date -> cal::local_date;
+			};
+
+			INSERT LocalDateFieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			LocalDate OptionalLocalDate `edgedb:"local_date"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT LocalDateFieldHolder { local_date } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.LocalDate.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalLocalDate{}
+		arg.Set(NewLocalDate(2020, 1, 1))
+		e = tx.QueryOne(ctx, `
+			SELECT LocalDateFieldHolder {
+				local_date := <cal::local_date>$0
+			}
+			LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.LocalDate.Set(NewLocalDate(2020, 1, 1))
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
 }
 
 func TestSendAndReceiveLocalDateTime(t *testing.T) {
@@ -1531,6 +2226,61 @@ func TestSendAndReceiveLocalDateTimeMarshaler(t *testing.T) {
 	)
 }
 
+func TestSendAndReceiveOptionalLocalDateTime(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE LocalDateTimeFieldHolder {
+				CREATE PROPERTY local_datetime -> cal::local_datetime;
+			};
+
+			INSERT LocalDateTimeFieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			LocalDateTime OptionalLocalDateTime `edgedb:"local_datetime"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT LocalDateTimeFieldHolder { local_datetime } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.LocalDateTime.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalLocalDateTime{}
+		arg.Set(NewLocalDateTime(2020, 1, 1, 0, 0, 0, 0))
+		e = tx.QueryOne(ctx, `
+			SELECT LocalDateTimeFieldHolder {
+				local_datetime := <cal::local_datetime>$0
+			}
+			LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.LocalDateTime.Set(NewLocalDateTime(2020, 1, 1, 0, 0, 0, 0))
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
+}
+
 func TestSendAndReceiveDateTime(t *testing.T) {
 	ctx := context.Background()
 	format := "2006-01-02T15:04:05.999999-07:00"
@@ -1651,6 +2401,61 @@ func TestSendAndReceiveDateTimeMarshaler(t *testing.T) {
 		},
 		result,
 	)
+}
+
+func TestSendAndReceiveOptionalDateTime(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE DateTimeFieldHolder {
+				CREATE PROPERTY datetime -> datetime;
+			};
+
+			INSERT DateTimeFieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			DateTime OptionalDateTime `edgedb:"datetime"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT DateTimeFieldHolder { datetime } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.DateTime.Unset()
+		assert.Equal(t, expected, result)
+
+		val := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		arg := OptionalDateTime{}
+		arg.Set(val)
+		e = tx.QueryOne(ctx, `
+			SELECT DateTimeFieldHolder { datetime := <datetime>$0 } LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		actual, ok := result.DateTime.Get()
+		assert.True(t, ok)
+		assert.True(t, val.Equal(actual),
+			"%v != %v", val.String(), actual.String())
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
 }
 
 func TestSendAndReceiveBigInt(t *testing.T) {
@@ -1862,6 +2667,58 @@ func TestSendAndReceiveBigIntMarshaler(t *testing.T) {
 	)
 }
 
+func TestSendAndReceiveOptionalBigInt(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE BigIntFieldHolder {
+				CREATE PROPERTY bigint -> bigint;
+			};
+
+			INSERT BigIntFieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			BigInt OptionalBigInt `edgedb:"bigint"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT BigIntFieldHolder { bigint } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.BigInt.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalBigInt{}
+		arg.Set(big.NewInt(123))
+		e = tx.QueryOne(ctx, `
+			SELECT BigIntFieldHolder { bigint := <bigint>$0 } LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.BigInt.Set(big.NewInt(123))
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
+}
+
 type CustomDecimal struct {
 	data []byte
 }
@@ -2008,6 +2865,58 @@ func TestSendAndReceiveUUIDMarshaler(t *testing.T) {
 		},
 		result,
 	)
+}
+
+func TestSendAndReceiveOptionalUUID(t *testing.T) {
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE UUIDFieldHolder {
+				CREATE PROPERTY uuid -> uuid;
+			};
+
+			INSERT UUIDFieldHolder;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Result struct {
+			UUID OptionalUUID `edgedb:"uuid"`
+		}
+
+		var result Result
+		e = tx.QueryOne(ctx, `
+			SELECT UUIDFieldHolder { uuid } LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Result{}
+		expected.UUID.Unset()
+		assert.Equal(t, expected, result)
+
+		arg := OptionalUUID{}
+		arg.Set(UUID{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1})
+		e = tx.QueryOne(ctx, `
+			SELECT UUIDFieldHolder { uuid := <uuid>$0 } LIMIT 1`,
+			&result,
+			arg,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected.UUID.Set(UUID{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1})
+		assert.Equal(t, expected, result)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
 }
 
 func TestSendAndReceiveCustomScalars(t *testing.T) {
@@ -2186,7 +3095,7 @@ func TestReceiveTuple(t *testing.T) {
 
 	var wrongType string
 	err := conn.QuerySingle(ctx, `SELECT ()`, &wrongType)
-	require.EqualError(t, err, "edgedb.UnsupportedFeatureError: "+
+	require.EqualError(t, err, "edgedb.InvalidArgumentError: "+
 		"the \"out\" argument does not match query schema: "+
 		"expected string to be a struct got string")
 
@@ -2196,7 +3105,7 @@ func TestReceiveTuple(t *testing.T) {
 
 	var missingTag struct{ first int64 }
 	err = conn.QuerySingle(ctx, `SELECT (<int64>$0,)`, &missingTag, int64(1))
-	require.EqualError(t, err, "edgedb.UnsupportedFeatureError: "+
+	require.EqualError(t, err, "edgedb.InvalidArgumentError: "+
 		"the \"out\" argument does not match query schema: "+
 		"expected struct { first int64 } to have a field "+
 		"with the tag `edgedb:\"0\"`")
@@ -2266,7 +3175,7 @@ func TestSendAndReceiveArray(t *testing.T) {
 	err = conn.QuerySingle(ctx,
 		"SELECT <array<int64>>$0", &result, []int64(nil))
 	require.NoError(t, err)
-	assert.Equal(t, []int64(nil), result)
+	assert.Equal(t, []int64{}, result)
 
 	err = conn.QuerySingle(ctx, "SELECT <array<int64>>$0", &result, []int64{1})
 	require.NoError(t, err)
@@ -2337,4 +3246,180 @@ func TestReceiveSet(t *testing.T) {
 			result.Sets,
 		)
 	}
+}
+
+type CustomOptionalInt16 struct {
+	value int64
+	isSet bool
+}
+
+func (i *CustomOptionalInt16) UnmarshalEdgeDBInt64(data []byte) error {
+	i.value = int64(binary.BigEndian.Uint64(data[:8]))
+	return nil
+}
+
+func (i *CustomOptionalInt16) SetMissing(missing bool) {
+	i.isSet = !missing
+}
+
+type OptionalTuple struct {
+	Zero int64 `edgedb:"0"`
+	One  int64 `edgedb:"1"`
+	Optional
+}
+
+type OptionalNamedTuple struct {
+	A     int64 `edgedb:"a"`
+	B     int64 `edgedb:"b"`
+	isSet bool
+}
+
+func (t *OptionalNamedTuple) SetMissing(missing bool) {
+	t.isSet = !missing
+}
+
+type OtherSample struct {
+	SimpleScalar CustomOptionalInt16 `edgedb:"simple_scalar"`
+	Optional
+}
+
+func TestMissingObjectFields(t *testing.T) {
+	if conn.conn.protocolVersion.LT(protocolVersion0p11) {
+		t.Skip()
+	}
+
+	ctx := context.Background()
+
+	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
+		e := tx.Execute(ctx, `
+			CREATE TYPE Sample {
+				CREATE PROPERTY simple_scalar -> int64;
+				CREATE PROPERTY array -> array<int64>;
+				CREATE PROPERTY tuple -> tuple<int64, int64>;
+				CREATE PROPERTY named_tuple -> tuple<a: int64, b: int64>;
+				CREATE LINK object -> Sample;
+				CREATE MULTI LINK set_ -> Sample;
+			};
+
+			# all fields are missing
+			INSERT Sample;
+		`)
+		if e != nil {
+			return e
+		}
+
+		type Sample struct {
+			SimpleScalar CustomOptionalInt16 `edgedb:"simple_scalar"`
+			Array        []int64             `edgedb:"array"`
+			Tuple        OptionalTuple       `edgedb:"tuple"`
+			NamedTuple   OptionalNamedTuple  `edgedb:"named_tuple"`
+			Object       OtherSample         `edgedb:"object"`
+			Set          []Sample            `edgedb:"set_"`
+		}
+
+		var result Sample
+		e = tx.QueryOne(ctx, `
+			SELECT Sample {
+				simple_scalar,
+				array,
+				tuple,
+				named_tuple,
+				object: { simple_scalar },
+				set_: { simple_scalar },
+			}
+			LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected := Sample{
+			SimpleScalar: CustomOptionalInt16{},
+			Array:        nil,
+			Tuple:        OptionalTuple{},
+			NamedTuple:   OptionalNamedTuple{},
+			Object:       OtherSample{},
+			Set:          []Sample{},
+		}
+		assert.Equal(t, expected, result)
+
+		e = tx.QueryOne(ctx, `
+			WITH
+				object := (INSERT Sample { simple_scalar := 2 }),
+				set_ := (INSERT Sample { simple_scalar := 3 }),
+				inserted := (INSERT Sample {
+					simple_scalar := 1,
+					array := [1],
+					tuple := (1, 2),
+					named_tuple := (a := 1, b := 2),
+					object := object,
+					set_ := set_,
+				})
+			SELECT inserted {
+				simple_scalar,
+				array,
+				tuple,
+				named_tuple,
+				object: { simple_scalar },
+				set_: { simple_scalar },
+			}
+			LIMIT 1`,
+			&result,
+		)
+		if e != nil {
+			return e
+		}
+
+		expected = Sample{
+			SimpleScalar: CustomOptionalInt16{
+				value: 1,
+				isSet: true,
+			},
+			Array: []int64{1},
+			Tuple: OptionalTuple{
+				Zero: int64(1),
+				One:  int64(2),
+			},
+			NamedTuple: OptionalNamedTuple{
+				A:     int64(1),
+				B:     int64(2),
+				isSet: true,
+			},
+			Object: OtherSample{
+				SimpleScalar: CustomOptionalInt16{
+					value: 2,
+					isSet: true,
+				},
+			},
+			Set: []Sample{{
+				SimpleScalar: CustomOptionalInt16{
+					value: 3,
+					isSet: true,
+				},
+			}},
+		}
+		expected.Tuple.SetMissing(false)
+		expected.Object.SetMissing(false)
+
+		assert.Equal(t, expected, result)
+
+		type WrongType struct {
+			SimpleScalar int64 `edgedb:"simple_scalar"`
+		}
+
+		var result2 WrongType
+		e = tx.QueryOne(ctx, `
+			SELECT Sample { simple_scalar } LIMIT 1`,
+			&result2,
+		)
+		assert.EqualError(t, e, "edgedb.InvalidArgumentError: "+
+			`the "out" argument does not match query schema: `+
+			`expected int64 at edgedb.WrongType.simple_scalar to implement `+
+			`OptionalUnmarshaler because the field is not required`)
+
+		return errors.New("rollback")
+	})
+
+	assert.EqualError(t, err, "rollback")
 }


### PR DESCRIPTION
Differentiate between a missing value and a zero value in query results. This change adds:

- Optional scalar types
- Arrays don't have an optional type instead nil is used to represents a missing array and an empty slice represents an empty array.
- An Optional struct that can be embeded in user defined structs to make them optional.
- an OptionalUnmarshaler interface for custom unmarshalers.

fixes #135