### PR TITLE
update nil error assertions

### DIFF
--- a/connect_test.go
+++ b/connect_test.go
@@ -36,13 +36,13 @@ func TestAuth(t *testing.T) {
 		TLSCAFile:         opts.TLSCAFile,
 		TLSVerifyHostname: opts.TLSVerifyHostname,
 	})
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	var result string
 	err = conn.QueryOne(ctx, "SELECT 'It worked!';", &result)
 	cancel()
 
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t, "It worked!", result)
 }

--- a/connutils_test.go
+++ b/connutils_test.go
@@ -421,7 +421,7 @@ func TestConUtils(t *testing.T) {
 				require.True(t, errors.As(err, &c.expected.err))
 				assert.Nil(t, config)
 			} else {
-				require.Nil(t, err, "encountered an err")
+				require.NoError(t, err)
 				// tlsConfigs cannot be compared reliably
 				config.tlsConfig = nil
 				assert.Equal(t, c.expected.cfg, *config)

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestCredentialsRead(t *testing.T) {
 	creds, err := readCredentials("credentials1.json")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	expected := &credentials{
 		database: "test3n",

--- a/internal/buff/write_test.go
+++ b/internal/buff/write_test.go
@@ -234,7 +234,7 @@ func TestOnlySendsWhatWasPushed(t *testing.T) {
 	w.PushString("hello")
 
 	f := &writerFixture{}
-	assert.Nil(t, w.Send(f))
+	assert.NoError(t, w.Send(f))
 
 	expected := []byte{0, 0, 0, 5, 0x68, 0x65, 0x6c, 0x6c, 0x6f}
 	assert.Equal(t, expected, f.written)
@@ -247,7 +247,7 @@ func TestSendsAllChuncks(t *testing.T) {
 	w.PushUint32(3)
 
 	f := &writerFixture{}
-	assert.Nil(t, w.Send(f))
+	assert.NoError(t, w.Send(f))
 
 	expected := []uint8{
 		0x0, 0x0, 0x0, 0x1,

--- a/internal/edgedbtypes/uuid_test.go
+++ b/internal/edgedbtypes/uuid_test.go
@@ -33,7 +33,7 @@ func TestUUIDString(t *testing.T) {
 
 func TestUUIDParse(t *testing.T) {
 	parsed, err := ParseUUID("00010203-0405-0607-0809-0a0b0c0d0e0f")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	expected := UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	require.Equal(t, expected, parsed)
 
@@ -48,7 +48,7 @@ func TestUUIDParse(t *testing.T) {
 	for _, id := range samples {
 		t.Run(id.String(), func(t *testing.T) {
 			parsed, err := ParseUUID(id.String())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, id, parsed)
 		})
 	}
@@ -57,7 +57,7 @@ func TestUUIDParse(t *testing.T) {
 func TestUUIDMarshalJSON(t *testing.T) {
 	uuid := UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	bts, err := json.Marshal(uuid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	expected := `"00010203-0405-0607-0809-0a0b0c0d0e0f"`
 	assert.Equal(t, expected, string(bts))
@@ -67,7 +67,7 @@ func TestUUIDUnmarshalJSON(t *testing.T) {
 	str := `"00010203-0405-0607-0809-0a0b0c0d0e0f"`
 	var uuid UUID
 	err := json.Unmarshal([]byte(str), &uuid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	expected := UUID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	assert.Equal(t, expected, uuid)

--- a/internal/marshal/marshal_test.go
+++ b/internal/marshal/marshal_test.go
@@ -72,7 +72,7 @@ func TestValueOfPointerToNil(t *testing.T) {
 func TestValueOfPointer(t *testing.T) {
 	var thing string
 	val, err := ValueOf(&thing)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	val.SetString("hello")
 	assert.Equal(t, "hello", thing)
 }
@@ -98,7 +98,7 @@ func TestValueOfSliceNonSlice(t *testing.T) {
 func TestValueOfSlice(t *testing.T) {
 	var thing []byte
 	val, err := ValueOfSlice(&thing)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	val.SetBytes([]byte{1, 2, 3})
 	assert.Equal(t, []byte{1, 2, 3}, thing)
 }

--- a/poolconn_test.go
+++ b/poolconn_test.go
@@ -31,7 +31,7 @@ func TestReleasePoolConn(t *testing.T) {
 	pConn := &PoolConn{pool: p, conn: conn}
 
 	err := pConn.Release()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	result := <-p.freeConns
 	assert.Equal(t, conn, result)
@@ -51,11 +51,11 @@ func TestReleasePoolConn(t *testing.T) {
 func TestPoolConnectionRejectsTransaction(t *testing.T) {
 	ctx := context.Background()
 	p, err := Connect(ctx, opts)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer p.Close() // nolint:errcheck
 
 	con, err := p.Acquire(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer con.Release() // nolint:errcheck
 
 	expected := "edgedb.DisabledCapabilityError: " +

--- a/query_test.go
+++ b/query_test.go
@@ -46,7 +46,7 @@ func TestObjectWithoutID(t *testing.T) {
 		LIMIT 1`,
 		&result,
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "edgedb", result.Name)
 }
 
@@ -137,7 +137,7 @@ SELECT 1 / $0
 
 	// cache query so that it is run optimistically next time
 	err = conn.QueryOne(ctx, "SELECT 1 / <int64>$0", &number, int64(3))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// cause error during optimistic execute
 	err = conn.QueryOne(ctx, "SELECT 1 / <int64>$0", &number, int64(0))
@@ -171,7 +171,7 @@ func TestNamedQueryArguments(t *testing.T) {
 		},
 	)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, [][]int64{{5, 8}}, result)
 }
 
@@ -186,7 +186,7 @@ func TestNumberedQueryArguments(t *testing.T) {
 		int64(8),
 	)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, [][]int64{{5, 8}}, result)
 }
 
@@ -205,7 +205,7 @@ func TestQueryJSON(t *testing.T) {
 	// when this test fails
 	actual := string(result)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(
 		t,
 		"[{\"a\" : 0, \"b\" : 1}, {\"a\" : 42, \"b\" : 2}]",
@@ -227,7 +227,7 @@ func TestQueryOneJSON(t *testing.T) {
 	// when this test fails
 	actual := string(result)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "{\"a\" : 0, \"b\" : 42}", actual)
 }
 
@@ -245,7 +245,7 @@ func TestQueryOne(t *testing.T) {
 	var result int64
 	err := conn.QueryOne(ctx, "SELECT 42", &result)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, int64(42), result)
 }
 
@@ -289,7 +289,7 @@ func TestQueryTimesOut(t *testing.T) {
 	require.Equal(t, int64(0), r)
 
 	err = conn.QueryOne(context.Background(), "SELECT 2;", &r)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(2), r)
 }
 

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -25,10 +25,10 @@ import (
 func TestRecconnectingConnBorrow(t *testing.T) {
 	b := reconnectingConn{}
 	err := b.assertUnborrowed()
-	require.Nil(t, err, "unexpected err: %v", err)
+	require.NoError(t, err)
 
 	err = b.borrow("transaction")
-	require.Nil(t, err, "unexpected err: %v", err)
+	require.NoError(t, err)
 
 	err = b.borrow("something else")
 	expected := "edgedb.InterfaceError: " +
@@ -43,5 +43,5 @@ func TestRecconnectingConnBorrow(t *testing.T) {
 
 	b.unborrow()
 	err = b.assertUnborrowed()
-	require.Nil(t, err, err)
+	require.NoError(t, err)
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -56,7 +56,7 @@ func TestTxRollesBack(t *testing.T) {
 	var testNames []string
 	err = conn.Query(ctx, query, &testNames)
 
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, 0, len(testNames), "The transaction wasn't rolled back")
 }
 
@@ -84,7 +84,7 @@ func TestTxRollesBackOnUserError(t *testing.T) {
 	var testNames []string
 	err = conn.Query(ctx, query, &testNames)
 
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, 0, len(testNames), "The transaction wasn't rolled back")
 }
 
@@ -93,7 +93,7 @@ func TestTxCommits(t *testing.T) {
 	err := conn.RawTx(ctx, func(ctx context.Context, tx *Tx) error {
 		return tx.Execute(ctx, "INSERT TxTest {name := 'Test Commit'};")
 	})
-	require.Nil(t, err, err)
+	require.NoError(t, err)
 
 	query := `
 		SELECT (
@@ -106,7 +106,7 @@ func TestTxCommits(t *testing.T) {
 	var testNames []string
 	err = conn.Query(ctx, query, &testNames)
 
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(
 		t,
 		[]string{"Test Commit"},
@@ -178,8 +178,8 @@ func TestTxKinds(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			c := conn.WithTxOptions(opts)
-			require.Nil(t, c.RawTx(ctx, noOp))
-			require.Nil(t, c.RetryingTx(ctx, noOp))
+			require.NoError(t, c.RawTx(ctx, noOp))
+			require.NoError(t, c.RetryingTx(ctx, noOp))
 		})
 	}
 }

--- a/tutorial_test.go
+++ b/tutorial_test.go
@@ -44,7 +44,7 @@ func TestTutorial(t *testing.T) {
 	ctx := context.Background()
 	dbName := fmt.Sprintf("test%v", rand.Intn(10_000))
 	err := conn.Execute(ctx, "CREATE DATABASE "+dbName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	edb, err := ConnectOne(
 		ctx,
@@ -58,7 +58,7 @@ func TestTutorial(t *testing.T) {
 			TLSVerifyHostname: opts.TLSVerifyHostname,
 		},
 	)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	defer edb.Close() // nolint:errcheck
 
@@ -83,7 +83,7 @@ func TestTutorial(t *testing.T) {
 
 		COMMIT MIGRATION;
 	`)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = edb.Execute(ctx, `
 		INSERT Movie {
@@ -111,7 +111,7 @@ func TestTutorial(t *testing.T) {
 			}
 		}`,
 	)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = edb.Execute(ctx, `
 		INSERT Movie {
@@ -128,7 +128,7 @@ func TestTutorial(t *testing.T) {
 				)
 		};`,
 	)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var out []Movie
 	err = edb.Query(ctx, `
@@ -146,7 +146,7 @@ func TestTutorial(t *testing.T) {
 		}`,
 		&out,
 	)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// clobber IDs with zero value since they are not deterministic
 	zeroID := make([]byte, 16)

--- a/types_test.go
+++ b/types_test.go
@@ -97,7 +97,7 @@ func TestSendAndReceiveInt64(t *testing.T) {
 
 	var results []Result
 	err := conn.Query(ctx, query, &results, numbers, strings)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, len(numbers), len(results), "unexpected result count")
 
 	for i, s := range strings {
@@ -146,7 +146,7 @@ func TestSendAndReceiveInt64Marshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: 123_456_789_987_654_321,
@@ -200,7 +200,7 @@ func TestSendAndReceiveInt32(t *testing.T) {
 
 	var results []Result
 	err := conn.Query(ctx, query, &results, numbers, strings)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, len(numbers), len(results), "wrong number of results")
 
 	for i, s := range strings {
@@ -249,7 +249,7 @@ func TestSendAndReceiveInt32Marshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: 655_665,
@@ -303,7 +303,7 @@ func TestSendAndReceiveInt16(t *testing.T) {
 
 	var results []Result
 	err := conn.Query(ctx, query, &results, numbers, strings)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, len(numbers), len(results), "wrong number of results")
 
 	for i, s := range strings {
@@ -352,7 +352,7 @@ func TestSendAndReceiveInt16Marshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: 6556,
@@ -393,7 +393,7 @@ func TestSendAndReceiveBool(t *testing.T) {
 		t.Run(s, func(t *testing.T) {
 			var result Result
 			err := conn.QueryOne(ctx, query, &result, i, s)
-			assert.Nil(t, err, "unexpected error: %v", err)
+			assert.NoError(t, err)
 
 			assert.True(t, result.IsEqual, "equality check faild")
 			assert.Equal(t, s, result.Encoded, "encoding failed")
@@ -436,7 +436,7 @@ func TestSendAndReceiveBoolMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: true,
@@ -493,7 +493,7 @@ func TestSendAndReceiveFloat64(t *testing.T) {
 
 	var results []Result
 	err := conn.Query(ctx, query, &results, numbers, strings)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, len(numbers), len(results), "wrong number of results")
 
 	for i, s := range strings {
@@ -502,7 +502,7 @@ func TestSendAndReceiveFloat64(t *testing.T) {
 			r := results[i]
 
 			encoded, err := strconv.ParseFloat(r.Encoded, 64)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			assert.True(t, r.IsEqual, "equality check faild")
 			assert.Equal(t, n, encoded, "encoding failed")
@@ -544,7 +544,7 @@ func TestSendAndReceiveFloat64Marshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: -15.625,
@@ -601,7 +601,7 @@ func TestSendAndReceiveFloat32(t *testing.T) {
 
 	var results []Result
 	err := conn.Query(ctx, query, &results, numbers, strings)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, len(numbers), len(results), "wrong number of results")
 
 	for i, s := range strings {
@@ -610,7 +610,7 @@ func TestSendAndReceiveFloat32(t *testing.T) {
 			r := results[i]
 
 			encoded, err := strconv.ParseFloat(r.Encoded, 32)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			assert.True(t, r.IsEqual, "equality check faild")
 			assert.Equal(t, n, float32(encoded), "encoding failed")
@@ -652,7 +652,7 @@ func TestSendAndReceiveFloat32Marshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: -15.625,
@@ -684,7 +684,7 @@ func TestSendAndReceiveBytes(t *testing.T) {
 
 	var results [][]byte
 	err := conn.Query(ctx, query, &results, samples)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, len(samples), len(results), "wrong number of results")
 
 	for i, b := range samples {
@@ -726,7 +726,7 @@ func TestSendAndReceiveBytesMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: data,
@@ -741,7 +741,7 @@ func TestSendAndReceiveStr(t *testing.T) {
 
 	var result string
 	err := conn.QueryOne(ctx, `SELECT <str>$0`, &result, "abcdef")
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t, "abcdef", result, "round trip failed")
 }
 
@@ -751,7 +751,7 @@ func TestFetchLargeStr(t *testing.T) {
 
 	var result string
 	err := conn.QueryOne(ctx, "SELECT str_repeat('a', <int64>(10^6))", &result)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t, strings.Repeat("a", 1_000_000), result)
 }
 
@@ -789,7 +789,7 @@ func TestSendAndReceiveStrMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: "Hello! 🙂",
@@ -813,7 +813,7 @@ func TestSendAndReceiveJSON(t *testing.T) {
 
 	var results [][]byte
 	err := conn.Query(ctx, query, &results, samples)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, len(samples), len(results), "wrong number of results")
 
 	for i, s := range strings {
@@ -855,7 +855,7 @@ func TestSendAndReceiveJSONMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: `{"hello": "world"}`,
@@ -892,7 +892,7 @@ func TestSendAndReceiveEnum(t *testing.T) {
 	var result Result
 	color := "Red"
 	err := conn.QueryOne(ctx, query, &result, color, color)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 
 	assert.Equal(t, color, result.Encoded, "encoding failed")
 	assert.Equal(t, color, result.Decoded, "decoding failed")
@@ -939,7 +939,7 @@ func TestSendAndReceiveEnumMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: "Red",
@@ -998,7 +998,7 @@ func TestSendAndReceiveDuration(t *testing.T) {
 
 	var results []Result
 	err := conn.Query(ctx, query, &results, durations, strings)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, len(durations), len(results), "wrong number of results")
 
 	for i, s := range strings {
@@ -1048,7 +1048,7 @@ func TestSendAndReceiveDurationMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: Duration(0x28dd117280),
@@ -1102,7 +1102,7 @@ func TestSendAndReceiveRelativeDuration(t *testing.T) {
 
 	var results []Result
 	err = conn.Query(ctx, query, &results, rds)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, len(rds), len(results), "wrong number of results")
 
 	for i, rd := range rds {
@@ -1160,7 +1160,7 @@ func TestSendAndReceiveRelativeDurationMarshaler(t *testing.T) {
 
 	var result Result
 	err = conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: NewRelativeDuration(8, 5, 0x28dd117280),
@@ -1235,7 +1235,7 @@ func TestSendAndReceiveLocalTime(t *testing.T) {
 
 	var results []Result
 	err := conn.Query(ctx, query, &results, times, strings)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 
 	for i, s := range strings {
 		t.Run(s, func(t *testing.T) {
@@ -1283,7 +1283,7 @@ func TestSendAndReceiveLocalTimeMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: "12:10:00",
@@ -1348,7 +1348,7 @@ func TestSendAndReceiveLocalDate(t *testing.T) {
 
 	var results []Result
 	err := conn.Query(ctx, query, &results, dates, strings)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, len(dates), len(results))
 
 	for i, s := range strings {
@@ -1397,7 +1397,7 @@ func TestSendAndReceiveLocalDateMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: "2019-05-06",
@@ -1469,7 +1469,7 @@ func TestSendAndReceiveLocalDateTime(t *testing.T) {
 
 	var results []Result
 	err := conn.Query(ctx, query, &results, datetimes, strings)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, len(datetimes), len(results), "wrong number of results")
 
 	for i, s := range strings {
@@ -1518,7 +1518,7 @@ func TestSendAndReceiveLocalDateTimeMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: "2019-05-06T12:00:00",
@@ -1585,7 +1585,7 @@ func TestSendAndReceiveDateTime(t *testing.T) {
 
 	var results []Result
 	err := conn.Query(ctx, query, &results, samples, strings)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t, len(samples), len(results), "wrong number of results")
 
 	for i, s := range strings {
@@ -1640,7 +1640,7 @@ func TestSendAndReceiveDateTimeMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: "2019-05-06T12:00:00+00:00",
@@ -1799,7 +1799,7 @@ func TestSendAndReceiveBigInt(t *testing.T) {
 
 			var result Result
 			err := conn.QueryOne(ctx, query, &result, i, s)
-			assert.Nil(t, err, "unexpected error: %v", err)
+			assert.NoError(t, err)
 
 			assert.True(t, result.IsEqual, "equality check faild")
 			assert.Equal(t, s, result.Encoded, "encoding failed")
@@ -1849,7 +1849,7 @@ func TestSendAndReceiveBigIntMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: `-15000`,
@@ -1898,7 +1898,7 @@ func TestSendAndReceiveDecimalMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 
 	expected := CustomDecimal{make([]byte, len(data))}
 	copy(expected.data, data)
@@ -1946,11 +1946,11 @@ func TestSendAndReceiveUUID(t *testing.T) {
 		t.Run(s, func(t *testing.T) {
 			var id UUID
 			err := id.UnmarshalText([]byte(s))
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			var result Result
 			err = conn.QueryOne(ctx, query, &result, id, s)
-			assert.Nil(t, err, "unexpected error: %v", err)
+			assert.NoError(t, err)
 
 			assert.True(t, result.IsEqual, "equality check faild")
 			assert.Equal(t, s, result.Encoded, "encoding failed")
@@ -1997,7 +1997,7 @@ func TestSendAndReceiveUUIDMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: "b9545c35-1fe7-485f-a6ea-f8ead251abd3",
@@ -2041,7 +2041,7 @@ func TestSendAndReceiveCustomScalars(t *testing.T) {
 			var result Result
 			err := conn.QueryOne(ctx, query, &result, i, s)
 
-			assert.Nil(t, err, "unexpected error: %v", err)
+			assert.NoError(t, err)
 			assert.Equal(t, s, result.Encoded)
 			assert.Equal(t, i, result.Decoded)
 			assert.Equal(t, i, result.Decoded)
@@ -2082,7 +2082,7 @@ func TestSendAndReceiveCustomScalarMarshaler(t *testing.T) {
 
 	var result Result
 	err := conn.QueryOne(ctx, query, &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
 			Encoded: 123_456_789_987_654_321,
@@ -2113,7 +2113,7 @@ func TestDecodeDeeplyNestedTuple(t *testing.T) {
 
 	var result ParentTuple
 	err := conn.QueryOne(ctx, query, &result)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 
 	expected := ParentTuple{
 		first: []Tuple{
@@ -2158,7 +2158,7 @@ func TestReceiveObject(t *testing.T) {
 
 	var result Function
 	err := conn.QueryOne(ctx, query, &result)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t, "std::str_repeat", result.Name)
 	assert.Equal(t, 2, len(result.Params))
 	assert.Equal(t, "PositionalParam", result.Params[0].Kind)
@@ -2174,7 +2174,7 @@ func TestReceiveNamedTuple(t *testing.T) {
 
 	var result NamedTuple
 	err := conn.QueryOne(ctx, "SELECT (a := 1,)", &result)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t, NamedTuple{A: 1}, result)
 }
 
@@ -2189,7 +2189,7 @@ func TestReceiveTuple(t *testing.T) {
 
 	var emptyStruct struct{}
 	err = conn.QueryOne(ctx, `SELECT ()`, &emptyStruct)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 
 	var missingTag struct{ first int64 }
 	err = conn.QueryOne(ctx, `SELECT (<int64>$0,)`, &missingTag, int64(1))
@@ -2211,12 +2211,12 @@ func TestReceiveTuple(t *testing.T) {
 
 	result := []Tuple{}
 	err = conn.Query(ctx, `SELECT (<int64>$0,)`, &result, int64(1))
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t, []Tuple{{first: 1}}, result)
 
 	result = []Tuple{}
 	err = conn.Query(ctx, `SELECT {(1, "abc"), (2, "def")}`, &result)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t,
 		[]Tuple{
 			{first: 1, second: "abc"},
@@ -2227,7 +2227,7 @@ func TestReceiveTuple(t *testing.T) {
 
 	result = []Tuple{}
 	err = conn.Query(ctx, `SELECT (1, "abc", (2.3, true))`, &result)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	require.Equal(t,
 		[]Tuple{{
 			1,
@@ -2256,20 +2256,20 @@ func TestSendAndReceiveArray(t *testing.T) {
 
 	var nested Tuple
 	err = conn.QueryOne(ctx, "SELECT (<array<int64>>$0,)", &nested, []int64{1})
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t, Tuple{[]int64{1}}, nested)
 
 	err = conn.QueryOne(ctx, "SELECT <array<int64>>$0", &result, []int64(nil))
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t, []int64(nil), result)
 
 	err = conn.QueryOne(ctx, "SELECT <array<int64>>$0", &result, []int64{1})
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t, []int64{1}, result)
 
 	arg := []int64{1, 2, 3}
 	err = conn.QueryOne(ctx, "SELECT <array<int64>>$0", &result, arg)
-	require.Nil(t, err, "unexpected error: %v", err)
+	require.NoError(t, err)
 	assert.Equal(t, []int64{1, 2, 3}, result)
 }
 
@@ -2293,7 +2293,7 @@ func TestReceiveSet(t *testing.T) {
 
 		var result Function
 		err := conn.QueryOne(ctx, query, &result)
-		require.Nil(t, err, "unexpected error: %v", err)
+		require.NoError(t, err)
 		assert.Equal(t, [][]int64{{1, 2}, {1}}, result.Sets)
 	}
 
@@ -2323,7 +2323,7 @@ func TestReceiveSet(t *testing.T) {
 
 		var result Function
 		err := conn.QueryOne(ctx, query, &result)
-		require.Nil(t, err, "unexpected error: %v", err)
+		require.NoError(t, err)
 		assert.Equal(t,
 			[][]Tuple{
 				{{1, NestedTuple{2}}},


### PR DESCRIPTION
The old `assert.Nil()` assertion doesn't reliably show the error message
when an error does happen. `assert.NoError()` shows a more helpful
message in these scenarios.