### PR TITLE
Change default host to 127.0.0.1

### DIFF
--- a/connutils.go
+++ b/connutils.go
@@ -458,7 +458,7 @@ func parseConnectDSNAndArgs(
 		if !usingCredentials {
 			hosts = append(hosts, defaultHosts...)
 		}
-		hosts = append(hosts, "localhost")
+		hosts = append(hosts, "127.0.0.1")
 	}
 
 	if len(ports) == 0 {


### PR DESCRIPTION
It seems like `edgedb instance create` generates a TLS certificate for
127.0.0.1 and not localhost. The clients should assume 127.0.0.1 so that
they can connect using the credentials file which doesn't include a host
name.