### PR TITLE
Add QuerySingle() and deprecate QueryOne()

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ func main() {
 	defer pool.Close()
 
 	var result string
-	err = pool.QueryOne(ctx, "SELECT 'hello EdgeDB!'", &result)
+	err = pool.QuerySingle(ctx, "SELECT 'hello EdgeDB!'", &result)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/connect_test.go
+++ b/connect_test.go
@@ -40,7 +40,7 @@ func TestAuth(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	var result string
-	err = conn.QueryOne(ctx, "SELECT 'It worked!';", &result)
+	err = conn.QuerySingle(ctx, "SELECT 'It worked!';", &result)
 	cancel()
 
 	require.NoError(t, err)

--- a/doc_test.go
+++ b/doc_test.go
@@ -57,7 +57,7 @@ func Example() {
 
 	// Insert a new user.
 	var inserted struct{ id edgedb.UUID }
-	err = db.QueryOne(ctx, `
+	err = db.QuerySingle(ctx, `
 		INSERT User {
 			name := <str>$0,
 			dob := <datetime>$1

--- a/error_test.go
+++ b/error_test.go
@@ -63,7 +63,7 @@ query:3:5
 		t.Run(s.query, func(t *testing.T) {
 			var result int64
 			ctx := context.Background()
-			err := conn.QueryOne(ctx, s.query, &result)
+			err := conn.QuerySingle(ctx, s.query, &result)
 			assert.EqualError(t, err, s.err)
 		})
 	}

--- a/granularflow.go
+++ b/granularflow.go
@@ -207,7 +207,7 @@ func (c *baseConn) describe(r *buff.Reader, q *gfQuery) (descPair, error) {
 				descs.out = descriptor.Pop(r.PopSlice(r.PopUint32()))
 			}
 
-			if q.expCard == cardinality.Single && card == cardinality.Many {
+			if q.expCard == cardinality.AtMostOne && card == cardinality.Many {
 				err = &resultCardinalityMismatchError{msg: fmt.Sprintf(
 					"the query has cardinality %v "+
 						"which does not match the expected cardinality %v",
@@ -255,7 +255,7 @@ func (c *baseConn) execute(r *buff.Reader, q *gfQuery, cdcs codecPair) error {
 
 	tmp := q.out
 	err := error(nil)
-	if q.expCard == cardinality.Single {
+	if q.expCard == cardinality.AtMostOne {
 		err = errZeroResults
 	}
 	done := buff.NewSignal()
@@ -352,7 +352,7 @@ func (c *baseConn) optimistic(
 
 	tmp := q.out
 	err := error(nil)
-	if q.expCard == cardinality.Single {
+	if q.expCard == cardinality.AtMostOne {
 		err = errZeroResults
 	}
 	done := buff.NewSignal()

--- a/granularflow.go
+++ b/granularflow.go
@@ -207,7 +207,7 @@ func (c *baseConn) describe(r *buff.Reader, q *gfQuery) (descPair, error) {
 				descs.out = descriptor.Pop(r.PopSlice(r.PopUint32()))
 			}
 
-			if q.expCard == cardinality.One && card == cardinality.Many {
+			if q.expCard == cardinality.Single && card == cardinality.Many {
 				err = &resultCardinalityMismatchError{msg: fmt.Sprintf(
 					"the query has cardinality %v "+
 						"which does not match the expected cardinality %v",
@@ -255,7 +255,7 @@ func (c *baseConn) execute(r *buff.Reader, q *gfQuery, cdcs codecPair) error {
 
 	tmp := q.out
 	err := error(nil)
-	if q.expCard == cardinality.One {
+	if q.expCard == cardinality.Single {
 		err = errZeroResults
 	}
 	done := buff.NewSignal()
@@ -352,7 +352,7 @@ func (c *baseConn) optimistic(
 
 	tmp := q.out
 	err := error(nil)
-	if q.expCard == cardinality.One {
+	if q.expCard == cardinality.Single {
 		err = errZeroResults
 	}
 	done := buff.NewSignal()

--- a/internal/cardinality/cardinality.go
+++ b/internal/cardinality/cardinality.go
@@ -18,14 +18,14 @@ package cardinality
 
 // Cardinalities
 const (
-	NoResult = 0x6e
-	Single   = 0x6f
-	Many     = 0x6d
+	NoResult  = 0x6e
+	AtMostOne = 0x6f
+	Many      = 0x6d
 )
 
 // ToStr maps cardinality values to their string representation.
 var ToStr = map[uint8]string{
-	NoResult: "NO_RESULT",
-	Single:   "SINGLE",
-	Many:     "MANY",
+	NoResult:  "NO_RESULT",
+	AtMostOne: "AT_MOST_ONE",
+	Many:      "MANY",
 }

--- a/internal/cardinality/cardinality.go
+++ b/internal/cardinality/cardinality.go
@@ -19,13 +19,13 @@ package cardinality
 // Cardinalities
 const (
 	NoResult = 0x6e
-	One      = 0x6f
+	Single   = 0x6f
 	Many     = 0x6d
 )
 
 // ToStr maps cardinality values to their string representation.
 var ToStr = map[uint8]string{
 	NoResult: "NO_RESULT",
-	One:      "ONE",
+	Single:   "SINGLE",
 	Many:     "MANY",
 }

--- a/pool.go
+++ b/pool.go
@@ -335,7 +335,14 @@ func (p *Pool) QuerySingle(
 	}
 
 	hdrs := msgHeaders{header.AllowCapabilities: noTxCapabilities}
-	q, err := newQuery(cmd, format.Binary, cardinality.Single, args, hdrs, out)
+	q, err := newQuery(
+		cmd,
+		format.Binary,
+		cardinality.AtMostOne,
+		args,
+		hdrs,
+		out,
+	)
 	if err != nil {
 		return err
 	}
@@ -395,7 +402,14 @@ func (p *Pool) QuerySingleJSON(
 	}
 
 	hdrs := msgHeaders{header.AllowCapabilities: noTxCapabilities}
-	q, err := newQuery(cmd, format.JSON, cardinality.Single, args, hdrs, out)
+	q, err := newQuery(
+		cmd,
+		format.JSON,
+		cardinality.AtMostOne,
+		args,
+		hdrs,
+		out,
+	)
 	if err != nil {
 		return err
 	}

--- a/pool.go
+++ b/pool.go
@@ -309,7 +309,21 @@ func (p *Pool) Query(
 // QueryOne runs a singleton-returning query and returns its element.
 // If the query executes successfully but doesn't return a result
 // a NoDataError is returned.
+//
+// Deprecated: use QuerySingle()
 func (p *Pool) QueryOne(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
+	return p.QuerySingle(ctx, cmd, out, args...)
+}
+
+// QuerySingle runs a singleton-returning query and returns its element.
+// If the query executes successfully but doesn't return a result
+// a NoDataError is returned.
+func (p *Pool) QuerySingle(
 	ctx context.Context,
 	cmd string,
 	out interface{},
@@ -321,7 +335,7 @@ func (p *Pool) QueryOne(
 	}
 
 	hdrs := msgHeaders{header.AllowCapabilities: noTxCapabilities}
-	q, err := newQuery(cmd, format.Binary, cardinality.One, args, hdrs, out)
+	q, err := newQuery(cmd, format.Binary, cardinality.Single, args, hdrs, out)
 	if err != nil {
 		return err
 	}
@@ -355,7 +369,21 @@ func (p *Pool) QueryJSON(
 // QueryOneJSON runs a singleton-returning query.
 // If the query executes successfully but doesn't have a result
 // a NoDataError is returned.
+//
+// Deprecated: use QuerySingleJSON()
 func (p *Pool) QueryOneJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
+	return p.QuerySingleJSON(ctx, cmd, out, args...)
+}
+
+// QuerySingleJSON runs a singleton-returning query.
+// If the query executes successfully but doesn't have a result
+// a NoDataError is returned.
+func (p *Pool) QuerySingleJSON(
 	ctx context.Context,
 	cmd string,
 	out *[]byte,
@@ -367,7 +395,7 @@ func (p *Pool) QueryOneJSON(
 	}
 
 	hdrs := msgHeaders{header.AllowCapabilities: noTxCapabilities}
-	q, err := newQuery(cmd, format.JSON, cardinality.One, args, hdrs, out)
+	q, err := newQuery(cmd, format.JSON, cardinality.Single, args, hdrs, out)
 	if err != nil {
 		return err
 	}

--- a/pool_test.go
+++ b/pool_test.go
@@ -33,7 +33,7 @@ func TestConnectPool(t *testing.T) {
 	require.NoError(t, err)
 
 	var result string
-	err = p.QueryOne(ctx, "SELECT 'hello';", &result)
+	err = p.QuerySingle(ctx, "SELECT 'hello';", &result)
 	assert.NoError(t, err)
 	assert.Equal(t, "hello", result)
 
@@ -65,10 +65,10 @@ func TestPoolRejectsTransaction(t *testing.T) {
 	err = p.QueryJSON(ctx, "START TRANSACTION", &result)
 	assert.EqualError(t, err, expected)
 
-	err = p.QueryOne(ctx, "START TRANSACTION", &result)
+	err = p.QuerySingle(ctx, "START TRANSACTION", &result)
 	assert.EqualError(t, err, expected)
 
-	err = p.QueryOneJSON(ctx, "START TRANSACTION", &result)
+	err = p.QuerySingleJSON(ctx, "START TRANSACTION", &result)
 	assert.EqualError(t, err, expected)
 
 	err = p.Close()
@@ -88,7 +88,7 @@ func TestConnectPoolZeroMinAndMaxConns(t *testing.T) {
 	require.Equal(t, defaultMaxConns, p.maxConns)
 
 	var result string
-	err = p.QueryOne(ctx, "SELECT 'hello';", &result)
+	err = p.QuerySingle(ctx, "SELECT 'hello';", &result)
 	assert.NoError(t, err)
 	assert.Equal(t, "hello", result)
 
@@ -248,7 +248,7 @@ func TestPoolRetryingTx(t *testing.T) {
 
 	var result int64
 	err = p.RetryingTx(ctx, func(ctx context.Context, tx *Tx) error {
-		return tx.QueryOne(ctx, "SELECT 33*21", &result)
+		return tx.QuerySingle(ctx, "SELECT 33*21", &result)
 	})
 
 	require.NoError(t, err)

--- a/poolconn.go
+++ b/poolconn.go
@@ -90,13 +90,27 @@ func (c *PoolConn) Query(
 // QueryOne runs a singleton-returning query and returns its element.
 // If the query executes successfully but doesn't return a result
 // a NoDataError is returned.
+//
+// Deprecated: use QuerySingle()
 func (c *PoolConn) QueryOne(
 	ctx context.Context,
 	cmd string,
 	out interface{},
 	args ...interface{},
 ) error {
-	err := c.conn.QueryOne(ctx, cmd, out, args...)
+	return c.QuerySingle(ctx, cmd, out, args...)
+}
+
+// QuerySingle runs a singleton-returning query and returns its element.
+// If the query executes successfully but doesn't return a result
+// a NoDataError is returned.
+func (c *PoolConn) QuerySingle(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
+	err := c.conn.QuerySingle(ctx, cmd, out, args...)
 	c.checkErr(err)
 	return err
 }
@@ -116,13 +130,27 @@ func (c *PoolConn) QueryJSON(
 // QueryOneJSON runs a singleton-returning query.
 // If the query executes successfully but doesn't have a result
 // a NoDataError is returned.
+//
+// Deprecated: use QuerySingleJSON()
 func (c *PoolConn) QueryOneJSON(
 	ctx context.Context,
 	cmd string,
 	out *[]byte,
 	args ...interface{},
 ) error {
-	err := c.conn.QueryOneJSON(ctx, cmd, out, args...)
+	return c.QuerySingleJSON(ctx, cmd, out, args...)
+}
+
+// QuerySingleJSON runs a singleton-returning query.
+// If the query executes successfully but doesn't have a result
+// a NoDataError is returned.
+func (c *PoolConn) QuerySingleJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
+	err := c.conn.QuerySingleJSON(ctx, cmd, out, args...)
 	c.checkErr(err)
 	return err
 }

--- a/poolconn_test.go
+++ b/poolconn_test.go
@@ -71,9 +71,9 @@ func TestPoolConnectionRejectsTransaction(t *testing.T) {
 	err = con.QueryJSON(ctx, "START TRANSACTION", &result)
 	assert.EqualError(t, err, expected)
 
-	err = con.QueryOne(ctx, "START TRANSACTION", &result)
+	err = con.QuerySingle(ctx, "START TRANSACTION", &result)
 	assert.EqualError(t, err, expected)
 
-	err = con.QueryOneJSON(ctx, "START TRANSACTION", &result)
+	err = con.QuerySingleJSON(ctx, "START TRANSACTION", &result)
 	assert.EqualError(t, err, expected)
 }

--- a/query.go
+++ b/query.go
@@ -61,7 +61,7 @@ func newQuery(
 
 	var err error
 
-	if fmt == format.JSON || expCard == cardinality.One {
+	if fmt == format.JSON || expCard == cardinality.Single {
 		q.out, err = marshal.ValueOf(out)
 	} else {
 		q.out, err = marshal.ValueOfSlice(out)

--- a/query.go
+++ b/query.go
@@ -61,7 +61,7 @@ func newQuery(
 
 	var err error
 
-	if fmt == format.JSON || expCard == cardinality.Single {
+	if fmt == format.JSON || expCard == cardinality.AtMostOne {
 		q.out, err = marshal.ValueOf(out)
 	} else {
 		q.out, err = marshal.ValueOfSlice(out)

--- a/reconnect.go
+++ b/reconnect.go
@@ -194,7 +194,14 @@ func (b *reconnectingConn) QuerySingle(
 	args ...interface{},
 ) error {
 	hdrs := msgHeaders{header.AllowCapabilities: noTxCapabilities}
-	q, err := newQuery(cmd, format.Binary, cardinality.Single, args, hdrs, out)
+	q, err := newQuery(
+		cmd,
+		format.Binary,
+		cardinality.AtMostOne,
+		args,
+		hdrs,
+		out,
+	)
 	if err != nil {
 		return err
 	}
@@ -242,7 +249,14 @@ func (b *reconnectingConn) QuerySingleJSON(
 	args ...interface{},
 ) error {
 	hdrs := msgHeaders{header.AllowCapabilities: noTxCapabilities}
-	q, err := newQuery(cmd, format.JSON, cardinality.Single, args, hdrs, out)
+	q, err := newQuery(
+		cmd,
+		format.JSON,
+		cardinality.AtMostOne,
+		args,
+		hdrs,
+		out,
+	)
 	if err != nil {
 		return err
 	}

--- a/reconnect.go
+++ b/reconnect.go
@@ -173,14 +173,28 @@ func (b *reconnectingConn) Query(
 // QueryOne runs a singleton-returning query and returns its element.
 // If the query executes successfully but doesn't return a result
 // a NoDataError is returned.
+//
+// Deprecated: use QuerySingle()
 func (b *reconnectingConn) QueryOne(
 	ctx context.Context,
 	cmd string,
 	out interface{},
 	args ...interface{},
 ) error {
+	return b.QuerySingle(ctx, cmd, out, args...)
+}
+
+// QuerySingle runs a singleton-returning query and returns its element.
+// If the query executes successfully but doesn't return a result
+// a NoDataError is returned.
+func (b *reconnectingConn) QuerySingle(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
 	hdrs := msgHeaders{header.AllowCapabilities: noTxCapabilities}
-	q, err := newQuery(cmd, format.Binary, cardinality.One, args, hdrs, out)
+	q, err := newQuery(cmd, format.Binary, cardinality.Single, args, hdrs, out)
 	if err != nil {
 		return err
 	}
@@ -207,14 +221,28 @@ func (b *reconnectingConn) QueryJSON(
 // QueryOneJSON runs a singleton-returning query.
 // If the query executes successfully but doesn't have a result
 // a NoDataError is returned.
+//
+// Deprecated: use QuerySingleJSON()
 func (b *reconnectingConn) QueryOneJSON(
 	ctx context.Context,
 	cmd string,
 	out *[]byte,
 	args ...interface{},
 ) error {
+	return b.QuerySingleJSON(ctx, cmd, out, args...)
+}
+
+// QuerySingleJSON runs a singleton-returning query.
+// If the query executes successfully but doesn't have a result
+// a NoDataError is returned.
+func (b *reconnectingConn) QuerySingleJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
 	hdrs := msgHeaders{header.AllowCapabilities: noTxCapabilities}
-	q, err := newQuery(cmd, format.JSON, cardinality.One, args, hdrs, out)
+	q, err := newQuery(cmd, format.JSON, cardinality.Single, args, hdrs, out)
 	if err != nil {
 		return err
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -178,7 +178,14 @@ func (t *Tx) QuerySingle(
 		return e
 	}
 
-	q, err := newQuery(cmd, format.Binary, cardinality.Single, args, nil, out)
+	q, err := newQuery(
+		cmd,
+		format.Binary,
+		cardinality.AtMostOne,
+		args,
+		nil,
+		out,
+	)
 	if err != nil {
 		return err
 	}
@@ -232,7 +239,7 @@ func (t *Tx) QuerySingleJSON(
 		return e
 	}
 
-	q, err := newQuery(cmd, format.JSON, cardinality.Single, args, nil, out)
+	q, err := newQuery(cmd, format.JSON, cardinality.AtMostOne, args, nil, out)
 	if err != nil {
 		return err
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -154,17 +154,31 @@ func (t *Tx) Query(
 // QueryOne runs a singleton-returning query and returns its element.
 // If the query executes successfully but doesn't return a result
 // a NoDataError is returned.
+//
+// Deprecated: use QuerySingle()
 func (t *Tx) QueryOne(
 	ctx context.Context,
 	cmd string,
 	out interface{},
 	args ...interface{},
 ) error {
-	if e := t.assertStarted("QueryOne"); e != nil {
+	return t.QuerySingle(ctx, cmd, out, args...)
+}
+
+// QuerySingle runs a singleton-returning query and returns its element.
+// If the query executes successfully but doesn't return a result
+// a NoDataError is returned.
+func (t *Tx) QuerySingle(
+	ctx context.Context,
+	cmd string,
+	out interface{},
+	args ...interface{},
+) error {
+	if e := t.assertStarted("QuerySingle"); e != nil {
 		return e
 	}
 
-	q, err := newQuery(cmd, format.Binary, cardinality.One, args, nil, out)
+	q, err := newQuery(cmd, format.Binary, cardinality.Single, args, nil, out)
 	if err != nil {
 		return err
 	}
@@ -194,7 +208,21 @@ func (t *Tx) QueryJSON(
 // QueryOneJSON runs a singleton-returning query.
 // If the query executes successfully but doesn't have a result
 // a NoDataError is returned.
+//
+// Deprecated: use QuerySingleJSON()
 func (t *Tx) QueryOneJSON(
+	ctx context.Context,
+	cmd string,
+	out *[]byte,
+	args ...interface{},
+) error {
+	return t.QuerySingleJSON(ctx, cmd, out, args...)
+}
+
+// QuerySingleJSON runs a singleton-returning query.
+// If the query executes successfully but doesn't have a result
+// a NoDataError is returned.
+func (t *Tx) QuerySingleJSON(
 	ctx context.Context,
 	cmd string,
 	out *[]byte,
@@ -204,7 +232,7 @@ func (t *Tx) QueryOneJSON(
 		return e
 	}
 
-	q, err := newQuery(cmd, format.JSON, cardinality.One, args, nil, out)
+	q, err := newQuery(cmd, format.JSON, cardinality.Single, args, nil, out)
 	if err != nil {
 		return err
 	}

--- a/types_test.go
+++ b/types_test.go
@@ -145,7 +145,7 @@ func TestSendAndReceiveInt64Marshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -248,7 +248,7 @@ func TestSendAndReceiveInt32Marshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -351,7 +351,7 @@ func TestSendAndReceiveInt16Marshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -392,7 +392,7 @@ func TestSendAndReceiveBool(t *testing.T) {
 		s := fmt.Sprint(i)
 		t.Run(s, func(t *testing.T) {
 			var result Result
-			err := conn.QueryOne(ctx, query, &result, i, s)
+			err := conn.QuerySingle(ctx, query, &result, i, s)
 			assert.NoError(t, err)
 
 			assert.True(t, result.IsEqual, "equality check faild")
@@ -435,7 +435,7 @@ func TestSendAndReceiveBoolMarshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -543,7 +543,7 @@ func TestSendAndReceiveFloat64Marshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -651,7 +651,7 @@ func TestSendAndReceiveFloat32Marshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -725,7 +725,7 @@ func TestSendAndReceiveBytesMarshaler(t *testing.T) {
 	copy(arg.data, data)
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -740,7 +740,7 @@ func TestSendAndReceiveStr(t *testing.T) {
 	ctx := context.Background()
 
 	var result string
-	err := conn.QueryOne(ctx, `SELECT <str>$0`, &result, "abcdef")
+	err := conn.QuerySingle(ctx, `SELECT <str>$0`, &result, "abcdef")
 	require.NoError(t, err)
 	assert.Equal(t, "abcdef", result, "round trip failed")
 }
@@ -750,7 +750,8 @@ func TestFetchLargeStr(t *testing.T) {
 	ctx := context.Background()
 
 	var result string
-	err := conn.QueryOne(ctx, "SELECT str_repeat('a', <int64>(10^6))", &result)
+	err := conn.QuerySingle(ctx,
+		"SELECT str_repeat('a', <int64>(10^6))", &result)
 	require.NoError(t, err)
 	assert.Equal(t, strings.Repeat("a", 1_000_000), result)
 }
@@ -788,7 +789,7 @@ func TestSendAndReceiveStrMarshaler(t *testing.T) {
 	copy(arg.data, data)
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -854,7 +855,7 @@ func TestSendAndReceiveJSONMarshaler(t *testing.T) {
 	copy(arg.data, data)
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -891,7 +892,7 @@ func TestSendAndReceiveEnum(t *testing.T) {
 
 	var result Result
 	color := "Red"
-	err := conn.QueryOne(ctx, query, &result, color, color)
+	err := conn.QuerySingle(ctx, query, &result, color, color)
 	require.NoError(t, err)
 
 	assert.Equal(t, color, result.Encoded, "encoding failed")
@@ -901,7 +902,7 @@ func TestSendAndReceiveEnum(t *testing.T) {
 	assert.Equal(t, color, result.String)
 
 	query = "SELECT (decoded := <ColorEnum><str>$0)"
-	err = conn.QueryOne(ctx, query, &result, "invalid")
+	err = conn.QuerySingle(ctx, query, &result, "invalid")
 
 	expected := "edgedb.InvalidValueError: " +
 		"invalid input value for enum 'default::ColorEnum': \"invalid\""
@@ -938,7 +939,7 @@ func TestSendAndReceiveEnumMarshaler(t *testing.T) {
 	copy(arg.data, data)
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -1047,7 +1048,7 @@ func TestSendAndReceiveDurationMarshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -1062,7 +1063,8 @@ func TestSendAndReceiveRelativeDuration(t *testing.T) {
 	ctx := context.Background()
 
 	var duration RelativeDuration
-	err := conn.QueryOne(ctx, "SELECT <cal::relative_duration>'1y'", &duration)
+	err := conn.QuerySingle(ctx,
+		"SELECT <cal::relative_duration>'1y'", &duration)
 	if err != nil {
 		t.Skip("server version is too old for this feature")
 	}
@@ -1134,7 +1136,8 @@ func TestSendAndReceiveRelativeDurationMarshaler(t *testing.T) {
 	ctx := context.Background()
 
 	var duration RelativeDuration
-	err := conn.QueryOne(ctx, "SELECT <cal::relative_duration>'1y'", &duration)
+	err := conn.QuerySingle(ctx,
+		"SELECT <cal::relative_duration>'1y'", &duration)
 	if err != nil {
 		t.Skip("server version is too old for this feature")
 	}
@@ -1159,7 +1162,7 @@ func TestSendAndReceiveRelativeDurationMarshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err = conn.QueryOne(ctx, query, &result, arg)
+	err = conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -1282,7 +1285,7 @@ func TestSendAndReceiveLocalTimeMarshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -1396,7 +1399,7 @@ func TestSendAndReceiveLocalDateMarshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -1517,7 +1520,7 @@ func TestSendAndReceiveLocalDateTimeMarshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -1639,7 +1642,7 @@ func TestSendAndReceiveDateTimeMarshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -1798,7 +1801,7 @@ func TestSendAndReceiveBigInt(t *testing.T) {
 			require.Equal(t, s, i.String())
 
 			var result Result
-			err := conn.QueryOne(ctx, query, &result, i, s)
+			err := conn.QuerySingle(ctx, query, &result, i, s)
 			assert.NoError(t, err)
 
 			assert.True(t, result.IsEqual, "equality check faild")
@@ -1848,7 +1851,7 @@ func TestSendAndReceiveBigIntMarshaler(t *testing.T) {
 	copy(arg.data, data)
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -1897,7 +1900,7 @@ func TestSendAndReceiveDecimalMarshaler(t *testing.T) {
 	)`
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 
 	expected := CustomDecimal{make([]byte, len(data))}
@@ -1949,7 +1952,7 @@ func TestSendAndReceiveUUID(t *testing.T) {
 			require.NoError(t, err)
 
 			var result Result
-			err = conn.QueryOne(ctx, query, &result, id, s)
+			err = conn.QuerySingle(ctx, query, &result, id, s)
 			assert.NoError(t, err)
 
 			assert.True(t, result.IsEqual, "equality check faild")
@@ -1996,7 +1999,7 @@ func TestSendAndReceiveUUIDMarshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -2039,7 +2042,7 @@ func TestSendAndReceiveCustomScalars(t *testing.T) {
 		s := fmt.Sprint(i)
 		t.Run(s, func(t *testing.T) {
 			var result Result
-			err := conn.QueryOne(ctx, query, &result, i, s)
+			err := conn.QuerySingle(ctx, query, &result, i, s)
 
 			assert.NoError(t, err)
 			assert.Equal(t, s, result.Encoded)
@@ -2081,7 +2084,7 @@ func TestSendAndReceiveCustomScalarMarshaler(t *testing.T) {
 	copy(arg.data[:], data[:])
 
 	var result Result
-	err := conn.QueryOne(ctx, query, &result, arg)
+	err := conn.QuerySingle(ctx, query, &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t,
 		Result{
@@ -2112,7 +2115,7 @@ func TestDecodeDeeplyNestedTuple(t *testing.T) {
 	}
 
 	var result ParentTuple
-	err := conn.QueryOne(ctx, query, &result)
+	err := conn.QuerySingle(ctx, query, &result)
 	require.NoError(t, err)
 
 	expected := ParentTuple{
@@ -2157,7 +2160,7 @@ func TestReceiveObject(t *testing.T) {
 	}
 
 	var result Function
-	err := conn.QueryOne(ctx, query, &result)
+	err := conn.QuerySingle(ctx, query, &result)
 	require.NoError(t, err)
 	assert.Equal(t, "std::str_repeat", result.Name)
 	assert.Equal(t, 2, len(result.Params))
@@ -2173,7 +2176,7 @@ func TestReceiveNamedTuple(t *testing.T) {
 	}
 
 	var result NamedTuple
-	err := conn.QueryOne(ctx, "SELECT (a := 1,)", &result)
+	err := conn.QuerySingle(ctx, "SELECT (a := 1,)", &result)
 	require.NoError(t, err)
 	assert.Equal(t, NamedTuple{A: 1}, result)
 }
@@ -2182,17 +2185,17 @@ func TestReceiveTuple(t *testing.T) {
 	ctx := context.Background()
 
 	var wrongType string
-	err := conn.QueryOne(ctx, `SELECT ()`, &wrongType)
+	err := conn.QuerySingle(ctx, `SELECT ()`, &wrongType)
 	require.EqualError(t, err, "edgedb.UnsupportedFeatureError: "+
 		"the \"out\" argument does not match query schema: "+
 		"expected string to be a struct got string")
 
 	var emptyStruct struct{}
-	err = conn.QueryOne(ctx, `SELECT ()`, &emptyStruct)
+	err = conn.QuerySingle(ctx, `SELECT ()`, &emptyStruct)
 	require.NoError(t, err)
 
 	var missingTag struct{ first int64 }
-	err = conn.QueryOne(ctx, `SELECT (<int64>$0,)`, &missingTag, int64(1))
+	err = conn.QuerySingle(ctx, `SELECT (<int64>$0,)`, &missingTag, int64(1))
 	require.EqualError(t, err, "edgedb.UnsupportedFeatureError: "+
 		"the \"out\" argument does not match query schema: "+
 		"expected struct { first int64 } to have a field "+
@@ -2245,7 +2248,7 @@ func TestSendAndReceiveArray(t *testing.T) {
 	ctx := context.Background()
 
 	var result []int64
-	err := conn.QueryOne(ctx, "SELECT <array<int64>>$0", &result, "hello")
+	err := conn.QuerySingle(ctx, "SELECT <array<int64>>$0", &result, "hello")
 	assert.EqualError(t, err,
 		"edgedb.InvalidArgumentError: "+
 			"expected args[0] to be a slice got: string")
@@ -2255,20 +2258,22 @@ func TestSendAndReceiveArray(t *testing.T) {
 	}
 
 	var nested Tuple
-	err = conn.QueryOne(ctx, "SELECT (<array<int64>>$0,)", &nested, []int64{1})
+	err = conn.QuerySingle(ctx,
+		"SELECT (<array<int64>>$0,)", &nested, []int64{1})
 	require.NoError(t, err)
 	assert.Equal(t, Tuple{[]int64{1}}, nested)
 
-	err = conn.QueryOne(ctx, "SELECT <array<int64>>$0", &result, []int64(nil))
+	err = conn.QuerySingle(ctx,
+		"SELECT <array<int64>>$0", &result, []int64(nil))
 	require.NoError(t, err)
 	assert.Equal(t, []int64(nil), result)
 
-	err = conn.QueryOne(ctx, "SELECT <array<int64>>$0", &result, []int64{1})
+	err = conn.QuerySingle(ctx, "SELECT <array<int64>>$0", &result, []int64{1})
 	require.NoError(t, err)
 	assert.Equal(t, []int64{1}, result)
 
 	arg := []int64{1, 2, 3}
-	err = conn.QueryOne(ctx, "SELECT <array<int64>>$0", &result, arg)
+	err = conn.QuerySingle(ctx, "SELECT <array<int64>>$0", &result, arg)
 	require.NoError(t, err)
 	assert.Equal(t, []int64{1, 2, 3}, result)
 }
@@ -2292,7 +2297,7 @@ func TestReceiveSet(t *testing.T) {
 		`
 
 		var result Function
-		err := conn.QueryOne(ctx, query, &result)
+		err := conn.QuerySingle(ctx, query, &result)
 		require.NoError(t, err)
 		assert.Equal(t, [][]int64{{1, 2}, {1}}, result.Sets)
 	}
@@ -2322,7 +2327,7 @@ func TestReceiveSet(t *testing.T) {
 		`
 
 		var result Function
-		err := conn.QueryOne(ctx, query, &result)
+		err := conn.QuerySingle(ctx, query, &result)
 		require.NoError(t, err)
 		assert.Equal(t,
 			[][]Tuple{


### PR DESCRIPTION
QuerySingJSON() is also added and QueryOneJSON() is also deprecated.