### PR TITLE
update golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -228,13 +228,9 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
 
-    # enable or disable analyzers by name
-    enable:
-      - atomicalign
-    enable-all: false
+    enable-all: true
     disable:
-      - shadow
-    disable-all: false
+      - fieldalignment
   depguard:
     list-type: blacklist
     include-go-root: false
@@ -371,12 +367,11 @@ linters:
     - gofmt
     - goheader
     - goimports
-    - golint
     - gosimple
     - govet
     - ineffassign
     - lll
-    - maligned
+    - revive
     - prealloc
     - staticcheck
     - structcheck

--- a/fallthrough.go
+++ b/fallthrough.go
@@ -24,7 +24,7 @@ import (
 	"github.com/edgedb/edgedb-go/internal/message"
 )
 
-var logMsgSeverityLookup map[uint8]string = map[uint8]string{
+var logMsgSeverityLookup = map[uint8]string{
 	0x14: "DEBUG",
 	0x28: "INFO",
 	0x3c: "NOTICE",

--- a/internal/codecs/bool.go
+++ b/internal/codecs/bool.go
@@ -67,7 +67,7 @@ func (c *boolCodec) Encode(w *buff.Writer, val interface{}, path Path) error {
 		w.PushUint32(1) // data length
 
 		// convert bool to uint8
-		var out uint8 = 0
+		var out uint8
 		if in {
 			out = 1
 		}

--- a/internal/codecs/numerics.go
+++ b/internal/codecs/numerics.go
@@ -103,7 +103,7 @@ func (c *bigIntCodec) Encode(
 		cpy := &big.Int{}
 		cpy.Set(in)
 
-		var sign uint16 = 0
+		var sign uint16
 		if in.Sign() == -1 {
 			sign = 0x4000
 			cpy = cpy.Neg(cpy)

--- a/main_test.go
+++ b/main_test.go
@@ -201,7 +201,7 @@ func startServer() {
 }
 
 func TestMain(m *testing.M) {
-	var err error = nil
+	var err error
 	code := 1
 	defer func() {
 		if e := recover(); e != nil {

--- a/poolconn.go
+++ b/poolconn.go
@@ -43,7 +43,7 @@ func (c *PoolConn) Release() error {
 		return &interfaceError{msg: msg}
 	}
 
-	var err error = nil
+	var err error
 	if c.err != nil {
 		err = *c.err
 	}


### PR DESCRIPTION
A couple of the linters that were configured were deprecated recently.
This change removes the depricated linters and replaces them with
golangci-lint's recomended replacements.