### PR TITLE
Reword deprecation messages

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -212,7 +212,7 @@ func (p *Pool) acquire(ctx context.Context) (*reconnectingConn, error) {
 // blocking until a connection is available.
 // Acquired connections must be released to the pool when no longer needed.
 //
-// Deprecated: use RetryingTx() or RawTx()
+// Deprecated: use the query methods on Pool instead
 func (p *Pool) Acquire(ctx context.Context) (*PoolConn, error) {
 	conn, err := p.acquire(ctx)
 	if err != nil {

--- a/poolconn.go
+++ b/poolconn.go
@@ -25,7 +25,7 @@ import (
 
 // PoolConn is a pooled connection.
 //
-// Deprecated: use Pool.RetryingTx() or Pool.RawTx()
+// Deprecated: use the query methods on Pool instead
 type PoolConn struct {
 	pool      *Pool
 	err       *error


### PR DESCRIPTION
Remove the suggestion to use Tx methods to get a single connection.