### PR TITLE
Support OPTIONAL argument types

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -74,20 +74,23 @@ type queryKey struct {
 	cmd     string
 	fmt     uint8
 	expCard uint8
+	outType reflect.Type
 }
 
-func (c *baseConn) getTypeIDs(q *gfQuery) (idPair, bool) {
+func (c *baseConn) getTypeIDs(q *gfQuery) (*idPair, bool) {
 	key := queryKey{
 		cmd:     q.cmd,
 		fmt:     q.fmt,
 		expCard: q.expCard,
+		outType: q.outType,
 	}
 
 	if val, ok := c.typeIDCache.Get(key); ok {
-		return val.(idPair), true
+		x := val.(idPair)
+		return &x, true
 	}
 
-	return idPair{}, false
+	return nil, false
 }
 
 func (c *baseConn) putTypeIDs(q *gfQuery, ids idPair) {

--- a/connect.go
+++ b/connect.go
@@ -28,9 +28,10 @@ import (
 
 var (
 	protocolVersionMin  = internal.ProtocolVersion{Major: 0, Minor: 9}
-	protocolVersionMax  = internal.ProtocolVersion{Major: 0, Minor: 11}
+	protocolVersionMax  = internal.ProtocolVersion{Major: 0, Minor: 12}
 	protocolVersion0p10 = internal.ProtocolVersion{Major: 0, Minor: 10}
 	protocolVersion0p11 = internal.ProtocolVersion{Major: 0, Minor: 11}
+	protocolVersion0p12 = internal.ProtocolVersion{Major: 0, Minor: 12}
 )
 
 func (c *baseConn) connect(r *buff.Reader, cfg *connConfig) error {
@@ -107,7 +108,7 @@ func (c *baseConn) connect(r *buff.Reader, cfg *connConfig) error {
 
 			done.Signal()
 		case message.ErrorResponse:
-			err = wrapAll(err, decodeError(r, ""))
+			err = wrapAll(err, decodeErrorResponseMsg(r, ""))
 			done.Signal()
 		default:
 			if e := c.fallThrough(r); e != nil {
@@ -179,7 +180,7 @@ func (c *baseConn) authenticate(r *buff.Reader, cfg *connConfig) error {
 
 			done.Signal()
 		case message.ErrorResponse:
-			err = decodeError(r, "")
+			err = decodeErrorResponseMsg(r, "")
 		default:
 			if e := c.fallThrough(r); e != nil {
 				// the connection will not be usable after this x_x
@@ -233,7 +234,7 @@ func (c *baseConn) authenticate(r *buff.Reader, cfg *connConfig) error {
 			r.Discard(1) // transaction state
 			done.Signal()
 		case message.ErrorResponse:
-			err = wrapAll(decodeError(r, ""))
+			err = wrapAll(decodeErrorResponseMsg(r, ""))
 		default:
 			if e := c.fallThrough(r); e != nil {
 				// the connection will not be usable after this x_x

--- a/error.go
+++ b/error.go
@@ -92,9 +92,9 @@ func positionFromHeaders(headers map[uint16]string) (position, bool) {
 	}, true
 }
 
-// decodeError decodes an error response
+// decodeErrorResponseMsg decodes an error response
 // https://www.edgedb.com/docs/internals/protocol/messages#errorresponse
-func decodeError(r *buff.Reader, query string) error {
+func decodeErrorResponseMsg(r *buff.Reader, query string) error {
 	r.Discard(1) // severity
 	code := r.PopUint32()
 	msg := r.PopString()

--- a/internal/codecs/args.go
+++ b/internal/codecs/args.go
@@ -1,0 +1,148 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codecs
+
+import (
+	"fmt"
+
+	"github.com/edgedb/edgedb-go/internal"
+	"github.com/edgedb/edgedb-go/internal/buff"
+	"github.com/edgedb/edgedb-go/internal/descriptor"
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
+)
+
+func buildArgEncoder(
+	desc descriptor.Descriptor,
+	version internal.ProtocolVersion,
+) (Encoder, error) {
+	fields := make([]*EncoderField, len(desc.Fields))
+
+	for i, field := range desc.Fields {
+		encoder, err := BuildEncoder(field.Desc, version)
+		if err != nil {
+			return nil, err
+		}
+
+		fields[i] = &EncoderField{
+			name:     field.Name,
+			encoder:  encoder,
+			required: field.Required,
+		}
+	}
+
+	if len(desc.Fields) > 0 && desc.Fields[0].Name != "0" {
+		return &kwargsEncoder{desc.ID, fields}, nil
+	}
+
+	return &argsEncoder{desc.ID, fields}, nil
+}
+
+type argsEncoder struct {
+	id     types.UUID
+	fields []*EncoderField
+}
+
+func (c *argsEncoder) DescriptorID() types.UUID { return c.id }
+
+func (c *argsEncoder) Encode(
+	w *buff.Writer,
+	val interface{},
+	path Path,
+	required bool,
+) error {
+	in, ok := val.([]interface{})
+	if !ok {
+		return fmt.Errorf("expected %v to be []interface{} got %T", path, val)
+	}
+
+	if len(in) != len(c.fields) {
+		return fmt.Errorf(
+			"expected %v arguments got %v", len(c.fields), len(in),
+		)
+	}
+
+	w.BeginBytes()
+
+	elmCount := len(c.fields)
+	w.PushUint32(uint32(elmCount))
+
+	var err error
+	for i, field := range c.fields {
+		w.PushUint32(0) // reserved
+		err = field.encoder.Encode(w, in[i], path.AddIndex(i), field.required)
+		if err != nil {
+			return err
+		}
+	}
+
+	w.EndBytes()
+	return nil
+}
+
+type kwargsEncoder struct {
+	id     types.UUID
+	fields []*EncoderField
+}
+
+func (c *kwargsEncoder) DescriptorID() types.UUID { return c.id }
+
+func (c *kwargsEncoder) Encode(
+	w *buff.Writer,
+	val interface{},
+	path Path,
+	required bool,
+) error {
+	args, ok := val.([]interface{})
+	if !ok {
+		return fmt.Errorf("expected %v to be []interface{} got %T", path, val)
+	}
+
+	if len(args) != 1 {
+		return fmt.Errorf(
+			"wrong number of arguments, expected 1 got: %v", len(args),
+		)
+	}
+
+	in, ok := args[0].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf(
+			"expected %v to be map[string]interface{} got %T", path, args[0],
+		)
+	}
+
+	elmCount := len(c.fields)
+	w.BeginBytes()
+	w.PushUint32(uint32(elmCount))
+
+	var err error
+	for _, field := range c.fields {
+		w.PushUint32(0) // reserved
+		err = field.encoder.Encode(
+			w,
+			in[field.name],
+			path.AddField(field.name),
+			field.required,
+		)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	w.EndBytes()
+	return nil
+}

--- a/internal/codecs/basescalar_test.go
+++ b/internal/codecs/basescalar_test.go
@@ -48,7 +48,7 @@ func BenchmarkEncodeUUID(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = codec.Encode(w, id, Path(""))
+		_ = codec.Encode(w, id, Path(""), true)
 	}
 }
 

--- a/internal/codecs/noop.go
+++ b/internal/codecs/noop.go
@@ -39,4 +39,16 @@ func (c noOpDecoder) DescriptorID() types.UUID { return descriptor.IDZero }
 
 func (c noOpDecoder) Decode(r *buff.Reader, out unsafe.Pointer) {}
 
-func (c noOpDecoder) DecodeMissing(out unsafe.Pointer) { panic("unreachable") }
+type noOpEncoder struct{}
+
+func (c noOpEncoder) DescriptorID() types.UUID { return descriptor.IDZero }
+
+func (c noOpEncoder) Encode(
+	w *buff.Writer,
+	val interface{},
+	path Path,
+	required bool,
+) error {
+	w.PushUint32(0)
+	return nil
+}

--- a/internal/codecs/numbers.go
+++ b/internal/codecs/numbers.go
@@ -56,36 +56,44 @@ func (c *int16Codec) Decode(r *buff.Reader, out unsafe.Pointer) {
 	*(*uint16)(out) = r.PopUint16()
 }
 
-func (c *int16Codec) DecodeMissing(out unsafe.Pointer) { panic("unreachable") }
+type optionalInt16Marshaler interface {
+	marshal.Int16Marshaler
+	marshal.OptionalMarshaler
+}
 
-func (c *int16Codec) Encode(w *buff.Writer, val interface{}, path Path) error {
+func (c *int16Codec) Encode(
+	w *buff.Writer,
+	val interface{},
+	path Path,
+	required bool,
+) error {
 	switch in := val.(type) {
 	case int16:
-		w.PushUint32(2) // data length
-		w.PushUint16(uint16(in))
+		return c.encodeData(w, in)
 	case types.OptionalInt16:
-		i, ok := in.Get()
-		if !ok {
-			return fmt.Errorf("cannot encode edgedb.OptionalInt16 at %v "+
-				"because its value is missing", path)
-		}
-
-		w.PushUint32(2) // data length
-		w.PushUint16(uint16(i))
+		data, ok := in.Get()
+		return encodeOptional(w, !ok, required,
+			func() error { return c.encodeData(w, data) },
+			func() error {
+				return missingValueError("edgedb.OptionalInt16", path)
+			})
+	case optionalInt16Marshaler:
+		return encodeOptional(w, in.Missing(), required,
+			func() error {
+				return encodeMarshaler(w, in, in.MarshalEdgeDBInt16, 2, path)
+			},
+			func() error { return missingValueError(in, path) })
 	case marshal.Int16Marshaler:
-		data, err := in.MarshalEdgeDBInt16()
-		if err != nil {
-			return err
-		}
-
-		w.BeginBytes()
-		w.PushBytes(data)
-		w.EndBytes()
+		return encodeMarshaler(w, in, in.MarshalEdgeDBInt16, 2, path)
 	default:
 		return fmt.Errorf("expected %v to be int16, edgedb.OptionalInt16 or "+
 			"Int16Marshaler got %T", path, val)
 	}
+}
 
+func (c *int16Codec) encodeData(w *buff.Writer, data int16) error {
+	w.PushUint32(2)
+	w.PushUint16(uint16(data))
 	return nil
 }
 
@@ -120,36 +128,44 @@ func (c *int32Codec) Decode(r *buff.Reader, out unsafe.Pointer) {
 	*(*uint32)(out) = r.PopUint32()
 }
 
-func (c *int32Codec) DecodeMissing(out unsafe.Pointer) { panic("unreachable") }
+type optionalInt32Marshaler interface {
+	marshal.Int32Marshaler
+	marshal.OptionalMarshaler
+}
 
-func (c *int32Codec) Encode(w *buff.Writer, val interface{}, path Path) error {
+func (c *int32Codec) Encode(
+	w *buff.Writer,
+	val interface{},
+	path Path,
+	required bool,
+) error {
 	switch in := val.(type) {
 	case int32:
-		w.PushUint32(4) // data length
-		w.PushUint32(uint32(in))
+		return c.encodeData(w, in)
 	case types.OptionalInt32:
-		i, ok := in.Get()
-		if !ok {
-			return fmt.Errorf("cannot encode edgedb.OptionalInt32 at %v "+
-				"because its value is missing", path)
-		}
-
-		w.PushUint32(4) // data length
-		w.PushUint32(uint32(i))
+		data, ok := in.Get()
+		return encodeOptional(w, !ok, required,
+			func() error { return c.encodeData(w, data) },
+			func() error {
+				return missingValueError("edgedb.OptionalInt32", path)
+			})
+	case optionalInt32Marshaler:
+		return encodeOptional(w, in.Missing(), required,
+			func() error {
+				return encodeMarshaler(w, in, in.MarshalEdgeDBInt32, 4, path)
+			},
+			func() error { return missingValueError(val, path) })
 	case marshal.Int32Marshaler:
-		data, err := in.MarshalEdgeDBInt32()
-		if err != nil {
-			return err
-		}
-
-		w.BeginBytes()
-		w.PushBytes(data)
-		w.EndBytes()
+		return encodeMarshaler(w, in, in.MarshalEdgeDBInt32, 4, path)
 	default:
 		return fmt.Errorf("expected %v to be int32, edgedb.OptionalInt32 "+
 			"or Int32Marshaler got %T", path, val)
 	}
+}
 
+func (c *int32Codec) encodeData(w *buff.Writer, data int32) error {
+	w.PushUint32(4) // data length
+	w.PushUint32(uint32(data))
 	return nil
 }
 
@@ -184,36 +200,44 @@ func (c *int64Codec) Decode(r *buff.Reader, out unsafe.Pointer) {
 	*(*uint64)(out) = r.PopUint64()
 }
 
-func (c *int64Codec) DecodeMissing(out unsafe.Pointer) { panic("unreachable") }
+type optionalInt64Marshaler interface {
+	marshal.Int64Marshaler
+	marshal.OptionalMarshaler
+}
 
-func (c *int64Codec) Encode(w *buff.Writer, val interface{}, path Path) error {
+func (c *int64Codec) Encode(
+	w *buff.Writer,
+	val interface{},
+	path Path,
+	required bool,
+) error {
 	switch in := val.(type) {
 	case int64:
-		w.PushUint32(8) // data length
-		w.PushUint64(uint64(in))
+		return c.encodeData(w, in)
 	case types.OptionalInt64:
-		i, ok := in.Get()
-		if !ok {
-			return fmt.Errorf("cannot encode edgedb.OptionalInt64 at %v "+
-				"because its value is missing", path)
-		}
-
-		w.PushUint32(8) // data length
-		w.PushUint64(uint64(i))
+		data, ok := in.Get()
+		return encodeOptional(w, !ok, required,
+			func() error { return c.encodeData(w, data) },
+			func() error {
+				return missingValueError("edgedb.OptionalInt64", path)
+			})
+	case optionalInt64Marshaler:
+		return encodeOptional(w, in.Missing(), required,
+			func() error {
+				return encodeMarshaler(w, in, in.MarshalEdgeDBInt64, 8, path)
+			},
+			func() error { return missingValueError(in, path) })
 	case marshal.Int64Marshaler:
-		data, err := in.MarshalEdgeDBInt64()
-		if err != nil {
-			return err
-		}
-
-		w.BeginBytes()
-		w.PushBytes(data)
-		w.EndBytes()
+		return encodeMarshaler(w, in, in.MarshalEdgeDBInt64, 8, path)
 	default:
 		return fmt.Errorf("expected %v to be int64, edgedb.OptionalInt64 or "+
 			"Int64Marshaler got %T", path, val)
 	}
+}
 
+func (c *int64Codec) encodeData(w *buff.Writer, data int64) error {
+	w.PushUint32(8) // data length
+	w.PushUint64(uint64(data))
 	return nil
 }
 
@@ -248,42 +272,44 @@ func (c *float32Codec) Decode(r *buff.Reader, out unsafe.Pointer) {
 	*(*uint32)(out) = r.PopUint32()
 }
 
-func (c *float32Codec) DecodeMissing(out unsafe.Pointer) {
-	panic("unreachable")
+type optionalFloat32Marshaler interface {
+	marshal.Float32Marshaler
+	marshal.OptionalMarshaler
 }
 
 func (c *float32Codec) Encode(
 	w *buff.Writer,
 	val interface{},
 	path Path,
+	required bool,
 ) error {
 	switch in := val.(type) {
 	case float32:
-		w.PushUint32(4)
-		w.PushUint32(math.Float32bits(in))
+		return c.encodeData(w, in)
 	case types.OptionalFloat32:
-		f, ok := in.Get()
-		if !ok {
-			return fmt.Errorf("cannot encode edgedb.OptionalFloat32 at %v "+
-				"because its value is missing", path)
-		}
-
-		w.PushUint32(4)
-		w.PushUint32(math.Float32bits(f))
+		data, ok := in.Get()
+		return encodeOptional(w, !ok, required,
+			func() error { return c.encodeData(w, data) },
+			func() error {
+				return missingValueError("edgedb.OptionalFloat32", path)
+			})
+	case optionalFloat32Marshaler:
+		return encodeOptional(w, in.Missing(), required,
+			func() error {
+				return encodeMarshaler(w, in, in.MarshalEdgeDBFloat32, 4, path)
+			},
+			func() error { return missingValueError(val, path) })
 	case marshal.Float32Marshaler:
-		data, err := in.MarshalEdgeDBFloat32()
-		if err != nil {
-			return err
-		}
-
-		w.BeginBytes()
-		w.PushBytes(data)
-		w.EndBytes()
+		return encodeMarshaler(w, in, in.MarshalEdgeDBFloat32, 4, path)
 	default:
 		return fmt.Errorf("expected %v to be float32, edgedb.OptionalFloat32 "+
 			"or Float32Marshaler got %T", path, val)
 	}
+}
 
+func (c *float32Codec) encodeData(w *buff.Writer, data float32) error {
+	w.PushUint32(4)
+	w.PushUint32(math.Float32bits(data))
 	return nil
 }
 
@@ -318,41 +344,44 @@ func (c *float64Codec) Decode(r *buff.Reader, out unsafe.Pointer) {
 	*(*uint64)(out) = r.PopUint64()
 }
 
-func (c *float64Codec) DecodeMissing(out unsafe.Pointer) {
-	panic("unreachable")
+type optionalFloat64Marshaler interface {
+	marshal.Float64Marshaler
+	marshal.OptionalMarshaler
 }
 
 func (c *float64Codec) Encode(
 	w *buff.Writer,
 	val interface{},
 	path Path,
+	required bool,
 ) error {
 	switch in := val.(type) {
 	case float64:
-		w.PushUint32(8)
-		w.PushUint64(math.Float64bits(in))
+		return c.encodeData(w, in)
 	case types.OptionalFloat64:
-		f, ok := in.Get()
-		if !ok {
-			return fmt.Errorf("cannot encode edgedb.OptionalFloat64 at %v "+
-				"because its value is missing", path)
-		}
-		w.PushUint32(8)
-		w.PushUint64(math.Float64bits(f))
+		data, ok := in.Get()
+		return encodeOptional(w, !ok, required,
+			func() error { return c.encodeData(w, data) },
+			func() error {
+				return missingValueError("edgedb.OptionalFloat64", path)
+			})
+	case optionalFloat64Marshaler:
+		return encodeOptional(w, in.Missing(), required,
+			func() error {
+				return encodeMarshaler(w, in, in.MarshalEdgeDBFloat64, 8, path)
+			},
+			func() error { return missingValueError(in, path) })
 	case marshal.Float64Marshaler:
-		data, err := in.MarshalEdgeDBFloat64()
-		if err != nil {
-			return err
-		}
-
-		w.BeginBytes()
-		w.PushBytes(data)
-		w.EndBytes()
+		return encodeMarshaler(w, in, in.MarshalEdgeDBFloat64, 8, path)
 	default:
 		return fmt.Errorf("expected %v to be float64, edgedb.OptionalFloat64 "+
 			"or Float64Marshaler got %T", path, val)
 	}
+}
 
+func (c *float64Codec) encodeData(w *buff.Writer, data float64) error {
+	w.PushUint32(8)
+	w.PushUint64(math.Float64bits(data))
 	return nil
 }
 

--- a/internal/codecs/set.go
+++ b/internal/codecs/set.go
@@ -121,5 +121,3 @@ func (c *setDecoder) DecodeMissing(out unsafe.Pointer) {
 	slice.Len = 0
 	slice.Cap = 0
 }
-
-func (c *setDecoder) DecodePresent(out unsafe.Pointer) {}

--- a/internal/codecs/utils.go
+++ b/internal/codecs/utils.go
@@ -1,0 +1,83 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright 2020-present EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codecs
+
+import (
+	"fmt"
+
+	"github.com/edgedb/edgedb-go/internal/buff"
+)
+
+func encodeOptional(
+	w *buff.Writer,
+	missingValue, requiredArgument bool,
+	encode, missingValueError func() error,
+) error {
+	switch {
+	case missingValue && requiredArgument:
+		return missingValueError()
+	case missingValue:
+		w.PushUint32(0xffffffff)
+		return nil
+	default:
+		return encode()
+	}
+}
+
+func encodeMarshaler(
+	w *buff.Writer,
+	val interface{},
+	marshal func() ([]byte, error),
+	expectedDataLen int,
+	path Path,
+) error {
+	data, err := marshal()
+	if err != nil {
+		return err
+	}
+	if len(data) != expectedDataLen {
+		return wrongNumberOfBytesError(val, path, expectedDataLen, len(data))
+	}
+	w.PushUint32(uint32(expectedDataLen))
+	w.PushBytes(data)
+	return nil
+}
+
+func missingValueError(val interface{}, path Path) error {
+	var name string
+	switch in := val.(type) {
+	case string:
+		name = in
+	default:
+		name = fmt.Sprintf("%T", in)
+	}
+
+	return fmt.Errorf(
+		"cannot encode %v at %v because its value is missing",
+		name, path)
+}
+
+func wrongNumberOfBytesError(
+	val interface{},
+	path Path,
+	expected interface{},
+	actual int,
+) error {
+	return fmt.Errorf(
+		"wrong number of bytes encoded by %T at %v expected %v, got %v",
+		val, path, expected, actual)
+}

--- a/internal/marshal/marshal.go
+++ b/internal/marshal/marshal.go
@@ -36,6 +36,12 @@ type OptionalUnmarshaler interface {
 	SetMissing(bool)
 }
 
+// OptionalMarshaler is used for optional (not required) shape field values.
+type OptionalMarshaler interface {
+	// Missing returns true when the value is missing.
+	Missing() bool
+}
+
 // StrMarshaler is the interface implemented by an object
 // that can marshal itself into the str wire format.
 // https://www.edgedb.com/docs/internals/protocol/dataformats#std-str

--- a/main_test.go
+++ b/main_test.go
@@ -237,8 +237,6 @@ func TestMain(m *testing.M) {
 					type TxTest {
 						required property name -> str;
 					}
-					scalar type CustomInt64 extending int64;
-					scalar type ColorEnum extending enum<Red, Green, Blue>;
 				}
 			};
 			POPULATE MIGRATION;

--- a/scriptflow.go
+++ b/scriptflow.go
@@ -67,14 +67,12 @@ func (c *baseConn) execScriptFlow(r *buff.Reader, q sfQuery) error {
 	for r.Next(done.Chan) {
 		switch r.MsgType {
 		case message.CommandComplete:
-			ignoreHeaders(r)
-			r.PopBytes() // command status
+			decodeCommandCompleteMsg(r)
 		case message.ReadyForCommand:
-			ignoreHeaders(r)
-			r.Discard(1) // transaction state
+			decodeReadyForCommandMsg(r)
 			done.Signal()
 		case message.ErrorResponse:
-			err = wrapAll(err, decodeError(r, q.cmd))
+			err = wrapAll(err, decodeErrorResponseMsg(r, q.cmd))
 		default:
 			if e := c.fallThrough(r); e != nil {
 				// the connection will not be usable after this x_x


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb-go/issues/151

- Add support for optional argument types. Previously all arguments were  treated as required even if they included the OPTIONAL key word. The  server version must be higher than 1-beta3 i.e. support protocol version 0.12 for this feature to work.
- Bump max protocol version to 0.12
- Make nil slices count as missing values for arrays.
- Fix bigint decoding bug that sums the decoded value with the value in  the memory that was decoded into.
- Fix query cache consistency bug by adding the out argument's type to  the cache key.
- Fix unmarshaler type checking. Previously any unmarshaler type could  be used with any descriptor type.
- Add handling CommandDataDescription sent in response to  OptimisticExecute.