### PR TITLE
Retry readonly queries outside of transactions

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -64,10 +64,11 @@ func ConnectOneDSN(
 		reconnectingConn: &reconnectingConn{
 			cfg: config,
 			cacheCollection: cacheCollection{
-				serverSettings: config.serverSettings,
-				typeIDCache:    cache.New(1_000),
-				inCodecCache:   cache.New(1_000),
-				outCodecCache:  cache.New(1_000),
+				serverSettings:    config.serverSettings,
+				typeIDCache:       cache.New(1_000),
+				inCodecCache:      cache.New(1_000),
+				outCodecCache:     cache.New(1_000),
+				capabilitiesCache: cache.New(1_000),
 			},
 		},
 	}}

--- a/edgedb.go
+++ b/edgedb.go
@@ -31,10 +31,11 @@ import (
 var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 type cacheCollection struct {
-	serverSettings map[string]string
-	typeIDCache    *cache.Cache
-	inCodecCache   *cache.Cache
-	outCodecCache  *cache.Cache
+	serverSettings    map[string]string
+	typeIDCache       *cache.Cache
+	inCodecCache      *cache.Cache
+	outCodecCache     *cache.Cache
+	capabilitiesCache *cache.Cache // nolint:structcheck
 }
 
 type protocolConnection struct {

--- a/internal/header/header.go
+++ b/internal/header/header.go
@@ -29,6 +29,10 @@ const (
 	// AllowCapabilitieTransaction represents the transaction capability
 	// in the AllowCapabilities header.
 	AllowCapabilitieTransaction uint64 = 0b100
+
+	// Capabilities is returned in PrepareComplete and CommandDataDescription
+	// messages.
+	Capabilities uint16 = 0x1001
 )
 
 // NewAllowCapabilitiesWithout returns an AllowCapabilities header value

--- a/pool.go
+++ b/pool.go
@@ -113,10 +113,11 @@ func ConnectDSN(ctx context.Context, dsn string, opts Options) (*Pool, error) { 
 		},
 
 		cacheCollection: cacheCollection{
-			serverSettings: cfg.serverSettings,
-			typeIDCache:    cache.New(1_000),
-			inCodecCache:   cache.New(1_000),
-			outCodecCache:  cache.New(1_000),
+			serverSettings:    cfg.serverSettings,
+			typeIDCache:       cache.New(1_000),
+			inCodecCache:      cache.New(1_000),
+			outCodecCache:     cache.New(1_000),
+			capabilitiesCache: cache.New(1_000),
 		},
 	}
 
@@ -298,7 +299,7 @@ func (p *Pool) Query(
 		return err
 	}
 
-	err = runQuery(ctx, conn, "Query", cmd, out, args)
+	err = runQuery(ctx, &conn, "Query", cmd, out, args)
 	return firstError(err, p.release(&conn, err))
 }
 
@@ -330,7 +331,7 @@ func (p *Pool) QuerySingle(
 		return err
 	}
 
-	err = runQuery(ctx, conn, "QuerySingle", cmd, out, args)
+	err = runQuery(ctx, &conn, "QuerySingle", cmd, out, args)
 	return firstError(err, p.release(&conn, err))
 }
 
@@ -346,7 +347,7 @@ func (p *Pool) QueryJSON(
 		return err
 	}
 
-	err = runQuery(ctx, conn, "QueryJSON", cmd, out, args)
+	err = runQuery(ctx, &conn, "QueryJSON", cmd, out, args)
 	return firstError(err, p.release(&conn, err))
 }
 
@@ -378,7 +379,7 @@ func (p *Pool) QuerySingleJSON(
 		return err
 	}
 
-	err = runQuery(ctx, conn, "QuerySingleJSON", cmd, out, args)
+	err = runQuery(ctx, &conn, "QuerySingleJSON", cmd, out, args)
 	return firstError(err, p.release(&conn, err))
 }
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -147,9 +147,10 @@ func mockPool(opts Options) *Pool { // nolint:gocritic
 		retryOpts:      RetryOptions{},
 		cfg:            &connConfig{},
 		cacheCollection: cacheCollection{
-			typeIDCache:   &cache.Cache{},
-			inCodecCache:  &cache.Cache{},
-			outCodecCache: &cache.Cache{},
+			typeIDCache:       &cache.Cache{},
+			inCodecCache:      &cache.Cache{},
+			outCodecCache:     &cache.Cache{},
+			capabilitiesCache: &cache.Cache{},
 		},
 	}
 }

--- a/scriptflow.go
+++ b/scriptflow.go
@@ -30,6 +30,20 @@ func ignoreHeaders(r *buff.Reader) {
 	}
 }
 
+func decodeHeaders(r *buff.Reader) msgHeaders {
+	n := int(r.PopUint16())
+
+	headers := make(msgHeaders, n)
+	for i := 0; i < n; i++ {
+		key := r.PopUint16()
+		val := r.PopBytes()
+		headers[key] = make([]byte, len(val))
+		copy(headers[key], val)
+	}
+
+	return headers
+}
+
 func copyHeaders(h msgHeaders) msgHeaders {
 	cpy := make(msgHeaders, len(h))
 


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb-go/issues/158

Other minor changes:
- fixed bug in type ID caching. The key used to retrieve entries from the cache had different pieces of information from the key used to cache entries.
- fixed QueryOneJSON which was sending queries as format.Binary