### PR TITLE
Suggested pool concurrency as default max pool size

### DIFF
--- a/options.go
+++ b/options.go
@@ -87,9 +87,8 @@ type Options struct {
 	// to reestablish a connection.
 	WaitUntilAvailable time.Duration
 
-	// MinConns determines the minimum number of connections.
-	// If MinConns is zero, 1 will be used.
-	// Has no effect for single connections.
+	// MinConns has no effect.
+	// Deprecated: does nothing
 	MinConns uint
 
 	// MaxConns determines the maximum number of connections.


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb-go/issues/162

Use the server setting `suggested_pool_concurrency` as the default max concurrency if the user does not set the value explicitly.