### PR TITLE
Add Marshal/UnmarshalJSON methods for the optional string/number/bool types

### DIFF
--- a/internal/edgedbtypes/bool.go
+++ b/internal/edgedbtypes/bool.go
@@ -16,6 +16,10 @@
 
 package edgedbtypes
 
+import (
+	"encoding/json"
+)
+
 // OptionalBool is an optional bool. Optional types must be used for out
 // parameters when a shape field is not required.
 type OptionalBool struct {
@@ -36,4 +40,24 @@ func (o *OptionalBool) Set(val bool) {
 func (o *OptionalBool) Unset() {
 	o.val = false
 	o.isSet = false
+}
+
+func (optBool OptionalBool) MarshalJSON() ([]byte, error) {
+	if optBool.isSet {
+		return json.Marshal(optBool.val)
+	}
+	return json.Marshal(nil)
+}
+
+func (optBool *OptionalBool) UnmarshalJSON(bytes []byte) error {
+	if string(bytes) == "null" {
+		return nil
+	}
+
+	if err := json.Unmarshal(bytes, &optBool.val); err != nil {
+		return err
+	}
+	optBool.isSet = true
+
+	return nil
 }

--- a/internal/edgedbtypes/numbers.go
+++ b/internal/edgedbtypes/numbers.go
@@ -16,6 +16,10 @@
 
 package edgedbtypes
 
+import (
+	"encoding/json"
+)
+
 // Optional represents a shape field that is not required.
 type Optional struct {
 	isSet bool
@@ -50,6 +54,26 @@ func (o *OptionalInt16) Unset() {
 	o.isSet = false
 }
 
+func (optInt OptionalInt16) MarshalJSON() ([]byte, error) {
+	if optInt.isSet {
+		return json.Marshal(optInt.val)
+	}
+	return json.Marshal(nil)
+}
+
+func (optInt *OptionalInt16) UnmarshalJSON(bytes []byte) error {
+	if string(bytes) == "null" {
+		return nil
+	}
+
+	if err := json.Unmarshal(bytes, &optInt.val); err != nil {
+		return err
+	}
+	optInt.isSet = true
+
+	return nil
+}
+
 // OptionalInt32 is an optional int32. Optional types must be used for out
 // parameters when a shape field is not required.
 type OptionalInt32 struct {
@@ -70,6 +94,26 @@ func (o *OptionalInt32) Set(val int32) {
 func (o *OptionalInt32) Unset() {
 	o.val = 0
 	o.isSet = false
+}
+
+func (optInt OptionalInt32) MarshalJSON() ([]byte, error) {
+	if optInt.isSet {
+		return json.Marshal(optInt.val)
+	}
+	return json.Marshal(nil)
+}
+
+func (optInt *OptionalInt32) UnmarshalJSON(bytes []byte) error {
+	if string(bytes) == "null" {
+		return nil
+	}
+
+	if err := json.Unmarshal(bytes, &optInt.val); err != nil {
+		return err
+	}
+	optInt.isSet = true
+
+	return nil
 }
 
 // OptionalInt64 is an optional int64. Optional types must be used for out
@@ -96,6 +140,26 @@ func (o *OptionalInt64) Unset() *OptionalInt64 {
 	return o
 }
 
+func (optInt OptionalInt64) MarshalJSON() ([]byte, error) {
+	if optInt.isSet {
+		return json.Marshal(optInt.val)
+	}
+	return json.Marshal(nil)
+}
+
+func (optInt *OptionalInt64) UnmarshalJSON(bytes []byte) error {
+	if string(bytes) == "null" {
+		return nil
+	}
+
+	if err := json.Unmarshal(bytes, &optInt.val); err != nil {
+		return err
+	}
+	optInt.isSet = true
+
+	return nil
+}
+
 // OptionalFloat32 is an optional float32. Optional types must be used for out
 // parameters when a shape field is not required.
 type OptionalFloat32 struct {
@@ -118,6 +182,26 @@ func (o *OptionalFloat32) Unset() {
 	o.isSet = false
 }
 
+func (optFloat OptionalFloat32) MarshalJSON() ([]byte, error) {
+	if optFloat.isSet {
+		return json.Marshal(optFloat.val)
+	}
+	return json.Marshal(nil)
+}
+
+func (optFloat *OptionalFloat32) UnmarshalJSON(bytes []byte) error {
+	if string(bytes) == "null" {
+		return nil
+	}
+
+	if err := json.Unmarshal(bytes, &optFloat.val); err != nil {
+		return err
+	}
+	optFloat.isSet = true
+
+	return nil
+}
+
 // OptionalFloat64 is an optional float64. Optional types must be used for out
 // parameters when a shape field is not required.
 type OptionalFloat64 struct {
@@ -138,4 +222,24 @@ func (o *OptionalFloat64) Set(val float64) {
 func (o *OptionalFloat64) Unset() {
 	o.val = 0
 	o.isSet = false
+}
+
+func (optFloat OptionalFloat64) MarshalJSON() ([]byte, error) {
+	if optFloat.isSet {
+		return json.Marshal(optFloat.val)
+	}
+	return json.Marshal(nil)
+}
+
+func (optFloat *OptionalFloat64) UnmarshalJSON(bytes []byte) error {
+	if string(bytes) == "null" {
+		return nil
+	}
+
+	if err := json.Unmarshal(bytes, &optFloat.val); err != nil {
+		return err
+	}
+	optFloat.isSet = true
+
+	return nil
 }

--- a/internal/edgedbtypes/numerics.go
+++ b/internal/edgedbtypes/numerics.go
@@ -16,7 +16,10 @@
 
 package edgedbtypes
 
-import "math/big"
+import (
+	"encoding/json"
+	"math/big"
+)
 
 // OptionalBigInt is an optional *big.Int. Optional types must be used for out
 // parameters when a shape field is not required.
@@ -43,4 +46,24 @@ func (o *OptionalBigInt) Set(val *big.Int) {
 func (o *OptionalBigInt) Unset() {
 	o.val = nil
 	o.isSet = false
+}
+
+func (optBigint OptionalBigInt) MarshalJSON() ([]byte, error) {
+	if optBigint.isSet {
+		return json.Marshal(optBigint.val)
+	}
+	return json.Marshal(nil)
+}
+
+func (optBigint *OptionalBigInt) UnmarshalJSON(bytes []byte) error {
+	if string(bytes) == "null" {
+		return nil
+	}
+
+	if err := json.Unmarshal(bytes, &optBigint.val); err != nil {
+		return err
+	}
+	optBigint.isSet = true
+
+	return nil
 }

--- a/internal/edgedbtypes/str.go
+++ b/internal/edgedbtypes/str.go
@@ -16,6 +16,10 @@
 
 package edgedbtypes
 
+import (
+	"encoding/json"
+)
+
 // OptionalStr is an optional string. Optional types must be used for out
 // parameters when a shape field is not required.
 type OptionalStr struct {
@@ -36,4 +40,24 @@ func (o *OptionalStr) Set(val string) {
 func (o *OptionalStr) Unset() {
 	o.val = ""
 	o.isSet = false
+}
+
+func (optStr OptionalStr) MarshalJSON() ([]byte, error) {
+	if optStr.isSet {
+		return json.Marshal(optStr.val)
+	}
+	return json.Marshal(nil)
+}
+
+func (optStr *OptionalStr) UnmarshalJSON(bytes []byte) error {
+	if string(bytes) == "null" {
+		return nil
+	}
+
+	if err := json.Unmarshal(bytes, &optStr.val); err != nil {
+		return err
+	}
+	optStr.isSet = true
+
+	return nil
 }


### PR DESCRIPTION
Queries that return properties with one of the custom `edgedb.Optional*` types are encoded by `json.Marshal` as `{}` regardless of if they have a value or not. This PR adds `MarshalJSON` and `UnmarshalJSON` methods to the `OptionalBool`, `OptionalStr`, `OptionalInt*` and `OptionalFloat*` types to encode to the actual value if set, else `null`.

@fmoor Should we also have json marshalers for the datetime types, since they don't really have equivalent json types?