### PR TITLE
Enable QuerySingle(JSON) lower cardinality assertion

### DIFF
--- a/client.go
+++ b/client.go
@@ -327,7 +327,7 @@ func (p *Client) QueryJSON(
 func (p *Client) QuerySingleJSON(
 	ctx context.Context,
 	cmd string,
-	out *[]byte,
+	out interface{},
 	args ...interface{},
 ) error {
 	conn, err := p.acquire(ctx)

--- a/client_test.go
+++ b/client_test.go
@@ -133,3 +133,56 @@ func TestClientRetryingTx(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(693), result, "Client.RetryingTx() failed")
 }
+
+func TestQuerySingleMissingResult(t *testing.T) {
+	ctx := context.Background()
+
+	var result string
+	err := client.QuerySingle(ctx, "SELECT <str>{}", &result)
+	assert.EqualError(t, err, "edgedb.NoDataError: zero results")
+
+	optionalResult := NewOptionalStr("this should be set to missing")
+	err = client.QuerySingle(ctx, "SELECT <str>{}", &optionalResult)
+	assert.NoError(t, err)
+	assert.Equal(t, OptionalStr{}, optionalResult)
+
+	var objectResult struct {
+		Name string `edgedb:"name"`
+	}
+	err = client.QuerySingle(ctx,
+		"SELECT sys::Database { name } FILTER .name = 'does not exist'",
+		&objectResult,
+	)
+	assert.EqualError(t, err, "edgedb.NoDataError: zero results")
+
+	var optionalObjectResult struct {
+		Optional
+		Name string `edgedb:"name"`
+	}
+	optionalObjectResult.SetMissing(false)
+	err = client.QuerySingle(ctx,
+		"SELECT sys::Database { name } FILTER .name = 'does not exist'",
+		&optionalObjectResult,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "", optionalObjectResult.Name)
+	assert.True(t, optionalObjectResult.Missing())
+}
+
+func TestQuerySingleJSONMissingResult(t *testing.T) {
+	ctx := context.Background()
+
+	var result []byte
+	err := client.QuerySingleJSON(ctx, "SELECT <str>{}", &result)
+	assert.EqualError(t, err, "edgedb.NoDataError: zero results")
+
+	optionalResult := NewOptionalBytes([]byte("this should be set to missing"))
+	err = client.QuerySingleJSON(ctx, "SELECT <str>{}", &optionalResult)
+	assert.NoError(t, err)
+	assert.Equal(t, OptionalBytes{}, optionalResult)
+
+	var wrongType string
+	err = client.QuerySingleJSON(ctx, "SELECT <str>{}", &wrongType)
+	assert.EqualError(t, err, "edgedb.InterfaceError: "+
+		"the \"out\" argument must be *[]byte or *OptionalBytes, got *string")
+}

--- a/internal/edgedbtypes/numbers.go
+++ b/internal/edgedbtypes/numbers.go
@@ -32,6 +32,9 @@ func (o *Optional) Missing() bool { return !o.isSet }
 // means present.
 func (o *Optional) SetMissing(missing bool) { o.isSet = !missing }
 
+// Unset marks the value a missing
+func (o *Optional) Unset() { o.isSet = false }
+
 // OptionalInt16 is an optional int16. Optional types must be used for out
 // parameters when a shape field is not required.
 type OptionalInt16 struct {

--- a/query_test.go
+++ b/query_test.go
@@ -337,6 +337,6 @@ func TestQueryTimesOut(t *testing.T) {
 func TestNilResultValue(t *testing.T) {
 	ctx := context.Background()
 	err := client.Query(ctx, "SELECT 1", nil)
-	assert.EqualError(t, err,
+	assert.EqualError(t, err, "edgedb.InterfaceError: "+
 		"the \"out\" argument must be a pointer, got untyped nil")
 }

--- a/subtransaction.go
+++ b/subtransaction.go
@@ -163,7 +163,7 @@ func (t *Subtx) QueryJSON(
 func (t *Subtx) QuerySingleJSON(
 	ctx context.Context,
 	cmd string,
-	out *[]byte,
+	out interface{},
 	args ...interface{},
 ) error {
 	return runQuery(ctx, t, "QuerySingleJSON", cmd, out, args)

--- a/transactable.go
+++ b/transactable.go
@@ -74,7 +74,7 @@ func (c *transactableConn) QueryJSON(
 func (c *transactableConn) QuerySingleJSON(
 	ctx context.Context,
 	cmd string,
-	out *[]byte,
+	out interface{},
 	args ...interface{},
 ) error {
 	return runQuery(ctx, c, "QuerySingleJSON", cmd, out, args)

--- a/transaction.go
+++ b/transaction.go
@@ -206,7 +206,7 @@ func (t *Tx) QueryJSON(
 func (t *Tx) QuerySingleJSON(
 	ctx context.Context,
 	cmd string,
-	out *[]byte,
+	out interface{},
 	args ...interface{},
 ) error {
 	return runQuery(ctx, t, "QuerySingleJSON", cmd, out, args)


### PR DESCRIPTION
Make QuerySingle & QuerySingleJSON only return NoDataError on zero results if the out value's type is not an optional type.

fix https://github.com/edgedb/edgedb-go/issues/184