### PR TITLE
Add support for non-file variants of `tls_ca_file` and `credentials_file`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,14 +51,10 @@ jobs:
           server-version: ${{ matrix.edgedb-version }}
 
       - name: Test
-        env:
-          EDGEDB_SERVER_BIN: edgedb-server
         run: |
           make test
 
       - name: Exercise Benchmarks
-        env:
-          EDGEDB_SERVER_BIN: edgedb-server
         run: |
           # run micro benchmarks to be sure they still work
           make bench

--- a/connect_test.go
+++ b/connect_test.go
@@ -27,13 +27,12 @@ import (
 func TestAuth(t *testing.T) {
 	ctx := context.Background()
 	p, err := CreateClient(ctx, Options{
-		Host:        opts.Host,
-		Port:        opts.Port,
-		User:        "user_with_password",
-		Password:    NewOptionalStr("secret"),
-		Database:    opts.Database,
-		TLSCAFile:   opts.TLSCAFile,
-		TLSSecurity: opts.TLSSecurity,
+		Host:       opts.Host,
+		Port:       opts.Port,
+		User:       "user_with_password",
+		Password:   NewOptionalStr("secret"),
+		Database:   opts.Database,
+		TLSOptions: opts.TLSOptions,
 	})
 	require.NoError(t, err)
 

--- a/main_test.go
+++ b/main_test.go
@@ -106,7 +106,7 @@ func startServer() {
 
 	serverBin := os.Getenv("EDGEDB_SERVER_BIN")
 	if serverBin == "" {
-		log.Fatal("EDGEDB_SERVER_BIN not set")
+		serverBin = "edgedb-server"
 	}
 
 	dir, err := ioutil.TempDir("", "")
@@ -191,13 +191,15 @@ func startServer() {
 	}
 
 	opts = Options{
-		Host:        "127.0.0.1",
-		Port:        info.Port,
-		User:        "test",
-		Password:    NewOptionalStr("shhh"),
-		Database:    "edgedb",
-		TLSCAFile:   info.TLSCertFile,
-		TLSSecurity: "no_host_verification",
+		Host:     "127.0.0.1",
+		Port:     info.Port,
+		User:     "test",
+		Password: NewOptionalStr("shhh"),
+		Database: "edgedb",
+		TLSOptions: TLSOptions{
+			CAFile:       info.TLSCertFile,
+			SecurityMode: TLSModeNoHostVerification,
+		},
 	}
 
 	log.Print("server started")

--- a/options.go
+++ b/options.go
@@ -42,11 +42,18 @@ type Options struct {
 	// their defaults.
 	Port int
 
+	// Credentials is a JSON string containing connection credentials.
+	//
+	// Credentials cannot be specified alongside the 'dsn' argument, Host,
+	// Port, or CredentialsFile.  Credentials will override all other
+	// credentials not present in the credentials string with their defaults.
+	Credentials []byte
+
 	// CredentialsFile is a path to a file containing connection credentials.
 	//
 	// CredentialsFile cannot be specified alongside the 'dsn' argument, Host,
-	// or Port. CredentialsFile will override all other credentials not
-	// present in the credentials file with their defaults.
+	// Port, or Credentials.  CredentialsFile will override all other
+	// credentials not present in the credentials file with their defaults.
 	CredentialsFile string
 
 	// User is the name of the database role used for authentication.
@@ -85,15 +92,46 @@ type Options struct {
 	// Has no effect for single connections.
 	Concurrency uint
 
-	// Read the TLS certificate from this file
+	// Parameters used to configure TLS connections to EdgeDB server.
+	TLSOptions TLSOptions
+
+	// Read the TLS certificate from this file.
+	// DEPRECATED, use TLSOptions.CAFile instead.
 	TLSCAFile string
 
-	// If false don't verify the server's hostname when using TLS.
+	// Specifies how strict TLS validation is.
+	// DEPRECATED, use TLSOptions.SecurityMode instead.
 	TLSSecurity string
 
 	// ServerSettings is currently unused.
 	ServerSettings map[string][]byte
 }
+
+// TLSOptions contains the parameters needed to configure TLS on EdgeDB
+// server connections.
+type TLSOptions struct {
+	// PEM-encoded CA certificate
+	CA []byte
+	// Path to a PEM-encoded CA certificate file
+	CAFile string
+	// Determines how strict we are with TLS checks
+	SecurityMode TLSSecurityMode
+}
+
+// TLSSecurityMode specifies how strict TLS validation is.
+type TLSSecurityMode string
+
+const (
+	// TLSModeDefault makes security mode inferred from other options
+	TLSModeDefault TLSSecurityMode = "default"
+	// TLSModeInsecure results in no certificate verification whatsoever
+	TLSModeInsecure TLSSecurityMode = "insecure"
+	// TLSModeNoHostVerification enables certificate verification
+	// against CAs, but hostname matching is not performed.
+	TLSModeNoHostVerification TLSSecurityMode = "no_host_verification"
+	// TLSModeStrict enables full certificate and hostname verification.
+	TLSModeStrict TLSSecurityMode = "strict"
+)
 
 // RetryBackoff returns the duration to wait after the nth attempt
 // before making the next attempt when retrying a transaction.

--- a/tutorial_test.go
+++ b/tutorial_test.go
@@ -49,13 +49,12 @@ func TestTutorial(t *testing.T) {
 	edb, err := CreateClient(
 		ctx,
 		Options{
-			Host:        opts.Host,
-			Port:        opts.Port,
-			User:        opts.User,
-			Password:    opts.Password,
-			Database:    dbName,
-			TLSCAFile:   opts.TLSCAFile,
-			TLSSecurity: opts.TLSSecurity,
+			Host:       opts.Host,
+			Port:       opts.Port,
+			User:       opts.User,
+			Password:   opts.Password,
+			Database:   dbName,
+			TLSOptions: opts.TLSOptions,
 		},
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
The client now supports `tls_ca` and `credentials` as direct options.  Also
spell `tls_ca_file` correctly as `tls_ca_file` in DSNs and move TLS
configuration options to a sub-struct in connection `Options` to future-proof it
for the possible additions of more options.