### PR TITLE
Add support for `tls_ca` in `credentials.json`

### DIFF
--- a/connutils.go
+++ b/connutils.go
@@ -489,7 +489,7 @@ func (r *configResolver) applyCredentials(
 		r.setPassword(pwd, source)
 	}
 
-	if data, ok := creds.certData.Get(); ok && len(data) > 0 {
+	if data, ok := creds.ca.Get(); ok && len(data) > 0 {
 		r.setTLSCAData(data, source)
 	}
 


### PR DESCRIPTION
`tls_ca` replaces the deprecated `tls_cert_data` for consistency with
granular connection options.