### PR TITLE
Add support for traversing into structs using '$inline' struct tag

### DIFF
--- a/internal/introspect/marshal.go
+++ b/internal/introspect/marshal.go
@@ -24,8 +24,15 @@ import (
 func fieldByTag(t reflect.Type, name string) (reflect.StructField, bool) {
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
-		if field.Tag.Get("edgedb") == name {
+		switch field.Tag.Get("edgedb") {
+		case name:
 			return field, true
+		case "$inline":
+			if f, ok := fieldByTag(field.Type, name); ok {
+				// Accumulate offsets from nested paths.
+				f.Offset += field.Offset
+				return f, true
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi there!

Coming from mongodb/bson, I've adapted a pattern where I re-use field definitions for larger models by defining them once and composing them together using the `inline` tag. Like so:

<details>
<summary> Demo </summary>

---

This demo is informal and "Not a Submission.".

```go
# project
type CommonTreeFields struct {
	Id   primitive.ObjectID `json:"_id" bson:"_id"`
	Name string             `json:"name" bson:"name"`
}
type FileRef struct {
	CommonTreeFields `bson:"inline"`

	Created time.Time `json:"created" bson:"created"`
	Size    int64     `json:"size" bson:"size"`
}

# deletedFileRef
type DeletedAtField struct {
	DeletedAt time.Time `json:"deletedAt" bson:"deletedAt"`
}
type DeletedFileRef struct {
	project.FileRef `bson:"inline"`
	DeletedAtField  `bson:"inline"`
}
```

A `DeletedFileRef` has all the fields of a regular `FileRef` plus a timestamp. The bson package would fill in all the details from a map like this: `{ "_id": ..., "name": ..., "created": ..., "size": ..., "deletedAt": ... }`.

> From their docs: https://docs.mongodb.com/drivers/go/current/fundamentals/bson/#struct-tags
> If the field type is a struct or map field, the field will be flattened when marshalling and unflattened when unmarshalling.

---

</details>

I really like that pattern and would like to continue using it with edgedb.

Let me know what you think!

Edit: Per the discussion below, the keyword in edgedb will be `$inline` to avoid potential conflicts with other identifiers.
Is there a good place for documenting `$inline` as a special keyword?