### PR TITLE
fix nil-ptr-deref caused by overwriting reconnectingConn.conn with nil

### DIFF
--- a/reconnect.go
+++ b/reconnect.go
@@ -45,7 +45,7 @@ type reconnectingConn struct {
 func (c *reconnectingConn) reconnect(
 	ctx context.Context,
 	single bool,
-) (err error) {
+) error {
 	if c.isClosed {
 		return &interfaceError{msg: "Connection is closed"}
 	}
@@ -57,9 +57,12 @@ func (c *reconnectingConn) reconnect(
 
 	var edbErr Error
 	for {
-		c.conn, err = connectWithTimeout(ctx, c.cfg, c.cacheCollection)
-		if err == nil ||
-			single ||
+		conn, err := connectWithTimeout(ctx, c.cfg, c.cacheCollection)
+		if err == nil {
+			c.conn = conn
+			return nil
+		}
+		if single ||
 			errors.Is(err, context.Canceled) ||
 			errors.Is(err, context.DeadlineExceeded) ||
 			!errors.As(err, &edbErr) ||


### PR DESCRIPTION
Plenty of places are accessing `reconnectingConn.conn` directly, without copying it first and doing a `nil` check on it. A failing reconnect attempt is currently setting the `.conn` pointer to `nil`, making all these direct access call-sites panic from the nil pointer de-reference.

This PR is storing the new `.conn` value locally and only overwriting `reconnectingConn.conn` on the happy path.