### PR TITLE
refactor usage of panic: Only direct coding errors may trigger panics

### DIFF
--- a/error.go
+++ b/error.go
@@ -85,13 +85,13 @@ func positionFromHeaders(headers map[uint16]string) (position, bool, error) {
 	lineNo, err := strconv.Atoi(lineNoRaw)
 	if err != nil {
 		return position{}, false, &binaryProtocolError{
-			msg: fmt.Sprintf("decode lineNo: %q: %s", lineNoRaw, err.Error()),
+			err: fmt.Errorf("decode lineNo: %q: %w", lineNoRaw, err),
 		}
 	}
 	byteNo, err := strconv.Atoi(byteNoRaw)
 	if err != nil {
 		return position{}, false, &binaryProtocolError{
-			msg: fmt.Sprintf("decode byteNo: %q: %s", byteNoRaw, err.Error()),
+			err: fmt.Errorf("decode byteNo: %q: %w", byteNoRaw, err),
 		}
 	}
 

--- a/error.go
+++ b/error.go
@@ -66,34 +66,34 @@ const (
 	lineStart     = 0xfff3
 )
 
-func atoiOrPanic(s string) int {
-	i, err := strconv.Atoi(s)
-	if err != nil {
-		panic(err)
-	}
-
-	return i
-}
-
 type position struct {
 	lineNo int
 	byteNo int
 }
 
 func positionFromHeaders(headers map[uint16]string) (position, bool) {
-	lineNo, ok := headers[lineStart]
+	lineNoRaw, ok := headers[lineStart]
 	if !ok {
 		return position{}, false
 	}
 
-	byteNo, ok := headers[positionStart]
+	byteNoRaw, ok := headers[positionStart]
 	if !ok {
+		return position{}, false
+	}
+
+	lineNo, err := strconv.Atoi(lineNoRaw)
+	if err != nil {
+		return position{}, false
+	}
+	byteNo, err := strconv.Atoi(byteNoRaw)
+	if err != nil {
 		return position{}, false
 	}
 
 	return position{
-		lineNo: atoiOrPanic(lineNo) - 1,
-		byteNo: atoiOrPanic(byteNo),
+		lineNo: lineNo - 1,
+		byteNo: byteNo,
 	}, true
 }
 

--- a/generatederrors.go
+++ b/generatederrors.go
@@ -3470,6 +3470,8 @@ func errorFromCode(code uint32, msg string) error {
 	case 0xff_03_00_00:
 		return &noDataError{msg: msg}
 	default:
-		panic(fmt.Sprintf("invalid error code 0x%x", code))
+		return &unexpectedMessageError{
+			msg: fmt.Sprintf("invalid error code 0x%x", code),
+		}
 	}
 }

--- a/generatederrors.go
+++ b/generatederrors.go
@@ -3471,7 +3471,9 @@ func errorFromCode(code uint32, msg string) error {
 		return &noDataError{msg: msg}
 	default:
 		return &unexpectedMessageError{
-			msg: fmt.Sprintf("invalid error code 0x%x", code),
+			msg: fmt.Sprintf(
+				"invalid error code 0x%x with message %q", code, msg,
+			),
 		}
 	}
 }

--- a/internal/buff/read.go
+++ b/internal/buff/read.go
@@ -52,8 +52,6 @@ func SimpleReader(buf []byte) *Reader {
 //
 // Callers must continue to call Next until it returns false.
 //
-// If the previous message was not fully read Next() panics.
-//
 // Next() panics if called on a reader created with SimpleReader().
 func (r *Reader) Next(doneReadingSignal chan struct{}) bool {
 	if r.toBeDeserialized == nil {
@@ -61,10 +59,11 @@ func (r *Reader) Next(doneReadingSignal chan struct{}) bool {
 	}
 
 	if len(r.Buf) > 0 {
-		panic(fmt.Sprintf(
+		r.Err = fmt.Errorf(
 			"cannot finish: unread data in buffer (message type: 0x%x)",
 			r.MsgType,
-		))
+		)
+		return false
 	}
 
 	if r.data != nil && len(r.data.Buf) == 0 {

--- a/internal/buff/read_test.go
+++ b/internal/buff/read_test.go
@@ -19,10 +19,11 @@ package buff
 import (
 	"testing"
 
-	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
-	"github.com/edgedb/edgedb-go/internal/soc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	types "github.com/edgedb/edgedb-go/internal/edgedbtypes"
+	"github.com/edgedb/edgedb-go/internal/soc"
 )
 
 func TestNext(t *testing.T) {
@@ -34,7 +35,8 @@ func TestNext(t *testing.T) {
 	assert.Equal(t, uint8(0xa), r.MsgType)
 
 	expected := "cannot finish: unread data in buffer (message type: 0xa)"
-	assert.PanicsWithValue(t, expected, func() { r.Next(nil) })
+	assert.False(t, r.Next(nil))
+	assert.Equal(t, expected, r.Err.Error())
 
 	assert.Equal(t, uint32(0x1020304), r.PopUint32())
 	assert.Panics(t, func() { r.Discard(1) })

--- a/internal/buff/read_test.go
+++ b/internal/buff/read_test.go
@@ -36,7 +36,7 @@ func TestNext(t *testing.T) {
 
 	expected := "cannot finish: unread data in buffer (message type: 0xa)"
 	assert.False(t, r.Next(nil))
-	assert.Equal(t, expected, r.Err.Error())
+	assert.EqualError(t, r.Err, expected)
 
 	assert.Equal(t, uint32(0x1020304), r.PopUint32())
 	assert.Panics(t, func() { r.Discard(1) })

--- a/internal/cmd/generr/main.go
+++ b/internal/cmd/generr/main.go
@@ -121,7 +121,9 @@ func errorFromCode(code uint32, msg string) error {
 	}
 	code := `
 	default:
-		panic(fmt.Sprintf("invalid error code 0x%x", code))
+		return &unexpectedMessageError{
+			msg: fmt.Sprintf("invalid error code 0x%x", code),
+		}
 	}
 }`
 	fmt.Print(code)

--- a/internal/cmd/generr/main.go
+++ b/internal/cmd/generr/main.go
@@ -122,7 +122,9 @@ func errorFromCode(code uint32, msg string) error {
 	code := `
 	default:
 		return &unexpectedMessageError{
-			msg: fmt.Sprintf("invalid error code 0x%x", code),
+			msg: fmt.Sprintf(
+				"invalid error code 0x%x with message %q", code, msg,
+			),
 		}
 	}
 }`

--- a/options.go
+++ b/options.go
@@ -255,7 +255,9 @@ func (o RetryOptions) ruleForException(err Error) (RetryRule, error) {
 	case err.Category(ClientError):
 		return o.network, nil
 	default:
-		return RetryRule{}, fmt.Errorf("unexpected error type: %T", err)
+		return RetryRule{}, &clientError{
+			msg: fmt.Sprintf("unexpected error type: %T", err),
+		}
 	}
 }
 

--- a/transactable.go
+++ b/transactable.go
@@ -109,7 +109,10 @@ func (c *transactableConn) granularFlow(
 			errors.As(err, &edbErr) &&
 			edbErr.HasTag(ShouldRetry) &&
 			(capabilities == 0 || edbErr.Category(TransactionConflictError)) {
-			rule := c.retryOpts.ruleForException(edbErr)
+			rule, e := c.retryOpts.ruleForException(edbErr)
+			if e != nil {
+				return e
+			}
 
 			if i >= rule.attempts {
 				return err
@@ -179,7 +182,10 @@ func (c *transactableConn) Tx(
 
 	Error:
 		if errors.As(err, &edbErr) && edbErr.HasTag(ShouldRetry) {
-			rule := c.retryOpts.ruleForException(edbErr)
+			rule, e := c.retryOpts.ruleForException(edbErr)
+			if e != nil {
+				return e
+			}
 
 			if i >= rule.attempts {
 				return err


### PR DESCRIPTION
panic-ing is kind of a bad practice in Golang as it requires all levels of goroutines to `recover` them. This is especially tricky when libraries (incl. edgedb-go) create them.

Instead of panic-ing it is better to just return an error or fail-safe.

This PR is refactoring all the direct `panic` invocations that are potentially reachable at runtime from unexpected server messages (e.g. unknown error message code, which tripped me up big) or other kinds of _harmless_ situations (missing flush of Buffer, unexpected error passed to retry rule).

Here is a break down of all the panics left un-touched:

<details>

## Test (setup)

```
./main_test.go-46-
./main_test.go-47-func executeOrPanic(command string) {
./main_test.go-48-      ctx := context.Background()
./main_test.go-49-      err := client.Execute(ctx, command)
./main_test.go-50-      if err != nil {
./main_test.go:51:              panic(err)
./main_test.go-52-      }
./main_test.go-53-}
./main_test.go-54-
./main_test.go-55-type serverInfo struct {
./main_test.go-56-      TLSCertFile string `json:"tls_cert_file"`
--
./main_test.go-209-
./main_test.go-210-     ctx := context.Background()
./main_test.go-211-     log.Println("connecting")
./main_test.go-212-     client, err = CreateClient(ctx, opts)
./main_test.go-213-     if err != nil {
./main_test.go:214:             panic(err)
./main_test.go-215-     }
./main_test.go-216-     log.Println("connected")
./main_test.go-217-
./main_test.go-218-     defer client.Close() // nolint:errcheck
./main_test.go-219-     err = client.Execute(ctx,
./main_test.go-220-             "configure instance set session_idle_timeout := <duration>'1s'")
./main_test.go-221-     if err != nil {
./main_test.go:222:             panic(err)
./main_test.go-223-     }
./main_test.go-224-     conn, err := client.acquire(ctx)
./main_test.go-225-     if err != nil {
./main_test.go:226:             panic(err)
./main_test.go-227-     }
./main_test.go-228-     protocolVersion = conn.conn.protocolVersion
./main_test.go-229-     err = client.release(conn, nil)
./main_test.go-230-     if err != nil {
./main_test.go:231:             panic(err)
./main_test.go-232-     }
./main_test.go-233-
./main_test.go-234-     log.Println("running migration")
./main_test.go-235-     executeOrPanic(`
./main_test.go-236-                     START MIGRATION TO {
--
./connutils_test.go-53-func setenv(key, val string) func() {
./connutils_test.go-54- old, ok := os.LookupEnv(key)
./connutils_test.go-55-
./connutils_test.go-56- err := os.Setenv(key, val)
./connutils_test.go-57- if err != nil {
./connutils_test.go:58:         panic(err)
./connutils_test.go-59- }
./connutils_test.go-60-
./connutils_test.go-61- if ok {
./connutils_test.go-62-         return func() {
./connutils_test.go-63-                 err = os.Setenv(key, old)
./connutils_test.go-64-                 if err != nil {
./connutils_test.go:65:                         panic(err)
./connutils_test.go-66-                 }
./connutils_test.go-67-         }
./connutils_test.go-68- }
./connutils_test.go-69-
./connutils_test.go-70- return func() {
./connutils_test.go-71-         err = os.Unsetenv(key)
./connutils_test.go-72-         if err != nil {
./connutils_test.go:73:                 panic(err)
./connutils_test.go-74-         }
./connutils_test.go-75- }
./connutils_test.go-76-}
./connutils_test.go-77-
./connutils_test.go-78-func newServerSettingValues(settings map[string][]byte) *snc.ServerSettings {
```

## Coding error that should throw on first (mis-)use.
```
./internal/soc/mempool.go-47-}
./internal/soc/mempool.go-48-
./internal/soc/mempool.go-49-// Release returns ownership of a slab to the pool.
./internal/soc/mempool.go-50-func (p *MemPool) Release(buf []byte) {
./internal/soc/mempool.go-51-   if len(buf) != p.slabSize {
./internal/soc/mempool.go:52:           panic("unexpected buffer len. " +
./internal/soc/mempool.go-53-                   "The buffer probably doesn't belong in this pool")
./internal/soc/mempool.go-54-   }
./internal/soc/mempool.go-55-
./internal/soc/mempool.go-56-   select {
./internal/soc/mempool.go-57-   case p.freeMemory <- buf:
```

## Sequence of protocol message composition, all internal and hard-coded.

```
./internal/buff/write.go-35-}
./internal/buff/write.go-36-
./internal/buff/write.go-37-// Unwrap returns the underlying []byte.
./internal/buff/write.go-38-func (w *Writer) Unwrap() []byte {
./internal/buff/write.go-39-    if w.msgPos != 0 {
./internal/buff/write.go:40:            panic("cannot send: the previous message is not finished")
./internal/buff/write.go-41-    }
./internal/buff/write.go-42-
./internal/buff/write.go-43-    if len(w.buf) == 0 {
./internal/buff/write.go:44:            panic("cannot send: no data")
./internal/buff/write.go-45-    }
./internal/buff/write.go-46-
./internal/buff/write.go-47-    buf := w.buf
./internal/buff/write.go-48-    w.buf = nil
./internal/buff/write.go-49-    return buf
--
./internal/buff/write.go-93-
./internal/buff/write.go-94-// BeginBytes allocates space for `data_length` in the buffer.
./internal/buff/write.go-95-// May be called multiple times to create nested bytes blocks.
./internal/buff/write.go-96-// Calling EndBytes once for each BeginBytes call is required
./internal/buff/write.go-97-// before ending a message.
./internal/buff/write.go:98:// BeginBytes panics if BeginMessage was not called first.
./internal/buff/write.go-99-func (w *Writer) BeginBytes() {
./internal/buff/write.go-100-   if w.msgPos == 0 {
./internal/buff/write.go:101:           panic("cannot begin bytes: no current message")
./internal/buff/write.go-102-   }
./internal/buff/write.go-103-
./internal/buff/write.go-104-   n := len(w.buf)
./internal/buff/write.go-105-   w.buf = append(w.buf, 0, 0, 0, 0)
./internal/buff/write.go-106-   w.bytePos = append(w.bytePos, n)
./internal/buff/write.go-107-}
./internal/buff/write.go-108-
./internal/buff/write.go-109-// EndBytes sets the `data_length` allocated by BeginBytes
./internal/buff/write.go-110-// to the number of bytes that were written since the last BeginBytes call.
./internal/buff/write.go:111:// EndBytes panics if BeginBytes was not called first.
./internal/buff/write.go-112-func (w *Writer) EndBytes() {
./internal/buff/write.go-113-   n := len(w.bytePos)
./internal/buff/write.go-114-   if n < 1 {
./internal/buff/write.go:115:           panic("cannot end bytes: no bytes in progress")
./internal/buff/write.go-116-   }
./internal/buff/write.go-117-
./internal/buff/write.go-118-   pos := w.bytePos[n-1]
./internal/buff/write.go-119-   w.bytePos = w.bytePos[:n-1]
./internal/buff/write.go-120-
--
./internal/buff/write.go-122-   binary.BigEndian.PutUint32(w.buf[pos:], byteLen)
./internal/buff/write.go-123-}
./internal/buff/write.go-124-
./internal/buff/write.go-125-// BeginMessage writes mType to the buffer
./internal/buff/write.go-126-// and allocates space for message length.
./internal/buff/write.go:127:// BeginMessage panics if the EndMessage was not called
./internal/buff/write.go-128-// for the previous message.
./internal/buff/write.go-129-func (w *Writer) BeginMessage(mType uint8) {
./internal/buff/write.go-130-   if w.msgPos != 0 {
./internal/buff/write.go:131:           panic("cannot begin message: the previous message is not finished")
./internal/buff/write.go-132-   }
./internal/buff/write.go-133-
./internal/buff/write.go-134-   w.msgPos = 1 + len(w.buf)
./internal/buff/write.go-135-   w.buf = append(w.buf, mType, 0, 0, 0, 0)
./internal/buff/write.go-136-}
./internal/buff/write.go-137-
./internal/buff/write.go-138-// EndMessage sets the `message_length` allocated by BeginMessage.
./internal/buff/write.go:139:// EndMessage panics if BeginMessage was not called first
./internal/buff/write.go-140-// or if BeginBytes was not followed by EndBytes.
./internal/buff/write.go-141-func (w *Writer) EndMessage() {
./internal/buff/write.go-142-   if w.msgPos == 0 {
./internal/buff/write.go:143:           panic("cannot end message: no current message")
./internal/buff/write.go-144-   }
./internal/buff/write.go-145-
./internal/buff/write.go-146-   if len(w.bytePos) != 0 {
./internal/buff/write.go:147:           panic("cannot end message: bytes in progress")
./internal/buff/write.go-148-   }
./internal/buff/write.go-149-
./internal/buff/write.go-150-   msgLen := uint32(len(w.buf) - w.msgPos)
./internal/buff/write.go-151-   binary.BigEndian.PutUint32(w.buf[w.msgPos:], msgLen)
./internal/buff/write.go-152-   w.msgPos = 0
```

## Coding error from using `SimpleReader(...).Next(...)`

It is unlikely that someone gets surprised here as it always panics.

```
./internal/buff/read.go-50-// and a signal is received on doneReadingSignal,
./internal/buff/read.go-51-// or an error is encountered while reading.
./internal/buff/read.go-52-//
./internal/buff/read.go-53-// Callers must continue to call Next until it returns false.
./internal/buff/read.go-54-//
./internal/buff/read.go:55:// Next() panics if called on a reader created with SimpleReader().
./internal/buff/read.go-56-func (r *Reader) Next(doneReadingSignal chan struct{}) bool {
./internal/buff/read.go-57-     if r.toBeDeserialized == nil {
./internal/buff/read.go:58:             panic("called next on a simple reader")
./internal/buff/read.go-59-     }
./internal/buff/read.go-60-
./internal/buff/read.go-61-     if len(r.Buf) > 0 {
./internal/buff/read.go-62-             r.Err = fmt.Errorf(
./internal/buff/read.go-63-                     "cannot finish: unread data in buffer (message type: 0x%x)",
```

## `NewLocalTime` would need a signature change to make it _safe_.
```
./internal/edgedbtypes/datetime.go-254-}
./internal/edgedbtypes/datetime.go-255-
./internal/edgedbtypes/datetime.go-256-// NewLocalTime returns a new LocalTime
./internal/edgedbtypes/datetime.go-257-func NewLocalTime(hour, minute, second, microsecond int) LocalTime {
./internal/edgedbtypes/datetime.go-258- if hour < 0 || hour > 23 {
./internal/edgedbtypes/datetime.go:259:         panic("hour out of range 0-23")
./internal/edgedbtypes/datetime.go-260- }
./internal/edgedbtypes/datetime.go-261-
./internal/edgedbtypes/datetime.go-262- if minute < 0 || minute > 59 {
./internal/edgedbtypes/datetime.go:263:         panic("minute out of range 0-59")
./internal/edgedbtypes/datetime.go-264- }
./internal/edgedbtypes/datetime.go-265-
./internal/edgedbtypes/datetime.go-266- if second < 0 || second > 59 {
./internal/edgedbtypes/datetime.go:267:         panic("second out of range 0-59")
./internal/edgedbtypes/datetime.go-268- }
./internal/edgedbtypes/datetime.go-269-
./internal/edgedbtypes/datetime.go-270- if microsecond < 0 || microsecond > 999_999 {
./internal/edgedbtypes/datetime.go:271:         panic("microsecond out of range 0-999_999")
./internal/edgedbtypes/datetime.go-272- }
./internal/edgedbtypes/datetime.go-273-
./internal/edgedbtypes/datetime.go-274- t := time.Date(
./internal/edgedbtypes/datetime.go-275-         1970, 1, 1, hour, minute, second, microsecond*1_000, time.UTC,
./internal/edgedbtypes/datetime.go-276- )
```

## Client setup that likely runs at boot-time and is likely coding error.

```
./options.go-185-}
./options.go-186-
./options.go-187-// WithAttempts sets the rule's attempts. attempts must be greater than zero.
./options.go-188-func (r RetryRule) WithAttempts(attempts int) RetryRule {
./options.go-189-       if attempts < 1 {
./options.go:190:               panic(fmt.Sprintf(
./options.go-191-                       "RetryRule attempts must be greater than 0, got %v",
./options.go-192-                       attempts,
./options.go-193-               ))
./options.go-194-       }
./options.go-195-
--
./options.go-198-}
./options.go-199-
./options.go-200-// WithBackoff returns a copy of the RetryRule with backoff set to fn.
./options.go-201-func (r RetryRule) WithBackoff(fn RetryBackoff) RetryRule {
./options.go-202-       if fn == nil {
./options.go:203:               panic("the backoff function must not be nil")
./options.go-204-       }
./options.go-205-
./options.go-206-       r.backoff = fn
./options.go-207-       return r
./options.go-208-}
--
./options.go-217-}
./options.go-218-
./options.go-219-// WithDefault sets the rule for all conditions to rule.
./options.go-220-func (o RetryOptions) WithDefault(rule RetryRule) RetryOptions { // nolint:gocritic,lll
./options.go-221-       if !rule.fromFactory {
./options.go:222:               panic("RetryRule not created with NewRetryRule() is not valid")
./options.go-223-       }
./options.go-224-
./options.go-225-       o.txConflict = rule
./options.go-226-       o.network = rule
./options.go-227-       return o
--
./options.go-231-func (o RetryOptions) WithCondition( // nolint:gocritic
./options.go-232-       condition RetryCondition,
./options.go-233-       rule RetryRule,
./options.go-234-) RetryOptions {
./options.go-235-       if !rule.fromFactory {
./options.go:236:               panic("RetryRule not created with NewRetryRule() is not valid")
./options.go-237-       }
./options.go-238-
./options.go-239-       switch condition {
./options.go-240-       case TxConflict:
./options.go-241-               o.txConflict = rule
./options.go-242-       case NetworkError:
./options.go-243-               o.network = rule
./options.go-244-       default:
./options.go:245:               panic(fmt.Sprintf("unexpected condition: %v", condition))
./options.go-246-       }
./options.go-247-
./options.go-248-       return o
./options.go-249-}
./options.go-250-
--
./options.go-291-
./options.go-292-// WithIsolation returns a copy of the TxOptions
./options.go-293-// with the isolation level set to i.
./options.go-294-func (o TxOptions) WithIsolation(i IsolationLevel) TxOptions {
./options.go-295-       if i != Serializable {
./options.go:296:               panic(fmt.Sprintf("unknown isolation level: %q", i))
./options.go-297-       }
./options.go-298-
./options.go-299-       o.isolation = i
./options.go-300-       return o
./options.go-301-}
--
./options.go-342-
./options.go-343-// WithTxOptions returns a shallow copy of the client
./options.go-344-// with the TxOptions set to opts.
./options.go-345-func (p Client) WithTxOptions(opts TxOptions) *Client { // nolint:gocritic
./options.go-346-       if !opts.fromFactory {
./options.go:347:               panic("TxOptions not created with NewTxOptions() are not valid")
./options.go-348-       }
./options.go-349-
./options.go-350-       p.txOpts = opts
./options.go-351-       return &p
./options.go-352-}
--
./options.go-355-// with the RetryOptions set to opts.
./options.go-356-func (p Client) WithRetryOptions( // nolint:gocritic
./options.go-357-       opts RetryOptions,
./options.go-358-) *Client {
./options.go-359-       if !opts.fromFactory {
./options.go:360:               panic("RetryOptions not created with NewRetryOptions() are not valid")
./options.go-361-       }
./options.go-362-
./options.go-363-       p.retryOpts = opts
./options.go-364-       return &p
./options.go-365-}
```

## Guard for impossible value of `TxOptions.isolation`

We are already checking that the options were composed via the factory and
 the factory is protecting against invalid values. Potentially we could just
 drop the default/panic case?
```
./options.go-319-
./options.go-320-       switch o.isolation {
./options.go-321-       case Serializable:
./options.go-322-               query += " ISOLATION SERIALIZABLE"
./options.go-323-       default:
./options.go:324:               panic(fmt.Sprintf("unknown isolation level: %q", o.isolation))
./options.go-325-       }
./options.go-326-
./options.go-327-       if o.readOnly {
./options.go-328-               query += ", READ ONLY"
./options.go-329-       } else {
```
</details>