### PR TITLE
Minor tweaks to tests

### DIFF
--- a/connutils_test.go
+++ b/connutils_test.go
@@ -722,12 +722,13 @@ func TestConnectInvalidName(t *testing.T) {
 		"wrong error: %v",
 		err,
 	)
-	assert.EqualError(
-		t,
-		err,
+	// Match lookup error agnostic to OS. Examples:
+	// dial tcp: lookup invalid.example.org: no such host
+	// dial tcp: lookup invalid.example.org on 127.0.0.1:53: no such host
+	assert.Contains(t, err.Error(),
 		"edgedb.ClientConnectionFailedTemporarilyError: "+
-			"dial tcp: lookup invalid.example.org: no such host",
-	)
+			"dial tcp: lookup invalid.example.org")
+	assert.Contains(t, err.Error(), "no such host")
 
 	var errNotFound *net.DNSError
 	assert.True(t, errors.As(err, &errNotFound))

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -158,8 +158,6 @@ func TestTxKinds(t *testing.T) {
 	}
 }
 
-var ctx = context.Background()
-
 // Transactions can be executed using the Tx() method. Note that queries are
 // executed on the Tx object. Queries executed on the client in a transaction
 // callback will not run in the transaction and will be applied immediately. In
@@ -168,6 +166,7 @@ var ctx = context.Background()
 // configured with TxOptions and the retrying behavior can be configured with
 // RetryOptions.
 func ExampleTx() {
+	ctx := context.Background()
 	err := client.Tx(ctx, func(ctx context.Context, tx *Tx) error {
 		return tx.Execute(ctx, "INSERT User { name := 'Don' }")
 	})


### PR DESCRIPTION
On my Linux host with a local DNS resolver process, the error message for a failed DNS lookup includes the address of the resolver. This is turn is breaking one of the integration tests that matches the full error message. I've split the matching of the error message into two parts.

Another small tweak is for a global `ctx` variable that is shadowing the local `ctx` in all the tests -- something that my IDE does not like.