### PR TITLE
Add support for connecting via unix sockets

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -124,7 +124,9 @@ func (c *protocolConnection) connect(r *buff.Reader, cfg *connConfig) error {
 	}
 
 	_, isTLS := c.soc.conn.(*tls.Conn)
-	if !isTLS && c.protocolVersion.GTE(protocolVersion0p11) {
+	if !isTLS &&
+		c.soc.conn.RemoteAddr().Network() != "unix" &&
+		c.protocolVersion.GTE(protocolVersion0p11) {
 		_ = c.soc.Close()
 		return &clientConnectionError{msg: fmt.Sprintf(
 			"server claims to use protocol version %v.%v without using TLS",

--- a/sock.go
+++ b/sock.go
@@ -34,16 +34,24 @@ func connectAutoClosingSocket(
 		defer cancel()
 	}
 
-	conn, err := connectTLS(ctx, cfg)
-	if err != nil {
-		if isTLSError(err) {
+	var conn net.Conn
+	var err error
+	if cfg.addr.network == "unix" {
+		if conn, err = connectNet(ctx, cfg.addr); err != nil {
 			return nil, err
 		}
+	} else {
+		conn, err = connectTLS(ctx, cfg)
+		if err != nil {
+			if isTLSError(err) {
+				return nil, err
+			}
 
-		var e error
-		conn, e = connectNet(ctx, cfg.addr)
-		if e != nil {
-			return nil, err
+			var e error
+			conn, e = connectNet(ctx, cfg.addr)
+			if e != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
I'm running edgedb in a docker container for my local dev-env. The rootless docker network stack is a little bit too slow for my taste. Getting a connection via a unix socket going was pretty straight forward.

The shared integration test cases include client options for unsupported unix sockets. I've skipped these cases for the Golang client.

Side note: switching the tests to use a unix socket is simple too (d2dfed9b975f27f306a6bad45f15b27060998c94), but the speedup is minimal (about 5%, 71s vs 75s).