### PR TITLE
Cache type ids immediately after reading them

### DIFF
--- a/granularflow.go
+++ b/granularflow.go
@@ -184,7 +184,6 @@ func (c *protocolConnection) prepare(r *buff.Reader, q *gfQuery) error {
 
 	var (
 		err error
-		ids idPair
 	)
 
 	done := buff.NewSignal()
@@ -193,8 +192,9 @@ func (c *protocolConnection) prepare(r *buff.Reader, q *gfQuery) error {
 		switch r.MsgType {
 		case message.PrepareComplete:
 			c.cacheCapabilities(q, decodeHeaders(r))
-			r.Discard(1) // cardianlity
-			ids = idPair{in: [16]byte(r.PopUUID()), out: [16]byte(r.PopUUID())}
+			r.Discard(1) // cardinality
+			ids := idPair{in: r.PopUUID(), out: r.PopUUID()}
+			c.cacheTypeIDs(q, ids)
 		case message.ReadyForCommand:
 			decodeReadyForCommandMsg(r)
 			done.Signal()
@@ -211,9 +211,6 @@ func (c *protocolConnection) prepare(r *buff.Reader, q *gfQuery) error {
 	if r.Err != nil {
 		return r.Err
 	}
-
-	c.cacheTypeIDs(q, ids)
-
 	return err
 }
 


### PR DESCRIPTION
On first glance it looked like this could yield empty `idPair`s. It required a few more reads (including the buff.Reader code) to understand that the loop cannot exit with `r.Err == nil` when the server did not sent all the messages yet -- with one remaining assumption: the server always sends `PrepareComplete` ahead of `ReadyForCommand`.

I think its simpler to just move the cache call right next to the population of the `idPair` :slightly_smiling_face: . WDYT?

_Side note: I've also fixed the typo in `cardinality` and dropped useless copying of already copied UUID bytes._