### PR TITLE
Skip inaccessible files/folders when generating

### DIFF
--- a/cmd/edgeql-go/main.go
+++ b/cmd/edgeql-go/main.go
@@ -33,6 +33,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -163,6 +164,9 @@ func queueFilesInBackground() chan string {
 			root,
 			func(f string, d fs.DirEntry, e error) error {
 				if e != nil {
+					if errors.Is(e, syscall.EACCES) {
+						return nil
+					}
 					return e
 				}
 


### PR DESCRIPTION
When we don't have permission to read a file/folder in the project tree skip it instead of failing.