### PR TITLE
Add named result types to generated code

### DIFF
--- a/cmd/edgeql-go/main.go
+++ b/cmd/edgeql-go/main.go
@@ -43,8 +43,6 @@ import (
 )
 
 var (
-	typeGen = Generator{typeNameLookup: make(map[lookupKey]Type)}
-
 	//go:embed templates/*.template
 	templates embed.FS
 )
@@ -200,7 +198,7 @@ func writeGoFile(
 
 	var imports []string
 	for _, q := range queries {
-		imports = append(imports, q.Imports()...)
+		imports = append(imports, q.imports...)
 	}
 
 	var buf bytes.Buffer

--- a/cmd/edgeql-go/templates/file.template
+++ b/cmd/edgeql-go/templates/file.template
@@ -3,10 +3,14 @@
 package {{.PackageName}}
 
 import (
-	"context"{{range .ExtraImports}}
-	"{{.}}"{{end}}
+	"context"
+	{{- range .ExtraImports}}
+	"{{.}}"
+	{{- end}}
 	_ "embed"
 
 	"github.com/edgedb/edgedb-go"
 )
-{{range .Queries}}{{template "query.template" .}}{{end}}
+{{range .Queries}}
+{{template "query.template" .}}
+{{- end}}

--- a/cmd/edgeql-go/templates/query.template
+++ b/cmd/edgeql-go/templates/query.template
@@ -1,20 +1,33 @@
-
 //go:embed {{.QueryFile}}
 var {{.CMDVarName}} string
+
+{{- range .ResultTypes}}
+
+{{template "struct.template" .}}
+{{- end}}
 
 // {{.QueryName}}
 // runs the query found in
 // {{.QueryFile}}
 func {{.QueryName}}(
 	ctx context.Context, 
-	client *edgedb.Client,{{.SignatureArgs}}
-) ({{.ResultType}}, error) {
-	var result {{.ResultType}}
+	client *edgedb.Client,
+	{{- range .SignatureArgs}}
+	{{.Name}} {{.Type}},
+	{{- end}}
+) ({{.SignatureReturnType}}, error) {
+	var result {{.SignatureReturnType}}
 
 	err := client.{{.Method}}(
 		ctx, 
 		{{.CMDVarName}}, 
-		&result,{{.ArgList}}
+		&result,
+		{{- if .SignatureArgs}}
+		map[string]interface{}{
+			{{- range .SignatureArgs}}
+			{{printf "%q" .Name}}: {{.Name}},
+			{{- end}}
+		},{{end}}
 	)
 
 	return result, err
@@ -26,14 +39,23 @@ func {{.QueryName}}(
 // returning the results as json encoded bytes
 func {{.QueryName}}JSON(
 	ctx context.Context,
-	client *edgedb.Client,{{.SignatureArgs}}
+	client *edgedb.Client,
+	{{- range .SignatureArgs}}
+	{{.Name}} {{.Type}},
+	{{- end}}
 ) ([]byte, error) {
 	var result []byte
 
 	err := client.{{.Method}}JSON(
 		ctx,
 		{{.CMDVarName}},
-		&result,{{.ArgList}}
+		&result,
+		{{- if .SignatureArgs}}
+		map[string]interface{}{
+			{{- range .SignatureArgs}}
+			{{printf "%q" .Name}}: {{.Name}},
+			{{- end}}
+		},{{end}}
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/edgeql-go/templates/struct.template
+++ b/cmd/edgeql-go/templates/struct.template
@@ -1,0 +1,6 @@
+// {{.Name}}
+// is part of the return type for
+// {{.QueryFuncName}}()
+type {{.Name}} struct {
+{{range .Fields}}    {{.Name}} {{.Type}} `edgedb:"{{.Name}}"`
+{{end}}}

--- a/cmd/edgeql-go/testdata/test-project2/object/select_link_prop_edgeql.go.assert
+++ b/cmd/edgeql-go/testdata/test-project2/object/select_link_prop_edgeql.go.assert
@@ -12,26 +12,30 @@ import (
 //go:embed select_link_prop.edgeql
 var selectLinkPropCmd string
 
+// selectLinkPropResult
+// is part of the return type for
+// selectLinkProp()
+type selectLinkPropResult struct {
+	Name    string                            `edgedb:"Name"`
+	Friends []selectLinkPropResultFriendsItem `edgedb:"Friends"`
+}
+
+// selectLinkPropResultFriendsItem
+// is part of the return type for
+// selectLinkProp()
+type selectLinkPropResultFriendsItem struct {
+	Name     string                 `edgedb:"Name"`
+	Strength edgedb.OptionalFloat64 `edgedb:"Strength"`
+}
+
 // selectLinkProp
 // runs the query found in
 // select_link_prop.edgeql
 func selectLinkProp(
 	ctx context.Context,
 	client *edgedb.Client,
-) ([]struct {
-	Name    string `edgedb:"Name"`
-	Friends []struct {
-		Name     string                 `edgedb:"Name"`
-		Strength edgedb.OptionalFloat64 `edgedb:"Strength"`
-	} `edgedb:"Friends"`
-}, error) {
-	var result []struct {
-		Name    string `edgedb:"Name"`
-		Friends []struct {
-			Name     string                 `edgedb:"Name"`
-			Strength edgedb.OptionalFloat64 `edgedb:"Strength"`
-		} `edgedb:"Friends"`
-	}
+) ([]selectLinkPropResult, error) {
+	var result []selectLinkPropResult
 
 	err := client.Query(
 		ctx,

--- a/cmd/edgeql-go/testdata/test-project2/object/select_object_edgeql.go.assert
+++ b/cmd/edgeql-go/testdata/test-project2/object/select_object_edgeql.go.assert
@@ -12,28 +12,31 @@ import (
 //go:embed select_object.edgeql
 var selectObjectCmd string
 
+// selectObjectResult
+// is part of the return type for
+// selectObject()
+type selectObjectResult struct {
+	Name     string                         `edgedb:"Name"`
+	Language string                         `edgedb:"Language"`
+	Params   []selectObjectResultParamsItem `edgedb:"Params"`
+}
+
+// selectObjectResultParamsItem
+// is part of the return type for
+// selectObject()
+type selectObjectResultParamsItem struct {
+	Name    string             `edgedb:"Name"`
+	Default edgedb.OptionalStr `edgedb:"Default"`
+}
+
 // selectObject
 // runs the query found in
 // select_object.edgeql
 func selectObject(
 	ctx context.Context,
 	client *edgedb.Client,
-) (struct {
-	Name     string `edgedb:"Name"`
-	Language string `edgedb:"Language"`
-	Params   []struct {
-		Name    string             `edgedb:"Name"`
-		Default edgedb.OptionalStr `edgedb:"Default"`
-	} `edgedb:"Params"`
-}, error) {
-	var result struct {
-		Name     string `edgedb:"Name"`
-		Language string `edgedb:"Language"`
-		Params   []struct {
-			Name    string             `edgedb:"Name"`
-			Default edgedb.OptionalStr `edgedb:"Default"`
-		} `edgedb:"Params"`
-	}
+) (selectObjectResult, error) {
+	var result selectObjectResult
 
 	err := client.QuerySingle(
 		ctx,

--- a/cmd/edgeql-go/testdata/test-project2/object/select_objects_edgeql.go.assert
+++ b/cmd/edgeql-go/testdata/test-project2/object/select_objects_edgeql.go.assert
@@ -12,28 +12,31 @@ import (
 //go:embed select_objects.edgeql
 var selectObjectsCmd string
 
+// selectObjectsResult
+// is part of the return type for
+// selectObjects()
+type selectObjectsResult struct {
+	Name     string                          `edgedb:"Name"`
+	Language string                          `edgedb:"Language"`
+	Params   []selectObjectsResultParamsItem `edgedb:"Params"`
+}
+
+// selectObjectsResultParamsItem
+// is part of the return type for
+// selectObjects()
+type selectObjectsResultParamsItem struct {
+	Name    string             `edgedb:"Name"`
+	Default edgedb.OptionalStr `edgedb:"Default"`
+}
+
 // selectObjects
 // runs the query found in
 // select_objects.edgeql
 func selectObjects(
 	ctx context.Context,
 	client *edgedb.Client,
-) ([]struct {
-	Name     string `edgedb:"Name"`
-	Language string `edgedb:"Language"`
-	Params   []struct {
-		Name    string             `edgedb:"Name"`
-		Default edgedb.OptionalStr `edgedb:"Default"`
-	} `edgedb:"Params"`
-}, error) {
-	var result []struct {
-		Name     string `edgedb:"Name"`
-		Language string `edgedb:"Language"`
-		Params   []struct {
-			Name    string             `edgedb:"Name"`
-			Default edgedb.OptionalStr `edgedb:"Default"`
-		} `edgedb:"Params"`
-	}
+) ([]selectObjectsResult, error) {
+	var result []selectObjectsResult
 
 	err := client.Query(
 		ctx,

--- a/cmd/edgeql-go/testdata/test-project2/when_no_go_files_in_dir_dir_name_becomes_package_name/select_args_edgeql.go.assert
+++ b/cmd/edgeql-go/testdata/test-project2/when_no_go_files_in_dir_dir_name_becomes_package_name/select_args_edgeql.go.assert
@@ -13,6 +13,14 @@ import (
 //go:embed select_args.edgeql
 var selectArgsCmd string
 
+// selectArgsResult
+// is part of the return type for
+// selectArgs()
+type selectArgsResult struct {
+	Str      string    `edgedb:"Str"`
+	DateTime time.Time `edgedb:"DateTime"`
+}
+
 // selectArgs
 // runs the query found in
 // select_args.edgeql
@@ -21,14 +29,8 @@ func selectArgs(
 	client *edgedb.Client,
 	str string,
 	datetime time.Time,
-) (struct {
-	Str      string    `edgedb:"Str"`
-	DateTime time.Time `edgedb:"DateTime"`
-}, error) {
-	var result struct {
-		Str      string    `edgedb:"Str"`
-		DateTime time.Time `edgedb:"DateTime"`
-	}
+) (selectArgsResult, error) {
+	var result selectArgsResult
 
 	err := client.QuerySingle(
 		ctx,

--- a/cmd/edgeql-go/testdata/test-project2/when_no_go_files_in_dir_dir_name_becomes_package_name/subpkg/my_query_edgeql.go.assert
+++ b/cmd/edgeql-go/testdata/test-project2/when_no_go_files_in_dir_dir_name_becomes_package_name/subpkg/my_query_edgeql.go.assert
@@ -14,6 +14,66 @@ import (
 //go:embed my_query.edgeql
 var myQueryCmd string
 
+// myQueryResult
+// is part of the return type for
+// myQuery()
+type myQueryResult struct {
+	a  edgedb.UUID                       `edgedb:"a"`
+	b  edgedb.OptionalUUID               `edgedb:"b"`
+	c  string                            `edgedb:"c"`
+	d  edgedb.OptionalStr                `edgedb:"d"`
+	e  []byte                            `edgedb:"e"`
+	f  edgedb.OptionalBytes              `edgedb:"f"`
+	g  int16                             `edgedb:"g"`
+	h  edgedb.OptionalInt16              `edgedb:"h"`
+	i  int32                             `edgedb:"i"`
+	j  edgedb.OptionalInt32              `edgedb:"j"`
+	k  int64                             `edgedb:"k"`
+	l  edgedb.OptionalInt64              `edgedb:"l"`
+	m  float32                           `edgedb:"m"`
+	n  edgedb.OptionalFloat32            `edgedb:"n"`
+	o  float64                           `edgedb:"o"`
+	p  edgedb.OptionalFloat64            `edgedb:"p"`
+	q  bool                              `edgedb:"q"`
+	r  edgedb.OptionalBool               `edgedb:"r"`
+	s  time.Time                         `edgedb:"s"`
+	t  edgedb.OptionalDateTime           `edgedb:"t"`
+	u  edgedb.LocalDateTime              `edgedb:"u"`
+	v  edgedb.OptionalLocalDateTime      `edgedb:"v"`
+	w  edgedb.LocalDate                  `edgedb:"w"`
+	x  edgedb.OptionalLocalDate          `edgedb:"x"`
+	y  edgedb.LocalTime                  `edgedb:"y"`
+	z  edgedb.OptionalLocalTime          `edgedb:"z"`
+	aa edgedb.Duration                   `edgedb:"aa"`
+	ab edgedb.OptionalDuration           `edgedb:"ab"`
+	ac *big.Int                          `edgedb:"ac"`
+	ad edgedb.OptionalBigInt             `edgedb:"ad"`
+	ae edgedb.RelativeDuration           `edgedb:"ae"`
+	af edgedb.OptionalRelativeDuration   `edgedb:"af"`
+	ag edgedb.DateDuration               `edgedb:"ag"`
+	ah edgedb.OptionalDateDuration       `edgedb:"ah"`
+	ai edgedb.Memory                     `edgedb:"ai"`
+	aj edgedb.OptionalMemory             `edgedb:"aj"`
+	ak edgedb.RangeInt32                 `edgedb:"ak"`
+	al edgedb.OptionalRangeInt32         `edgedb:"al"`
+	am edgedb.RangeInt64                 `edgedb:"am"`
+	an edgedb.OptionalRangeInt64         `edgedb:"an"`
+	ao edgedb.RangeFloat32               `edgedb:"ao"`
+	ap edgedb.OptionalRangeFloat32       `edgedb:"ap"`
+	aq edgedb.RangeFloat64               `edgedb:"aq"`
+	ar edgedb.OptionalRangeFloat64       `edgedb:"ar"`
+	as edgedb.RangeDateTime              `edgedb:"as"`
+	at edgedb.OptionalRangeDateTime      `edgedb:"at"`
+	au edgedb.RangeLocalDateTime         `edgedb:"au"`
+	av edgedb.OptionalRangeLocalDateTime `edgedb:"av"`
+	aw edgedb.RangeLocalDate             `edgedb:"aw"`
+	ax edgedb.OptionalRangeLocalDate     `edgedb:"ax"`
+	ay int64                             `edgedb:"ay"`
+	az edgedb.OptionalInt64              `edgedb:"az"`
+	ba string                            `edgedb:"ba"`
+	bb edgedb.OptionalStr                `edgedb:"bb"`
+}
+
 // myQuery
 // runs the query found in
 // my_query.edgeql
@@ -56,132 +116,22 @@ func myQuery(
 	ah edgedb.OptionalDateDuration,
 	ai edgedb.Memory,
 	aj edgedb.OptionalMemory,
-	ak edgedb.OptionalRangeInt32,
-	al edgedb.RangeInt32,
-	am edgedb.OptionalRangeInt64,
-	an edgedb.RangeInt64,
-	ao edgedb.OptionalRangeFloat32,
-	ap edgedb.RangeFloat32,
-	aq edgedb.OptionalRangeFloat64,
-	ar edgedb.RangeFloat64,
-	as edgedb.OptionalRangeDateTime,
-	at edgedb.RangeDateTime,
-	au edgedb.OptionalRangeLocalDateTime,
-	av edgedb.RangeLocalDateTime,
-	aw edgedb.OptionalRangeLocalDate,
-	ax edgedb.RangeLocalDate,
-) (struct {
-	a  edgedb.UUID                       `edgedb:"a"`
-	b  edgedb.OptionalUUID               `edgedb:"b"`
-	c  string                            `edgedb:"c"`
-	d  edgedb.OptionalStr                `edgedb:"d"`
-	e  []byte                            `edgedb:"e"`
-	f  edgedb.OptionalBytes              `edgedb:"f"`
-	g  int16                             `edgedb:"g"`
-	h  edgedb.OptionalInt16              `edgedb:"h"`
-	i  int32                             `edgedb:"i"`
-	j  edgedb.OptionalInt32              `edgedb:"j"`
-	k  int64                             `edgedb:"k"`
-	l  edgedb.OptionalInt64              `edgedb:"l"`
-	m  float32                           `edgedb:"m"`
-	n  edgedb.OptionalFloat32            `edgedb:"n"`
-	o  float64                           `edgedb:"o"`
-	p  edgedb.OptionalFloat64            `edgedb:"p"`
-	q  bool                              `edgedb:"q"`
-	r  edgedb.OptionalBool               `edgedb:"r"`
-	s  time.Time                         `edgedb:"s"`
-	t  edgedb.OptionalDateTime           `edgedb:"t"`
-	u  edgedb.LocalDateTime              `edgedb:"u"`
-	v  edgedb.OptionalLocalDateTime      `edgedb:"v"`
-	w  edgedb.LocalDate                  `edgedb:"w"`
-	x  edgedb.OptionalLocalDate          `edgedb:"x"`
-	y  edgedb.LocalTime                  `edgedb:"y"`
-	z  edgedb.OptionalLocalTime          `edgedb:"z"`
-	aa edgedb.Duration                   `edgedb:"aa"`
-	ab edgedb.OptionalDuration           `edgedb:"ab"`
-	ac *big.Int                          `edgedb:"ac"`
-	ad edgedb.OptionalBigInt             `edgedb:"ad"`
-	ae edgedb.RelativeDuration           `edgedb:"ae"`
-	af edgedb.OptionalRelativeDuration   `edgedb:"af"`
-	ag edgedb.DateDuration               `edgedb:"ag"`
-	ah edgedb.OptionalDateDuration       `edgedb:"ah"`
-	ai edgedb.Memory                     `edgedb:"ai"`
-	aj edgedb.OptionalMemory             `edgedb:"aj"`
-	ak edgedb.OptionalRangeInt32         `edgedb:"ak"`
-	al edgedb.RangeInt32                 `edgedb:"al"`
-	am edgedb.OptionalRangeInt64         `edgedb:"am"`
-	an edgedb.RangeInt64                 `edgedb:"an"`
-	ao edgedb.OptionalRangeFloat32       `edgedb:"ao"`
-	ap edgedb.RangeFloat32               `edgedb:"ap"`
-	aq edgedb.OptionalRangeFloat64       `edgedb:"aq"`
-	ar edgedb.RangeFloat64               `edgedb:"ar"`
-	as edgedb.OptionalRangeDateTime      `edgedb:"as"`
-	at edgedb.RangeDateTime              `edgedb:"at"`
-	au edgedb.OptionalRangeLocalDateTime `edgedb:"au"`
-	av edgedb.RangeLocalDateTime         `edgedb:"av"`
-	aw edgedb.OptionalRangeLocalDate     `edgedb:"aw"`
-	ax edgedb.RangeLocalDate             `edgedb:"ax"`
-	ay int64                             `edgedb:"ay"`
-	az edgedb.OptionalInt64              `edgedb:"az"`
-	ba string                            `edgedb:"ba"`
-	bb edgedb.OptionalStr                `edgedb:"bb"`
-}, error) {
-	var result struct {
-		a  edgedb.UUID                       `edgedb:"a"`
-		b  edgedb.OptionalUUID               `edgedb:"b"`
-		c  string                            `edgedb:"c"`
-		d  edgedb.OptionalStr                `edgedb:"d"`
-		e  []byte                            `edgedb:"e"`
-		f  edgedb.OptionalBytes              `edgedb:"f"`
-		g  int16                             `edgedb:"g"`
-		h  edgedb.OptionalInt16              `edgedb:"h"`
-		i  int32                             `edgedb:"i"`
-		j  edgedb.OptionalInt32              `edgedb:"j"`
-		k  int64                             `edgedb:"k"`
-		l  edgedb.OptionalInt64              `edgedb:"l"`
-		m  float32                           `edgedb:"m"`
-		n  edgedb.OptionalFloat32            `edgedb:"n"`
-		o  float64                           `edgedb:"o"`
-		p  edgedb.OptionalFloat64            `edgedb:"p"`
-		q  bool                              `edgedb:"q"`
-		r  edgedb.OptionalBool               `edgedb:"r"`
-		s  time.Time                         `edgedb:"s"`
-		t  edgedb.OptionalDateTime           `edgedb:"t"`
-		u  edgedb.LocalDateTime              `edgedb:"u"`
-		v  edgedb.OptionalLocalDateTime      `edgedb:"v"`
-		w  edgedb.LocalDate                  `edgedb:"w"`
-		x  edgedb.OptionalLocalDate          `edgedb:"x"`
-		y  edgedb.LocalTime                  `edgedb:"y"`
-		z  edgedb.OptionalLocalTime          `edgedb:"z"`
-		aa edgedb.Duration                   `edgedb:"aa"`
-		ab edgedb.OptionalDuration           `edgedb:"ab"`
-		ac *big.Int                          `edgedb:"ac"`
-		ad edgedb.OptionalBigInt             `edgedb:"ad"`
-		ae edgedb.RelativeDuration           `edgedb:"ae"`
-		af edgedb.OptionalRelativeDuration   `edgedb:"af"`
-		ag edgedb.DateDuration               `edgedb:"ag"`
-		ah edgedb.OptionalDateDuration       `edgedb:"ah"`
-		ai edgedb.Memory                     `edgedb:"ai"`
-		aj edgedb.OptionalMemory             `edgedb:"aj"`
-		ak edgedb.OptionalRangeInt32         `edgedb:"ak"`
-		al edgedb.RangeInt32                 `edgedb:"al"`
-		am edgedb.OptionalRangeInt64         `edgedb:"am"`
-		an edgedb.RangeInt64                 `edgedb:"an"`
-		ao edgedb.OptionalRangeFloat32       `edgedb:"ao"`
-		ap edgedb.RangeFloat32               `edgedb:"ap"`
-		aq edgedb.OptionalRangeFloat64       `edgedb:"aq"`
-		ar edgedb.RangeFloat64               `edgedb:"ar"`
-		as edgedb.OptionalRangeDateTime      `edgedb:"as"`
-		at edgedb.RangeDateTime              `edgedb:"at"`
-		au edgedb.OptionalRangeLocalDateTime `edgedb:"au"`
-		av edgedb.RangeLocalDateTime         `edgedb:"av"`
-		aw edgedb.OptionalRangeLocalDate     `edgedb:"aw"`
-		ax edgedb.RangeLocalDate             `edgedb:"ax"`
-		ay int64                             `edgedb:"ay"`
-		az edgedb.OptionalInt64              `edgedb:"az"`
-		ba string                            `edgedb:"ba"`
-		bb edgedb.OptionalStr                `edgedb:"bb"`
-	}
+	ak edgedb.RangeInt32,
+	al edgedb.OptionalRangeInt32,
+	am edgedb.RangeInt64,
+	an edgedb.OptionalRangeInt64,
+	ao edgedb.RangeFloat32,
+	ap edgedb.OptionalRangeFloat32,
+	aq edgedb.RangeFloat64,
+	ar edgedb.OptionalRangeFloat64,
+	as edgedb.RangeDateTime,
+	at edgedb.OptionalRangeDateTime,
+	au edgedb.RangeLocalDateTime,
+	av edgedb.OptionalRangeLocalDateTime,
+	aw edgedb.RangeLocalDate,
+	ax edgedb.OptionalRangeLocalDate,
+) (myQueryResult, error) {
+	var result myQueryResult
 
 	err := client.QuerySingle(
 		ctx,
@@ -287,20 +237,20 @@ func myQueryJSON(
 	ah edgedb.OptionalDateDuration,
 	ai edgedb.Memory,
 	aj edgedb.OptionalMemory,
-	ak edgedb.OptionalRangeInt32,
-	al edgedb.RangeInt32,
-	am edgedb.OptionalRangeInt64,
-	an edgedb.RangeInt64,
-	ao edgedb.OptionalRangeFloat32,
-	ap edgedb.RangeFloat32,
-	aq edgedb.OptionalRangeFloat64,
-	ar edgedb.RangeFloat64,
-	as edgedb.OptionalRangeDateTime,
-	at edgedb.RangeDateTime,
-	au edgedb.OptionalRangeLocalDateTime,
-	av edgedb.RangeLocalDateTime,
-	aw edgedb.OptionalRangeLocalDate,
-	ax edgedb.RangeLocalDate,
+	ak edgedb.RangeInt32,
+	al edgedb.OptionalRangeInt32,
+	am edgedb.RangeInt64,
+	an edgedb.OptionalRangeInt64,
+	ao edgedb.RangeFloat32,
+	ap edgedb.OptionalRangeFloat32,
+	aq edgedb.RangeFloat64,
+	ar edgedb.OptionalRangeFloat64,
+	as edgedb.RangeDateTime,
+	at edgedb.OptionalRangeDateTime,
+	au edgedb.RangeLocalDateTime,
+	av edgedb.OptionalRangeLocalDateTime,
+	aw edgedb.RangeLocalDate,
+	ax edgedb.OptionalRangeLocalDate,
 ) ([]byte, error) {
 	var result []byte
 

--- a/cmd/edgeql-go/types.go
+++ b/cmd/edgeql-go/types.go
@@ -1,0 +1,60 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// Query is used in templates/Query.template
+type Query struct {
+	QueryFile           string
+	QueryName           string
+	CMDVarName          string
+	ResultTypes         []*goStruct
+	SignatureReturnType string
+	SignatureArgs       []goStructField
+	Method              string
+
+	imports []string
+}
+
+type goType interface {
+	// Reference is the name used to refer to the type.
+	Reference() string
+}
+
+type goScalar struct {
+	Name string
+}
+
+func (t *goScalar) Reference() string { return t.Name }
+
+type goSlice struct {
+	typ goType
+}
+
+func (t *goSlice) Reference() string { return "[]" + t.typ.Reference() }
+
+type goStructField struct {
+	Name string
+	Type string
+}
+
+type goStruct struct {
+	Name          string
+	QueryFuncName string
+	Fields        []goStructField
+}
+
+func (t *goStruct) Reference() string { return t.Name }


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb-go/issues/244

This also fixes a bug where generated range types had the wrong "optionality".