### PR TITLE
Correct connection pooling accounting

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -244,6 +244,7 @@ func (p *Client) release(conn *transactableConn, err error) error {
 				connChan <- conn
 			case <-time.After(timeout):
 				connChan <- nil
+				p.potentialConns <- struct{}{}
 				if e := conn.Close(); e != nil {
 					log.Println("error while closing idle connection:", e)
 				}


### PR DESCRIPTION
fixes https://github.com/edgedb/edgedb-go/issues/259

This fixes a connection pooling bug that would permanently remove a connection from the pool if it's idle timeout expired. This effectively reduced the pools concurrency by one every time an idle timeout was reached.