### PR TITLE
Improve no toml found because of fs boundary error

### DIFF
--- a/internal/client/connutils.go
+++ b/internal/client/connutils.go
@@ -1359,7 +1359,7 @@ func findEdgeDBTOML(paths *cfgPaths) (string, error) {
 
 			// Stop searching at file system boundaries.
 			if pDev != dev {
-				if err == nil {
+				if err == nil { // nolint:govet
 					err = errNoTOMLFound
 				}
 				return "", fmt.Errorf("%w: stopped searching for edgedb.toml "+

--- a/internal/client/connutils.go
+++ b/internal/client/connutils.go
@@ -1359,6 +1359,9 @@ func findEdgeDBTOML(paths *cfgPaths) (string, error) {
 
 			// Stop searching at file system boundaries.
 			if pDev != dev {
+				if err == nil {
+					err = errNoTOMLFound
+				}
 				return "", fmt.Errorf("%w: stopped searching for edgedb.toml "+
 					"at file system boundary %q", err, dir)
 			}


### PR DESCRIPTION
The old error said
```
%!w(<nil>): stopped searching for edgedb.toml at file system boundary "/home/fmoor"
```

The new error says
```
no edgedb.toml found: stopped searching for edgedb.toml at file system boundary "/home/fmoor"
```