### PR TITLE
Attempt to make CI more reliable

### DIFF
--- a/internal/client/testserver.go
+++ b/internal/client/testserver.go
@@ -197,6 +197,7 @@ func initOptions(info serverInfo) {
 			CAFile:       info.TLSCertFile,
 			SecurityMode: TLSModeNoHostVerification,
 		},
+		WaitUntilAvailable: 2 * time.Minute,
 	}
 }
 


### PR DESCRIPTION
The test suite frequently fails on Github because of network errors. Maybe trying a little longer will help.