### PR TITLE
Use edgedb.Optional in generated optional structs

### DIFF
--- a/cmd/edgeql-go/gen.go
+++ b/cmd/edgeql-go/gen.go
@@ -185,7 +185,7 @@ func generateSlice(
 ) ([]goType, []string, error) {
 	types, imports, err := generateType(
 		desc.Fields[0].Desc,
-		desc.Fields[0].Required,
+		true,
 		path,
 		mixedCaps,
 	)
@@ -204,7 +204,7 @@ func generateSliceV2(
 ) ([]goType, []string, error) {
 	types, imports, err := generateTypeV2(
 		&desc.Fields[0].Desc,
-		desc.Fields[0].Required,
+		true,
 		path,
 		mixedCaps,
 	)
@@ -223,7 +223,7 @@ func generateObject(
 	mixedCaps bool,
 ) ([]goType, []string, error) {
 	var imports []string
-	typ := goStruct{Name: nameFromPath(path)}
+	typ := goStruct{Name: nameFromPath(path), Required: required}
 	types := []goType{&typ}
 
 	for _, field := range desc.Fields {
@@ -258,12 +258,12 @@ func generateObject(
 
 func generateObjectV2(
 	desc *descriptor.V2,
-	_ bool,
+	required bool,
 	path []string,
 	mixedCaps bool,
 ) ([]goType, []string, error) {
 	var imports []string
-	typ := goStruct{Name: nameFromPath(path)}
+	typ := goStruct{Name: nameFromPath(path), Required: required}
 	types := []goType{&typ}
 
 	for _, field := range desc.Fields {
@@ -303,7 +303,7 @@ func generateTuple(
 	mixedCaps bool,
 ) ([]goType, []string, error) {
 	var imports []string
-	typ := &goStruct{Name: nameFromPath(path)}
+	typ := &goStruct{Name: nameFromPath(path), Required: required}
 	types := []goType{typ}
 
 	for _, field := range desc.Fields {
@@ -339,12 +339,12 @@ func generateTuple(
 
 func generateTupleV2(
 	desc *descriptor.V2,
-	_ bool,
+	required bool,
 	path []string,
 	mixedCaps bool,
 ) ([]goType, []string, error) {
 	var imports []string
-	typ := &goStruct{Name: nameFromPath(path)}
+	typ := &goStruct{Name: nameFromPath(path), Required: required}
 	types := []goType{typ}
 
 	for _, field := range desc.Fields {

--- a/cmd/edgeql-go/templates/struct.template
+++ b/cmd/edgeql-go/templates/struct.template
@@ -2,5 +2,8 @@
 // is part of the return type for
 // {{.QueryFuncName}}()
 type {{.Name}} struct {
+{{- if not .Required}}
+edgedb.Optional
+{{- end}}
 {{range .Fields}}    {{.GoName}} {{.Type}} `{{.Tag}}`
 {{end}}}

--- a/cmd/edgeql-go/testdata/mixedcaps/test-project2/object/select_object_edgeql.go.assert
+++ b/cmd/edgeql-go/testdata/mixedcaps/test-project2/object/select_object_edgeql.go.assert
@@ -16,6 +16,7 @@ var selectObjectCmd string
 // is part of the return type for
 // selectObject()
 type selectObjectResult struct {
+	edgedb.Optional
 	Name     string                         `edgedb:"Name"`
 	Language string                         `edgedb:"Language"`
 	Params   []selectObjectResultParamsItem `edgedb:"Params"`

--- a/cmd/edgeql-go/testdata/mixedcaps/test-project2/scalar/select_array_edgeql.go.assert
+++ b/cmd/edgeql-go/testdata/mixedcaps/test-project2/scalar/select_array_edgeql.go.assert
@@ -18,8 +18,8 @@ var selectArrayCmd string
 func selectArray(
 	ctx context.Context,
 	client *edgedb.Client,
-) ([]edgedb.OptionalStr, error) {
-	var result []edgedb.OptionalStr
+) ([]string, error) {
+	var result []string
 
 	err := client.QuerySingle(
 		ctx,

--- a/cmd/edgeql-go/testdata/mixedcaps/test-project2/scalar/select_scalars_edgeql.go.assert
+++ b/cmd/edgeql-go/testdata/mixedcaps/test-project2/scalar/select_scalars_edgeql.go.assert
@@ -18,8 +18,8 @@ var selectScalarsCmd string
 func selectScalars(
 	ctx context.Context,
 	client *edgedb.Client,
-) ([]edgedb.OptionalMemory, error) {
-	var result []edgedb.OptionalMemory
+) ([]edgedb.Memory, error) {
+	var result []edgedb.Memory
 
 	err := client.Query(
 		ctx,

--- a/cmd/edgeql-go/testdata/mixedcaps/test-project2/tuple/select_tuple_edgeql.go.assert
+++ b/cmd/edgeql-go/testdata/mixedcaps/test-project2/tuple/select_tuple_edgeql.go.assert
@@ -25,6 +25,7 @@ type selectTupleResult struct {
 // is part of the return type for
 // selectTuple()
 type selectTupleResult2Item struct {
+	edgedb.Optional
 	Element0 edgedb.OptionalStr   `edgedb:"0"`
 	Element1 edgedb.OptionalInt64 `edgedb:"1"`
 }

--- a/cmd/edgeql-go/testdata/no-args/test-project2/object/select_object_edgeql.go.assert
+++ b/cmd/edgeql-go/testdata/no-args/test-project2/object/select_object_edgeql.go.assert
@@ -16,6 +16,7 @@ var selectObjectCmd string
 // is part of the return type for
 // selectObject()
 type selectObjectResult struct {
+	edgedb.Optional
 	Name     string                         `edgedb:"Name"`
 	Language string                         `edgedb:"Language"`
 	Params   []selectObjectResultParamsItem `edgedb:"Params"`

--- a/cmd/edgeql-go/testdata/no-args/test-project2/scalar/select_array_edgeql.go.assert
+++ b/cmd/edgeql-go/testdata/no-args/test-project2/scalar/select_array_edgeql.go.assert
@@ -18,8 +18,8 @@ var selectArrayCmd string
 func selectArray(
 	ctx context.Context,
 	client *edgedb.Client,
-) ([]edgedb.OptionalStr, error) {
-	var result []edgedb.OptionalStr
+) ([]string, error) {
+	var result []string
 
 	err := client.QuerySingle(
 		ctx,

--- a/cmd/edgeql-go/testdata/no-args/test-project2/scalar/select_scalars_edgeql.go.assert
+++ b/cmd/edgeql-go/testdata/no-args/test-project2/scalar/select_scalars_edgeql.go.assert
@@ -18,8 +18,8 @@ var selectScalarsCmd string
 func selectScalars(
 	ctx context.Context,
 	client *edgedb.Client,
-) ([]edgedb.OptionalMemory, error) {
-	var result []edgedb.OptionalMemory
+) ([]edgedb.Memory, error) {
+	var result []edgedb.Memory
 
 	err := client.Query(
 		ctx,

--- a/cmd/edgeql-go/testdata/no-args/test-project2/tuple/select_tuple_edgeql.go.assert
+++ b/cmd/edgeql-go/testdata/no-args/test-project2/tuple/select_tuple_edgeql.go.assert
@@ -25,6 +25,7 @@ type selectTupleResult struct {
 // is part of the return type for
 // selectTuple()
 type selectTupleResult2Item struct {
+	edgedb.Optional
 	Element0 edgedb.OptionalStr   `edgedb:"0"`
 	Element1 edgedb.OptionalInt64 `edgedb:"1"`
 }

--- a/cmd/edgeql-go/types.go
+++ b/cmd/edgeql-go/types.go
@@ -57,6 +57,7 @@ type goStruct struct {
 	Name          string
 	QueryFuncName string
 	Fields        []goStructField
+	Required      bool
 }
 
 func (t *goStruct) Reference() string { return t.Name }


### PR DESCRIPTION
This fixes a bug in the generator that didn't make optional structs optional.

Also, for generated code, this makes values in slices never be their optional variant.