### PR TITLE
Expose a common interface between Client and Tx

### DIFF
--- a/export.go
+++ b/export.go
@@ -71,6 +71,10 @@ type (
 	// ErrorTag is the argument type to Error.HasTag().
 	ErrorTag = edgedb.ErrorTag
 
+	// Executor is a common interface between Client and Tx,
+	// that can run queries on an EdgeDB database.
+	Executor = edgedb.Executor
+
 	// IsolationLevel documentation can be found here
 	// https://www.edgedb.com/docs/reference/edgeql/tx_start#parameters
 	IsolationLevel = edgedb.IsolationLevel

--- a/internal/client/executor.go
+++ b/internal/client/executor.go
@@ -1,0 +1,29 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedb
+
+import "context"
+
+// Executor is a common interface between *Client and *Tx,
+// that can run queries on an EdgeDB database.
+type Executor interface {
+	Execute(context.Context, string, ...any) error
+	Query(context.Context, string, any, ...any) error
+	QueryJSON(context.Context, string, *[]byte, ...any) error
+	QuerySingle(context.Context, string, any, ...any) error
+	QuerySingleJSON(context.Context, string, any, ...any) error
+}

--- a/rstdocs/api.rst
+++ b/rstdocs/api.rst
@@ -47,6 +47,18 @@ ErrorTag is the argument type to Error.HasTag().
     type ErrorTag = edgedb.ErrorTag
 
 
+*type* Executor
+---------------
+
+Executor is a common interface between Client and Tx,
+that can run queries on an EdgeDB database.
+
+
+.. code-block:: go
+
+    type Executor = edgedb.Executor
+
+
 *type* IsolationLevel
 ---------------------
 


### PR DESCRIPTION
This PR introduces the `Executor` interface which exposes all querying functions that are common to both `Client` and `Tx`.
Example use-case:

```go
func CreateItem(db edgedb.Executor, name string) (item Item, err error) {
  query := `select (insert Item { name := $0 }) { name };`
  err = db.QuerySingle(context.Background(), query, &item, name)
  return 
}

// Using Client
client, _ := edgedb.CreateClient(ctx, edgedb.Options{})
CreateItem(client, "Item name")

// Using Tx
client.Tx(context.Background(), func(ctx context.Context, tx *edgedb.Tx) error {
  CreateItem(tx, "Item name")
  // Transaction may then be rolled back, e.g. if this is a unit-test
  return errors.New("Rollback")
})
```