### PR TITLE
Add convenience functions to transform between edgedb.Duration and time.Duration

### DIFF
--- a/export.go
+++ b/export.go
@@ -288,6 +288,10 @@ var (
 	// The following options are recognized: host, port, user, database, password.
 	CreateClientDSN = edgedb.CreateClientDSN
 
+	// DurationFromNanoseconds creates a Duration represented as microseconds
+	// from a [time.Duration] represented as nanoseconds.
+	DurationFromNanoseconds = edgedbtypes.DurationFromNanoseconds
+
 	// NewDateDuration returns a new DateDuration
 	NewDateDuration = edgedbtypes.NewDateDuration
 

--- a/internal/edgedbtypes/datetime.go
+++ b/internal/edgedbtypes/datetime.go
@@ -660,6 +660,26 @@ func (d Duration) String() string {
 	return strings.Join(buf, "")
 }
 
+// AsNanoseconds returns [time.Duration] represented as nanoseconds,
+// after transforming from Duration microsecond representation.
+// Returns an error if the Duration is too long and would cause an overflow of
+// the internal int64 representation.
+func (d Duration) AsNanoseconds() (time.Duration, error) {
+	if int64(d) > math.MaxInt64/int64(time.Microsecond) ||
+		int64(d) < math.MinInt64/int64(time.Microsecond) {
+		return time.Duration(0), fmt.Errorf(
+			"Duration is too large to be represented as nanoseconds",
+		)
+	}
+	return time.Duration(d) * time.Microsecond, nil
+}
+
+// DurationFromNanoseconds creates a Duration represented as microseconds
+// from a [time.Duration] represented as nanoseconds.
+func DurationFromNanoseconds(d time.Duration) Duration {
+	return Duration(math.RoundToEven(float64(d) / 1e3))
+}
+
 // NewOptionalDuration is a convenience function for creating an
 // OptionalDuration with its value set to v.
 func NewOptionalDuration(v Duration) OptionalDuration {

--- a/rstdocs/types.rst
+++ b/rstdocs/types.rst
@@ -75,6 +75,19 @@ as an int64 microsecond count.
     type Duration int64
 
 
+*function* DurationFromNanoseconds
+..................................
+
+.. code-block:: go
+
+    func DurationFromNanoseconds(d time.Duration) Duration
+
+DurationFromNanoseconds creates a Duration represented as microseconds
+from a `time.Duration <https://pkg.go.dev/time>`_ represented as nanoseconds.
+
+
+
+
 *function* ParseDuration
 ........................
 
@@ -83,6 +96,21 @@ as an int64 microsecond count.
     func ParseDuration(s string) (Duration, error)
 
 ParseDuration parses an EdgeDB duration string.
+
+
+
+
+*method* AsNanoseconds
+......................
+
+.. code-block:: go
+
+    func (d Duration) AsNanoseconds() (time.Duration, error)
+
+AsNanoseconds returns `time.Duration <https://pkg.go.dev/time>`_ represented as nanoseconds,
+after transforming from Duration microsecond representation.
+Returns an error if the Duration is too long and would cause an overflow of
+the internal int64 representation.
 
 
 


### PR DESCRIPTION
This is meant to improve usability of `Duration` values and better integrate with the Go ecosystem.
This also makes the unit (micro/nanoseconds) difference  between `Duration` and `time.Duration` more obvious, hopefully reducing the likelihood of introducing hard to detect bugs such as: 
```go
func ConvertDuration(d edgedb.Duration) time.Duration {
  return time.Duration(int64(d)) 
  // change from microseconds to nanoseconds representation is not taken care of, 
  // and the compiler can not help to prevent this
}