### PR TITLE
Don't hide errors when multiple are encountered.

### DIFF
--- a/internal/client/connect.go
+++ b/internal/client/connect.go
@@ -143,11 +143,7 @@ func (c *protocolConnection) connect(r *buff.Reader, cfg *connConfig) error {
 		}
 	}
 
-	if r.Err != nil {
-		return r.Err
-	}
-
-	return err
+	return wrapAll(err, r.Err)
 }
 
 func (c *protocolConnection) authenticate(
@@ -206,12 +202,8 @@ func (c *protocolConnection) authenticate(
 		}
 	}
 
-	if r.Err != nil {
-		return r.Err
-	}
-
-	if err != nil {
-		return err
+	if err != nil || r.Err != nil {
+		return wrapAll(err, r.Err)
 	}
 
 	w = buff.NewWriter(c.writeMemory[:0])
@@ -264,11 +256,7 @@ func (c *protocolConnection) authenticate(
 		}
 	}
 
-	if r.Err != nil {
-		return r.Err
-	}
-
-	return err
+	return wrapAll(err, r.Err)
 }
 
 func (c *protocolConnection) terminate() error {

--- a/internal/client/granularflow0pX.go
+++ b/internal/client/granularflow0pX.go
@@ -211,10 +211,7 @@ func (c *protocolConnection) prepare0pX(r *buff.Reader, q *query) error {
 		}
 	}
 
-	if r.Err != nil {
-		return r.Err
-	}
-	return err
+	return wrapAll(err, r.Err)
 }
 
 func (c *protocolConnection) describe(
@@ -331,7 +328,7 @@ func (c *protocolConnection) execute0pX(
 	}
 
 	if r.Err != nil {
-		return r.Err
+		return wrapAll(err, r.Err)
 	}
 
 	if !q.flat() {

--- a/internal/client/granularflow1pX.go
+++ b/internal/client/granularflow1pX.go
@@ -268,7 +268,7 @@ func (c *protocolConnection) execute1pX(
 	}
 
 	if r.Err != nil {
-		return r.Err
+		return wrapAll(err, r.Err)
 	}
 
 	if !q.flat() && q.fmt != Null {

--- a/internal/client/granularflow2pX.go
+++ b/internal/client/granularflow2pX.go
@@ -273,7 +273,7 @@ func (c *protocolConnection) execute2pX(
 	}
 
 	if r.Err != nil {
-		return r.Err
+		return wrapAll(err, r.Err)
 	}
 
 	if !q.flat() && q.fmt != Null {

--- a/internal/client/scriptflow.go
+++ b/internal/client/scriptflow.go
@@ -98,9 +98,5 @@ func (c *protocolConnection) execScriptFlow(r *buff.Reader, q *query) error {
 		}
 	}
 
-	if r.Err != nil {
-		return r.Err
-	}
-
-	return err
+	return wrapAll(err, r.Err)
 }


### PR DESCRIPTION
Some server errors cause the client to also produce a network error. In these cases the client would report the network error but not the server error. This change makes the client report both errors, with the server error displayed first.