### PR TITLE
Add a warning system

### DIFF
--- a/export.go
+++ b/export.go
@@ -270,6 +270,11 @@ type (
 	// UUID is a universally unique identifier
 	// https://www.edgedb.com/docs/stdlib/uuid
 	UUID = edgedbtypes.UUID
+
+	// WarningHandler takes a slice of edgedb.Error that represent warnings and
+	// optionally returns an error. This can be used to log warnings, increment
+	// metrics, promote warnings to errors by returning them etc.
+	WarningHandler = edgedb.WarningHandler
 )
 
 var (
@@ -291,6 +296,9 @@ var (
 	// DurationFromNanoseconds creates a Duration represented as microseconds
 	// from a [time.Duration] represented as nanoseconds.
 	DurationFromNanoseconds = edgedbtypes.DurationFromNanoseconds
+
+	// LogWarnings is an edgedb.WarningHandler that logs warnings.
+	LogWarnings = edgedb.LogWarnings
 
 	// NewDateDuration returns a new DateDuration
 	NewDateDuration = edgedbtypes.NewDateDuration
@@ -439,4 +447,8 @@ var (
 
 	// ParseUUID parses s into a UUID or returns an error.
 	ParseUUID = edgedbtypes.ParseUUID
+
+	// WarningsAsErrors is an edgedb.WarningHandler that returns warnings as
+	// errors.
+	WarningsAsErrors = edgedb.WarningsAsErrors
 )

--- a/internal/client/cache.go
+++ b/internal/client/cache.go
@@ -98,7 +98,7 @@ func (c *protocolConnection) cacheTypeIDs(q *query, ids idPair) {
 
 func (c *protocolConnection) cacheCapabilities0pX(
 	q *query,
-	headers header.Header,
+	headers header.Header0pX,
 ) {
 	if capabilities, ok := headers[header.Capabilities]; ok {
 		x := binary.BigEndian.Uint64(capabilities)

--- a/internal/client/granularflow1pX.go
+++ b/internal/client/granularflow1pX.go
@@ -125,7 +125,7 @@ func (c *protocolConnection) decodeCommandDataDescriptionMsg1pX(
 	r *buff.Reader,
 	q *query,
 ) (*CommandDescription, error) {
-	discardHeaders(r)
+	discardHeaders0pX(r)
 	c.cacheCapabilities1pX(q, r.PopUint64())
 
 	var (
@@ -323,7 +323,7 @@ func (c *protocolConnection) decodeCommandCompleteMsg1pX(
 	q *query,
 	r *buff.Reader,
 ) error {
-	discardHeaders(r)
+	discardHeaders0pX(r)
 	c.cacheCapabilities1pX(q, r.PopUint64())
 	r.Discard(int(r.PopUint32())) // discard command status
 	if r.PopUUID() == descriptor.IDZero {

--- a/internal/client/granularflow1pX.go
+++ b/internal/client/granularflow1pX.go
@@ -125,14 +125,14 @@ func (c *protocolConnection) decodeCommandDataDescriptionMsg1pX(
 	r *buff.Reader,
 	q *query,
 ) (*CommandDescription, error) {
-	discardHeaders0pX(r)
+	_, err := decodeHeaders1pX(r, q.warningHandler)
+	if err != nil {
+		return nil, err
+	}
+
 	c.cacheCapabilities1pX(q, r.PopUint64())
 
-	var (
-		err   error
-		descs CommandDescription
-	)
-
+	var descs CommandDescription
 	descs.Card = Cardinality(r.PopUint8())
 	id := r.PopUUID()
 	descs.In, err = descriptor.Pop(

--- a/internal/client/granularflow2pX.go
+++ b/internal/client/granularflow2pX.go
@@ -131,7 +131,7 @@ func (c *protocolConnection) decodeCommandDataDescriptionMsg2pX(
 	r *buff.Reader,
 	q *query,
 ) (*CommandDescriptionV2, error) {
-	discardHeaders(r)
+	discardHeaders0pX(r)
 	c.cacheCapabilities1pX(q, r.PopUint64())
 
 	var (
@@ -367,7 +367,7 @@ func (c *protocolConnection) decodeCommandCompleteMsg2pX(
 	q *query,
 	r *buff.Reader,
 ) error {
-	discardHeaders(r)
+	discardHeaders0pX(r)
 	c.cacheCapabilities1pX(q, r.PopUint64())
 	r.Discard(int(r.PopUint32())) // discard command status
 	if r.PopUUID() == descriptor.IDZero {

--- a/internal/client/granularflow2pX.go
+++ b/internal/client/granularflow2pX.go
@@ -131,14 +131,14 @@ func (c *protocolConnection) decodeCommandDataDescriptionMsg2pX(
 	r *buff.Reader,
 	q *query,
 ) (*CommandDescriptionV2, error) {
-	discardHeaders0pX(r)
+	_, err := decodeHeaders2pX(r, q.warningHandler)
+	if err != nil {
+		return nil, err
+	}
+
 	c.cacheCapabilities1pX(q, r.PopUint64())
 
-	var (
-		err   error
-		descs CommandDescriptionV2
-	)
-
+	var descs CommandDescriptionV2
 	descs.Card = Cardinality(r.PopUint8())
 	id := r.PopUUID()
 	descs.In, err = descriptor.PopV2(
@@ -231,9 +231,9 @@ func (c *protocolConnection) execute2pX(
 				err = wrapAll(err, e)
 			}
 		case CommandDataDescription:
-			descs, e := c.decodeCommandDataDescriptionMsg1pX(r, q)
+			descs, e := c.decodeCommandDataDescriptionMsg2pX(r, q)
 			err = wrapAll(err, e)
-			cdcs, e = c.codecsFromDescriptors1pX(q, descs)
+			cdcs, e = c.codecsFromDescriptors2pX(q, descs)
 			err = wrapAll(err, e)
 		case Data:
 			val, ok, e := decodeDataMsg(r, q, cdcs)

--- a/internal/client/options.go
+++ b/internal/client/options.go
@@ -116,6 +116,10 @@ type Options struct {
 
 	// SecretKey is used to connect to cloud instances.
 	SecretKey string
+
+	// WarningHandler is invoked when EdgeDB returns warnings. Defaults to
+	// edgedb.LogWarnings.
+	WarningHandler WarningHandler
 }
 
 // TLSOptions contains the parameters needed to configure TLS on EdgeDB
@@ -510,5 +514,18 @@ func (p Client) WithoutGlobals(globals ...string) *Client { // nolint:gocritic
 	}
 
 	p.state = state
+	return &p
+}
+
+// WithWarningHandler sets the warning handler for the returned client. If
+// warningHandler is nil edgedb.LogWarnings is used.
+func (p Client) WithWarningHandler( // nolint:gocritic
+	warningHandler WarningHandler,
+) *Client {
+	if warningHandler == nil {
+		warningHandler = LogWarnings
+	}
+
+	p.warningHandler = warningHandler
 	return &p
 }

--- a/internal/client/query.go
+++ b/internal/client/query.go
@@ -53,11 +53,11 @@ func (q *query) flat() bool {
 	return false
 }
 
-func (q *query) headers0pX() header.Header {
+func (q *query) headers0pX() header.Header0pX {
 	bts := make([]byte, 8)
 	binary.BigEndian.PutUint64(bts, q.capabilities)
 
-	return header.Header{header.AllowCapabilities: bts}
+	return header.Header0pX{header.AllowCapabilities: bts}
 }
 
 // newQuery returns a new granular flow query.

--- a/internal/client/query.go
+++ b/internal/client/query.go
@@ -28,17 +28,23 @@ import (
 	"github.com/edgedb/edgedb-go/internal/introspect"
 )
 
+// WarningHandler takes a slice of edgedb.Error that represent warnings and
+// optionally returns an error. This can be used to log warnings, increment
+// metrics, promote warnings to errors by returning them etc.
+type WarningHandler = func([]error) error
+
 type query struct {
-	out          reflect.Value
-	outType      reflect.Type
-	method       string
-	cmd          string
-	fmt          Format
-	expCard      Cardinality
-	args         []interface{}
-	capabilities uint64
-	state        map[string]interface{}
-	parse        bool
+	out            reflect.Value
+	outType        reflect.Type
+	method         string
+	cmd            string
+	fmt            Format
+	expCard        Cardinality
+	args           []interface{}
+	capabilities   uint64
+	state          map[string]interface{}
+	parse          bool
+	warningHandler WarningHandler
 }
 
 func (q *query) flat() bool {
@@ -68,6 +74,7 @@ func newQuery(
 	state map[string]interface{},
 	out interface{},
 	parse bool,
+	warningHandler WarningHandler,
 ) (*query, error) {
 	var (
 		expCard Cardinality
@@ -77,14 +84,15 @@ func newQuery(
 	switch method {
 	case "Execute":
 		return &query{
-			method:       method,
-			cmd:          cmd,
-			fmt:          Null,
-			expCard:      Many,
-			args:         args,
-			capabilities: capabilities,
-			state:        state,
-			parse:        parse,
+			method:         method,
+			cmd:            cmd,
+			fmt:            Null,
+			expCard:        Many,
+			args:           args,
+			capabilities:   capabilities,
+			state:          state,
+			parse:          parse,
+			warningHandler: warningHandler,
 		}, nil
 	case "Query":
 		expCard = Many
@@ -103,14 +111,15 @@ func newQuery(
 	}
 
 	q := query{
-		method:       method,
-		cmd:          cmd,
-		fmt:          frmt,
-		expCard:      expCard,
-		args:         args,
-		capabilities: capabilities,
-		state:        state,
-		parse:        parse,
+		method:         method,
+		cmd:            cmd,
+		fmt:            frmt,
+		expCard:        expCard,
+		args:           args,
+		capabilities:   capabilities,
+		state:          state,
+		parse:          parse,
+		warningHandler: warningHandler,
 	}
 
 	var err error
@@ -152,6 +161,7 @@ func runQuery(
 	out interface{},
 	args []interface{},
 	state map[string]interface{},
+	warningHandler WarningHandler,
 ) error {
 	if method == "QuerySingleJSON" {
 		switch out.(type) {
@@ -171,6 +181,7 @@ func runQuery(
 		state,
 		out,
 		true,
+		warningHandler,
 	)
 	if err != nil {
 		return err

--- a/internal/client/scriptflow.go
+++ b/internal/client/scriptflow.go
@@ -30,10 +30,10 @@ func ignoreHeaders(r *buff.Reader) {
 	}
 }
 
-func decodeHeaders(r *buff.Reader) header.Header {
+func decodeHeaders0pX(r *buff.Reader) header.Header0pX {
 	n := int(r.PopUint16())
 
-	headers := make(header.Header, n)
+	headers := make(header.Header0pX, n)
 	for i := 0; i < n; i++ {
 		key := r.PopUint16()
 		val := r.PopBytes()
@@ -44,7 +44,7 @@ func decodeHeaders(r *buff.Reader) header.Header {
 	return headers
 }
 
-func discardHeaders(r *buff.Reader) {
+func discardHeaders0pX(r *buff.Reader) {
 	n := int(r.PopUint16())
 
 	for i := 0; i < n; i++ {
@@ -53,7 +53,7 @@ func discardHeaders(r *buff.Reader) {
 	}
 }
 
-func writeHeaders(w *buff.Writer, headers header.Header) {
+func writeHeaders0pX(w *buff.Writer, headers header.Header0pX) {
 	w.PushUint16(uint16(len(headers)))
 
 	for key, val := range headers {
@@ -70,7 +70,7 @@ func (c *protocolConnection) execScriptFlow(r *buff.Reader, q *query) error {
 
 	w := buff.NewWriter(c.writeMemory[:0])
 	w.BeginMessage(uint8(ExecuteScript))
-	writeHeaders(w, q.headers0pX())
+	writeHeaders0pX(w, q.headers0pX())
 	w.PushString(q.cmd)
 	w.EndMessage()
 

--- a/internal/client/transactable.go
+++ b/internal/client/transactable.go
@@ -77,6 +77,7 @@ func (c *transactableConn) tx(
 	ctx context.Context,
 	action TxBlock,
 	state map[string]interface{},
+	warningHandler WarningHandler,
 ) (err error) {
 	conn, err := c.borrow("transaction")
 	if err != nil {
@@ -101,6 +102,7 @@ func (c *transactableConn) tx(
 				txState:        &txState{},
 				options:        c.txOpts,
 				state:          state,
+				warningHandler: warningHandler,
 			}
 			err = tx.start(ctx)
 			if err != nil {

--- a/internal/client/transaction.go
+++ b/internal/client/transaction.go
@@ -76,8 +76,9 @@ func (s *txState) assertStarted(opName string) error {
 type Tx struct {
 	borrowableConn
 	*txState
-	options TxOptions
-	state   map[string]interface{}
+	options        TxOptions
+	state          map[string]interface{}
+	warningHandler WarningHandler
 }
 
 func (t *Tx) execute(
@@ -93,6 +94,7 @@ func (t *Tx) execute(
 		t.state,
 		nil,
 		false,
+		t.warningHandler,
 	)
 	if err != nil {
 		return err
@@ -171,6 +173,7 @@ func (t *Tx) Execute(
 		t.state,
 		nil,
 		true,
+		t.warningHandler,
 	)
 	if err != nil {
 		return err
@@ -186,7 +189,16 @@ func (t *Tx) Query(
 	out interface{},
 	args ...interface{},
 ) error {
-	return runQuery(ctx, t, "Query", cmd, out, args, t.state)
+	return runQuery(
+		ctx,
+		t,
+		"Query",
+		cmd,
+		out,
+		args,
+		t.state,
+		t.warningHandler,
+	)
 }
 
 // QuerySingle runs a singleton-returning query and returns its element.
@@ -199,7 +211,16 @@ func (t *Tx) QuerySingle(
 	out interface{},
 	args ...interface{},
 ) error {
-	return runQuery(ctx, t, "QuerySingle", cmd, out, args, t.state)
+	return runQuery(
+		ctx,
+		t,
+		"QuerySingle",
+		cmd,
+		out,
+		args,
+		t.state,
+		t.warningHandler,
+	)
 }
 
 // QueryJSON runs a query and return the results as JSON.
@@ -209,7 +230,16 @@ func (t *Tx) QueryJSON(
 	out *[]byte,
 	args ...interface{},
 ) error {
-	return runQuery(ctx, t, "QueryJSON", cmd, out, args, t.state)
+	return runQuery(
+		ctx,
+		t,
+		"QueryJSON",
+		cmd,
+		out,
+		args,
+		t.state,
+		t.warningHandler,
+	)
 }
 
 // QuerySingleJSON runs a singleton-returning query.
@@ -221,5 +251,14 @@ func (t *Tx) QuerySingleJSON(
 	out interface{},
 	args ...interface{},
 ) error {
-	return runQuery(ctx, t, "QuerySingleJSON", cmd, out, args, t.state)
+	return runQuery(
+		ctx,
+		t,
+		"QuerySingleJSON",
+		cmd,
+		out,
+		args,
+		t.state,
+		t.warningHandler,
+	)
 }

--- a/internal/client/warning.go
+++ b/internal/client/warning.go
@@ -1,0 +1,43 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edgedb
+
+import (
+	"errors"
+	"log"
+)
+
+// Warning is used to decode warnings in the protocol.
+type Warning struct {
+	Code    uint32 `json:"code"`
+	Message string `json:"message"`
+}
+
+// LogWarnings is an edgedb.WarningHandler that logs warnings.
+func LogWarnings(errors []error) error {
+	for _, err := range errors {
+		log.Println("EdgeDB warning:", err.Error())
+	}
+
+	return nil
+}
+
+// WarningsAsErrors is an edgedb.WarningHandler that returns warnings as
+// errors.
+func WarningsAsErrors(warnings []error) error {
+	return errors.Join(warnings...)
+}

--- a/internal/cmd/export/names.txt
+++ b/internal/cmd/export/names.txt
@@ -12,6 +12,7 @@ IsolationLevel
 LocalDate
 LocalDateTime
 LocalTime
+LogWarnings
 Memory
 ModuleAlias
 NetworkError
@@ -107,3 +108,5 @@ TxBlock
 TxConflict
 TxOptions
 UUID
+WarningHandler
+WarningsAsErrors

--- a/internal/header/header.go
+++ b/internal/header/header.go
@@ -18,8 +18,11 @@ package header
 
 import "encoding/binary"
 
-// Header0pX is a binary protocol header
+// Header0pX is a binary protocol header for protocol major version 0
 type Header0pX map[uint16][]byte
+
+// Header1pX is a binary protocol header for protocol major version 1
+type Header1pX map[string]string
 
 const (
 	// AllowCapabilities tells the server what capabilities it should allow.

--- a/internal/header/header.go
+++ b/internal/header/header.go
@@ -18,8 +18,8 @@ package header
 
 import "encoding/binary"
 
-// Header is a binary protocol header
-type Header map[uint16][]byte
+// Header0pX is a binary protocol header
+type Header0pX map[uint16][]byte
 
 const (
 	// AllowCapabilities tells the server what capabilities it should allow.

--- a/rstdocs/api.rst
+++ b/rstdocs/api.rst
@@ -196,3 +196,16 @@ TxOptions configures how transactions behave.
 .. code-block:: go
 
     type TxOptions = edgedb.TxOptions
+
+
+*type* WarningHandler
+---------------------
+
+WarningHandler takes a slice of edgedb.Error that represent warnings and
+optionally returns an error. This can be used to log warnings, increment
+metrics, promote warnings to errors by returning them etc.
+
+
+.. code-block:: go
+
+    type WarningHandler = edgedb.WarningHandler


### PR DESCRIPTION
EdgeDB server recently added the ability to emit warnings. This change makes the client log them by default and adds a mechanism for users to define their own warning handler.

See [EdgeDB issue #7822](https://github.com/edgedb/edgedb/issues/7822)