### PR TITLE
edgeql-go: only fetch protocol version once

### DIFF
--- a/cmd/edgeql-go/main.go
+++ b/cmd/edgeql-go/main.go
@@ -37,6 +37,7 @@ import (
 	"time"
 
 	"github.com/geldata/gel-go/gelcfg"
+	"github.com/geldata/gel-go/internal"
 	gelint "github.com/geldata/gel-go/internal/client"
 	"github.com/geldata/gel-go/internal/descriptor"
 	toml "github.com/pelletier/go-toml/v2"
@@ -62,10 +63,11 @@ func usage() {
 }
 
 type cmdConfig struct {
-	mixedCaps  bool
-	pubfuncs   bool
-	pubtypes   bool
-	rawmessage bool
+	mixedCaps       bool
+	pubfuncs        bool
+	pubtypes        bool
+	rawmessage      bool
+	protocolVersion internal.ProtocolVersion
 }
 
 func main() {
@@ -108,6 +110,11 @@ func main() {
 
 	if !timer.Stop() {
 		log.Println("connected")
+	}
+
+	cfg.protocolVersion, err = gelint.ProtocolVersion(ctx, c)
+	if err != nil {
+		log.Fatalf("error determining the protocol version: %s", err)
 	}
 
 	fileQueue := queueFilesInBackground()

--- a/cmd/edgeql-go/query.go
+++ b/cmd/edgeql-go/query.go
@@ -81,14 +81,9 @@ func newQuery(
 		log.Fatalf("error reading %q: %s", qryFile, err)
 	}
 
-	v, err := gelint.ProtocolVersion(ctx, p)
-	if err != nil {
-		log.Fatalf("error determining the protocol version: %s", err)
-	}
-
 	var qs querySetup
 
-	if v.GTE(internal.ProtocolVersion{Major: 2, Minor: 0}) {
+	if cfg.protocolVersion.GTE(internal.ProtocolVersion{Major: 2, Minor: 0}) {
 		qs = &queryConfigV2{}
 	} else {
 		qs = &queryConfigV1{}


### PR DESCRIPTION
This is a minor optimization